### PR TITLE
fix: switch icon source from Clearbit Logo API to Google Favicons

### DIFF
--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -158,7 +158,7 @@ async function resolveCompanyIconUrl(
       const hostname = new URL(careersUrl).hostname;
       const parts = hostname.split('.');
       const domain = parts.slice(-2).join('.');
-      return `https://logo.clearbit.com/${domain}`;
+      return `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
     } catch { /* fall through */ }
   }
 
@@ -166,7 +166,7 @@ async function resolveCompanyIconUrl(
     const slug = extractATSSlug(applicationUrl);
     const match = await queryClearbit(companyName);
     if (match && isConfidentMatch(match.name, match.domain, companyName, slug)) {
-      return `https://logo.clearbit.com/${match.domain}`;
+      return `https://www.google.com/s2/favicons?domain=${match.domain}&sz=64`;
     }
     return null;
   }
@@ -176,13 +176,13 @@ async function resolveCompanyIconUrl(
       const hostname = new URL(applicationUrl).hostname;
       const parts = hostname.split('.');
       const domain = parts.slice(-2).join('.');
-      return `https://logo.clearbit.com/${domain}`;
+      return `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
     } catch { /* fall through */ }
   }
 
   const match = await queryClearbit(companyName);
   if (match && isConfidentMatch(match.name, match.domain, companyName)) {
-    return `https://logo.clearbit.com/${match.domain}`;
+    return `https://www.google.com/s2/favicons?domain=${match.domain}&sz=64`;
   }
 
   return null;


### PR DESCRIPTION
## Summary
- Clearbit's \`logo.clearbit.com\` is down following their HubSpot acquisition — icon URLs were returning nothing
- Switches all icon URL construction back to Google Favicons (\`https://www.google.com/s2/favicons?domain=...&sz=64\`)

## Changes
- 4 return statements in \`resolveCompanyIconUrl\` updated to use Google Favicons format
- Zero changes to the domain resolution logic (ATS detection, Clearbit Autocomplete, confidence validation all unchanged)

## Test plan
- [ ] Create a card with a Greenhouse ATS URL — verify correct company favicon appears
- [ ] Create a card with a direct careers URL — verify favicon appears
- [ ] Create a card with a LinkedIn URL — verify company favicon appears if Clearbit resolves the company name

🤖 Generated with [Claude Code](https://claude.com/claude-code)