### PR TITLE
Fix DELETE CORS + draggable column resize with persistence

### DIFF
--- a/backend/dist-migrations/006_add_width_to_stages.js
+++ b/backend/dist-migrations/006_add_width_to_stages.js
@@ -1,0 +1,14 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.up = up;
+exports.down = down;
+async function up(knex) {
+    await knex.schema.alterTable('stages', function (table) {
+        table.integer('width').nullable().defaultTo(null);
+    });
+}
+async function down(knex) {
+    await knex.schema.alterTable('stages', function (table) {
+        table.dropColumn('width');
+    });
+}

--- a/backend/migrations/006_add_width_to_stages.ts
+++ b/backend/migrations/006_add_width_to_stages.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('stages', (table) => {
+    table.integer('width').nullable().defaultTo(null);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('stages', (table) => {
+    table.dropColumn('width');
+  });
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ const corsOrigin = process.env.CORS_ORIGIN || 'http://localhost:5173';
 app.use(cors({
   origin: corsOrigin.includes(',') ? corsOrigin.split(',').map(s => s.trim()) : corsOrigin,
   credentials: true,
+  methods: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS'],
 }));
 
 // Body parsing

--- a/backend/src/routes/stages.ts
+++ b/backend/src/routes/stages.ts
@@ -44,15 +44,17 @@ router.patch(
   validate([
     body('name').optional().isString().trim().notEmpty().withMessage('Name cannot be empty'),
     body('position').optional().isInt({ min: 0 }).withMessage('Position must be a non-negative integer'),
+    body('width').optional().isInt({ min: 200, max: 800 }).withMessage('Width must be between 200 and 800'),
   ]),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const userId = req.user!.id;
       const { id } = req.params;
-      const data: { name?: string; position?: number } = {};
+      const data: { name?: string; position?: number; width?: number } = {};
 
       if (req.body.name !== undefined) data.name = req.body.name;
       if (req.body.position !== undefined) data.position = req.body.position;
+      if (req.body.width !== undefined) data.width = req.body.width;
 
       const stage = await stageService.updateStage(id, userId, data);
       res.json({ data: stage });

--- a/backend/src/services/stageService.ts
+++ b/backend/src/services/stageService.ts
@@ -4,6 +4,7 @@ import { AppError } from '../middleware/errorHandler';
 export interface StageData {
   name: string;
   position: number;
+  width?: number | null;
 }
 
 export const stageService = {
@@ -66,6 +67,7 @@ export const stageService = {
     const updateData: Record<string, unknown> = {};
     if (data.name !== undefined) updateData.name = data.name;
     if (data.position !== undefined) updateData.position = data.position;
+    if (data.width !== undefined) updateData.width = data.width;
 
     const [updated] = await db('stages')
       .where({ id: stageId, user_id: userId })

--- a/frontend/src/components/Board/Board.tsx
+++ b/frontend/src/components/Board/Board.tsx
@@ -27,6 +27,7 @@ interface BoardProps {
   onEditStage?: (stage: Stage) => void;
   onDeleteStage?: (stage: Stage) => void;
   onReorderStages?: (stageIds: string[]) => void;
+  onResizeStage?: (stageId: string, width: number) => void;
   onAddStage?: () => void;
 }
 
@@ -34,7 +35,7 @@ type DragType = 'card' | 'column' | null;
 
 export default function Board({
   stages, cards, loading, onMoveCard, onCardClick, onAddCard,
-  onEditStage, onDeleteStage, onReorderStages, onAddStage,
+  onEditStage, onDeleteStage, onReorderStages, onResizeStage, onAddStage,
 }: BoardProps) {
   const [activeCard, setActiveCard] = useState<Card | null>(null);
   const [activeColumn, setActiveColumn] = useState<Stage | null>(null);
@@ -178,6 +179,7 @@ export default function Board({
               onAddCard={() => onAddCard(stage.id)}
               onEditStage={onEditStage || (() => {})}
               onDeleteStage={onDeleteStage || (() => {})}
+              onResizeStage={onResizeStage}
             />
           ))}
         </SortableContext>

--- a/frontend/src/components/Board/Column.tsx
+++ b/frontend/src/components/Board/Column.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import type { Stage, Card } from '@/types';
@@ -12,13 +12,46 @@ interface ColumnProps {
   onAddCard: () => void;
   onEditStage?: (stage: Stage) => void;
   onDeleteStage?: (stage: Stage) => void;
+  onResizeStage?: (stageId: string, width: number) => void;
   dragHandleProps?: Record<string, unknown>;
 }
 
-export default function Column({ stage, cards, onCardClick, onAddCard, onEditStage, onDeleteStage, dragHandleProps }: ColumnProps) {
+export default function Column({ stage, cards, onCardClick, onAddCard, onEditStage, onDeleteStage, onResizeStage, dragHandleProps }: ColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id: stage.id });
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const [resizeWidth, setResizeWidth] = useState<number | null>(null);
+  const lastWidthRef = useRef(0);
+
+  const columnWidth = resizeWidth ?? stage.width ?? 320;
+
+  const handleResizeMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const startX = e.clientX;
+    const startW = columnWidth;
+    lastWidthRef.current = startW;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const delta = e.clientX - startX;
+      const newWidth = Math.min(800, Math.max(200, startW + delta));
+      lastWidthRef.current = newWidth;
+      setResizeWidth(newWidth);
+    };
+
+    const handleMouseUp = () => {
+      const finalWidth = lastWidthRef.current;
+      setResizeWidth(null);
+      if (onResizeStage && finalWidth !== (stage.width ?? 320)) {
+        onResizeStage(stage.id, finalWidth);
+      }
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  }, [columnWidth, onResizeStage, stage.id, stage.width]);
 
   const cardIds = cards.map((c) => c.id);
 
@@ -37,6 +70,7 @@ export default function Column({ stage, cards, onCardClick, onAddCard, onEditSta
   return (
     <div
       className={`board-column transition-colors ${isOver ? 'bg-primary-50/60 border-primary-300' : ''}`}
+      style={{ width: columnWidth, minWidth: 200, maxWidth: 800 }}
     >
       <div className="flex items-center justify-between px-3 py-2.5 border-b border-gray-200">
         <div className="flex items-center gap-1.5">
@@ -106,6 +140,13 @@ export default function Column({ stage, cards, onCardClick, onAddCard, onEditSta
           ))}
         </div>
       </SortableContext>
+
+      {onResizeStage && (
+        <div
+          onMouseDown={handleResizeMouseDown}
+          className="column-resize-handle"
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Board/SortableColumn.tsx
+++ b/frontend/src/components/Board/SortableColumn.tsx
@@ -10,9 +10,10 @@ interface SortableColumnProps {
   onAddCard: () => void;
   onEditStage: (stage: Stage) => void;
   onDeleteStage: (stage: Stage) => void;
+  onResizeStage?: (stageId: string, width: number) => void;
 }
 
-export default function SortableColumn({ stage, cards, onCardClick, onAddCard, onEditStage, onDeleteStage }: SortableColumnProps) {
+export default function SortableColumn({ stage, cards, onCardClick, onAddCard, onEditStage, onDeleteStage, onResizeStage }: SortableColumnProps) {
   const {
     attributes,
     listeners,
@@ -37,6 +38,7 @@ export default function SortableColumn({ stage, cards, onCardClick, onAddCard, o
         onAddCard={onAddCard}
         onEditStage={onEditStage}
         onDeleteStage={onDeleteStage}
+        onResizeStage={onResizeStage}
         dragHandleProps={listeners}
       />
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -44,8 +44,7 @@
 
 /* Column styles */
 .board-column {
-  min-width: 320px;
-  max-width: 320px;
+  min-width: 200px;
   flex-shrink: 0;
   background: #f8fafc;
   border-radius: 0.75rem;
@@ -53,6 +52,23 @@
   display: flex;
   flex-direction: column;
   max-height: calc(100vh - 12rem);
+  position: relative;
+}
+
+.column-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -2px;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 10;
+  border-radius: 2px;
+}
+
+.column-resize-handle:hover,
+.column-resize-handle:active {
+  background: #818cf8;
 }
 
 .board-column-cards {

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -114,6 +114,16 @@ export default function BoardPage() {
     }
   };
 
+  const handleResizeStage = async (stageId: string, width: number) => {
+    // Optimistic update
+    setStages((prev) => prev.map((s) => (s.id === stageId ? { ...s, width } : s)));
+    try {
+      await stagesApi.updateStage(stageId, { width });
+    } catch {
+      fetchData();
+    }
+  };
+
   const handleReorderStages = async (stageIds: string[]) => {
     // Optimistic update
     const reordered = stageIds.map((id, i) => {
@@ -148,6 +158,7 @@ export default function BoardPage() {
           onEditStage={handleEditStage}
           onDeleteStage={handleDeleteStage}
           onReorderStages={handleReorderStages}
+          onResizeStage={handleResizeStage}
           onAddStage={handleAddStage}
         />
       </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -123,7 +123,7 @@ export const stagesApi = {
     const res = await api.post('/stages', { name, position });
     return snakeToCamel(res.data.data) as Stage;
   },
-  updateStage: async (id: string, data: { name: string }): Promise<Stage> => {
+  updateStage: async (id: string, data: { name?: string; width?: number }): Promise<Stage> => {
     const res = await api.patch(`/stages/${id}`, data);
     return snakeToCamel(res.data.data) as Stage;
   },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -8,6 +8,7 @@ export interface Stage {
   id: string;
   name: string;
   position: number;
+  width?: number;
 }
 
 export interface Card {


### PR DESCRIPTION
## Summary
- **Fix DELETE "Route not found"**: Added explicit `methods` to CORS config so OPTIONS preflight for DELETE gets a proper 200 response instead of falling through to the 404 handler
- **Draggable column resize**: Users can drag the right edge of any column to resize between 200–800px, with `col-resize` cursor and visual feedback
- **Width persistence**: New `stages.width` DB column (migration 006) + backend PATCH support + optimistic frontend updates — width survives page reloads

## Test plan
- [x] All 44 backend tests pass
- [x] Frontend `tsc --noEmit` clean
- [x] Frontend `vite build` succeeds
- [ ] Verify DELETE stage works in production (CORS fix)
- [ ] Drag right edge of column → resizes smoothly between 200–800px
- [ ] Width persists on page reload
- [ ] Column order still persists (existing behavior)
- [ ] Run migration 006 on production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)