### PR TITLE
Fix resize revert and harden CORS for DELETE

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ app.use(cors({
   origin: corsOrigin.includes(',') ? corsOrigin.split(',').map(s => s.trim()) : corsOrigin,
   credentials: true,
   methods: ['GET', 'POST', 'PATCH', 'PUT', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
 }));
 
 // Body parsing

--- a/frontend/src/components/Search/SearchBar.tsx
+++ b/frontend/src/components/Search/SearchBar.tsx
@@ -15,7 +15,10 @@ export default function SearchBar({ filters, onFiltersChange, stages }: SearchBa
 
   useEffect(() => {
     debounceRef.current = setTimeout(() => {
-      onFiltersChange({ ...filters, search: searchText || undefined });
+      const newSearch = searchText || undefined;
+      if (newSearch !== filters.search) {
+        onFiltersChange({ ...filters, search: newSearch });
+      }
     }, 300);
     return () => clearTimeout(debounceRef.current);
   }, [searchText]);

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -118,7 +118,8 @@ export default function BoardPage() {
     // Optimistic update
     setStages((prev) => prev.map((s) => (s.id === stageId ? { ...s, width } : s)));
     try {
-      await stagesApi.updateStage(stageId, { width });
+      const updated = await stagesApi.updateStage(stageId, { width });
+      setStages((prev) => prev.map((s) => (s.id === stageId ? updated : s)));
     } catch {
       fetchData();
     }


### PR DESCRIPTION
## Summary
- **Fix resize reverting**: The SearchBar's debounced `useEffect` was firing on mount, creating a new `filters` object that triggered `fetchData` to re-fetch all stages ~300ms after render — overwriting the optimistic width update. Added a guard to skip the update when search value hasn't changed.
- **Persist resize from API response**: `handleResizeStage` now applies the API response to state, so the persisted width survives any subsequent re-fetch.
- **Harden CORS**: Added explicit `allowedHeaders: ['Content-Type', 'Authorization']` to ensure DELETE preflight responses include the required headers.

## Test plan
- [x] All 44 backend tests pass
- [x] Frontend `tsc --noEmit` + `vite build` pass
- [ ] Resize column → width persists on page reload (no revert after 1s)
- [ ] Delete stage works in production
- [ ] Search/filter still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)