### PR TITLE
feat: smart company icon resolution via Clearbit + ATS detection

### DIFF
--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -135,8 +135,10 @@ async function queryClearbit(companyName: string): Promise<{ name: string; domai
     clearTimeout(timer);
     if (!res.ok) return null;
     const results = await res.json() as { name: string; domain: string }[];
-    if (!results || results.length === 0) return null;
-    return results[0];
+    if (!Array.isArray(results) || results.length === 0) return null;
+    const top = results[0];
+    if (!top || typeof top.name !== 'string' || typeof top.domain !== 'string') return null;
+    return top;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Fixes wrong company icons when application URLs come from ATS platforms (Greenhouse, Lever, Workday, etc.)
- Uses Clearbit Autocomplete API to find the real company domain from the company name
- Validates results before using — prefers showing no icon over showing the wrong one

## Changes
- Replaced `deriveCompanyIconUrl` with async `resolveCompanyIconUrl` in `cardService.ts`
- Added ATS platform registry covering 15+ platforms
- Added confidence validation to prevent wrong icons
- Switched icon source from Google Favicons to Clearbit Logo API

## Test plan
- [ ] Create a card with a Greenhouse URL (e.g. boards.greenhouse.io/optimove/...) — verify Optimove icon appears, not Greenhouse
- [ ] Create a card with a Lever URL — verify correct company icon
- [ ] Create a card with a direct company careers URL — verify icon appears as before
- [ ] Create a card for an obscure company not in Clearbit — verify no icon shown (not a broken/wrong icon)
- [ ] Create a card with no URL at all — verify no icon shown
- [ ] Update an existing card's application_url to an ATS URL — verify icon re-resolves correctly
- [ ] Simulate Clearbit being unreachable — verify card still saves successfully with null icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)