### PR TITLE
Add dynamic columns, draggable resize, and company icons

### DIFF
--- a/backend/dist-migrations/007_add_company_icon_url_to_cards.js
+++ b/backend/dist-migrations/007_add_company_icon_url_to_cards.js
@@ -1,0 +1,36 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.up = up;
+exports.down = down;
+async function up(knex) {
+    await knex.schema.alterTable('cards', function (table) {
+        table.text('company_icon_url').nullable().defaultTo(null);
+    });
+    const cards = await knex('cards').select('id', 'company_name', 'application_url', 'careers_url');
+    for (const card of cards) {
+        let domain = null;
+        for (const url of [card.application_url, card.careers_url]) {
+            if (url) {
+                try {
+                    const hostname = new URL(url).hostname;
+                    const parts = hostname.split('.');
+                    domain = parts.slice(-2).join('.');
+                    break;
+                } catch (_) {}
+            }
+        }
+        if (!domain && card.company_name) {
+            domain = card.company_name.toLowerCase().replace(/[^a-z0-9]/g, '') + '.com';
+        }
+        if (domain) {
+            await knex('cards').where('id', card.id).update({
+                company_icon_url: `https://www.google.com/s2/favicons?domain=${domain}&sz=64`,
+            });
+        }
+    }
+}
+async function down(knex) {
+    await knex.schema.alterTable('cards', function (table) {
+        table.dropColumn('company_icon_url');
+    });
+}

--- a/backend/migrations/007_add_company_icon_url_to_cards.ts
+++ b/backend/migrations/007_add_company_icon_url_to_cards.ts
@@ -1,0 +1,40 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // 1. Add column
+  await knex.schema.alterTable('cards', (table) => {
+    table.text('company_icon_url').nullable().defaultTo(null);
+  });
+
+  // 2. Backfill existing cards
+  const cards = await knex('cards').select('id', 'company_name', 'application_url', 'careers_url');
+  for (const card of cards) {
+    let domain: string | null = null;
+    // Try application_url first
+    for (const url of [card.application_url, card.careers_url]) {
+      if (url) {
+        try {
+          const hostname = new URL(url).hostname;
+          const parts = hostname.split('.');
+          domain = parts.slice(-2).join('.');
+          break;
+        } catch {}
+      }
+    }
+    // Fall back to company name
+    if (!domain && card.company_name) {
+      domain = card.company_name.toLowerCase().replace(/[^a-z0-9]/g, '') + '.com';
+    }
+    if (domain) {
+      await knex('cards').where('id', card.id).update({
+        company_icon_url: `https://www.google.com/s2/favicons?domain=${domain}&sz=64`,
+      });
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('cards', (table) => {
+    table.dropColumn('company_icon_url');
+  });
+}

--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -54,6 +54,24 @@ async function logActivity(
   });
 }
 
+function extractRootDomain(url: string): string | null {
+  try {
+    const hostname = new URL(url).hostname;
+    const parts = hostname.split('.');
+    return parts.slice(-2).join('.');
+  } catch {
+    return null;
+  }
+}
+
+function deriveCompanyIconUrl(companyName: string, applicationUrl?: string, careersUrl?: string): string {
+  let domain: string | null = null;
+  if (applicationUrl) domain = extractRootDomain(applicationUrl);
+  if (!domain && careersUrl) domain = extractRootDomain(careersUrl);
+  if (!domain) domain = companyName.toLowerCase().replace(/[^a-z0-9]/g, '') + '.com';
+  return `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
+}
+
 export const cardService = {
   async getAllCards(userId: string, filters: CardFilters) {
     let query = db('cards')
@@ -150,6 +168,7 @@ export const cardService = {
         tech_stack: data.tech_stack || [],
         tags: data.tags || [],
         interest_level: data.interest_level ?? 3,
+        company_icon_url: deriveCompanyIconUrl(data.company_name, data.application_url, data.careers_url),
       })
       .returning('*');
 
@@ -204,6 +223,14 @@ export const cardService = {
     }
     if ('tags' in data) {
       updatePayload.tags = data.tags || [];
+    }
+
+    // Re-derive company icon if relevant fields changed
+    if ('company_name' in data || 'application_url' in data || 'careers_url' in data) {
+      const name = (data.company_name as string) || existing.company_name;
+      const appUrl = 'application_url' in data ? (data.application_url as string) : existing.application_url;
+      const carUrl = 'careers_url' in data ? (data.careers_url as string) : existing.careers_url;
+      updatePayload.company_icon_url = deriveCompanyIconUrl(name, appUrl, carUrl);
     }
 
     const [updated] = await db('cards')

--- a/frontend/src/components/Card/CardDetail.tsx
+++ b/frontend/src/components/Card/CardDetail.tsx
@@ -116,9 +116,15 @@ export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: Ca
       >
         {/* Header */}
         <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10 rounded-t-xl">
-          <h2 className="text-lg font-semibold text-gray-900 truncate">
-            {card.companyName} - {card.roleTitle}
-          </h2>
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            {card.companyIconUrl && (
+              <img src={card.companyIconUrl} alt="" className="w-6 h-6 rounded shrink-0"
+                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+            )}
+            <h2 className="text-lg font-semibold text-gray-900 truncate">
+              {card.companyName} - {card.roleTitle}
+            </h2>
+          </div>
           <button onClick={onClose} className="p-1 rounded-md hover:bg-gray-100 text-gray-400">
             <X size={20} />
           </button>

--- a/frontend/src/components/Card/CardPreview.tsx
+++ b/frontend/src/components/Card/CardPreview.tsx
@@ -45,9 +45,15 @@ export default function CardPreview({ card }: CardPreviewProps) {
   return (
     <div className="space-y-2">
       {/* Header */}
-      <div>
-        <h4 className="text-sm font-semibold text-gray-900 leading-tight">{card.companyName}</h4>
-        <p className="text-xs text-gray-500 mt-0.5 leading-tight">{card.roleTitle}</p>
+      <div className="flex items-start gap-2">
+        {card.companyIconUrl && (
+          <img src={card.companyIconUrl} alt="" className="w-5 h-5 rounded mt-0.5 shrink-0"
+            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+        )}
+        <div className="min-w-0">
+          <h4 className="text-sm font-semibold text-gray-900 leading-tight">{card.companyName}</h4>
+          <p className="text-xs text-gray-500 mt-0.5 leading-tight">{card.roleTitle}</p>
+        </div>
       </div>
 
       {/* Badges row */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -35,6 +35,7 @@ export interface Card {
   techStack: string[];
   tags: string[];
   interestLevel: number;
+  companyIconUrl?: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- **Dynamic columns:** Create, rename, delete, and reorder stages with drag-and-drop
- **Column resize:** Draggable column borders with width persistence
- **Company icons:** Auto-fetch company favicons via Google Favicon API, displayed on card previews and detail views
- **CORS hardening:** Fix DELETE preflight and support comma-separated origins
- **Vercel config:** Disable preview deployments on non-main branches

## Test plan
- [ ] Create, rename, reorder, and delete stages on the board
- [ ] Drag column borders to resize — verify widths persist on reload
- [ ] Create a card with a company URL — verify icon appears on preview and detail
- [ ] Edit company name or URL — verify icon updates
- [ ] All 44 backend tests pass
- [ ] Frontend `tsc --noEmit` and `vite build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)