### PR TITLE
feat: default date applied and next followup on card creation

### DIFF
--- a/frontend/src/components/Card/CardForm.tsx
+++ b/frontend/src/components/Card/CardForm.tsx
@@ -3,6 +3,13 @@ import { cardsApi } from '@/services/api';
 import type { Card, Stage } from '@/types';
 import { X, Plus } from 'lucide-react';
 
+function toLocalDateStr(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 interface CardFormProps {
   stageId: string;
   stages: Stage[];
@@ -23,8 +30,12 @@ export default function CardForm({ stageId, stages, onClose, onCreated }: CardFo
   const [salaryCurrency, setSalaryCurrency] = useState('USD');
   const [priority, setPriority] = useState<'low' | 'medium' | 'high' | 'critical'>('medium');
   const [notes, setNotes] = useState('');
-  const [dateApplied, setDateApplied] = useState('');
-  const [nextFollowupDate, setNextFollowupDate] = useState('');
+  const [dateApplied, setDateApplied] = useState(() => toLocalDateStr(new Date()));
+  const [nextFollowupDate, setNextFollowupDate] = useState(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    return toLocalDateStr(d);
+  });
   const [recruiterName, setRecruiterName] = useState('');
   const [recruiterEmail, setRecruiterEmail] = useState('');
   const [techStackInput, setTechStackInput] = useState('');


### PR DESCRIPTION
## Summary
- Pre-fills "Date Applied" with today's local date when creating a new card
- Pre-fills "Next Follow-up" with 7 days from today when creating a new card

## Changes
- Added `toLocalDateStr()` helper outside the component to format dates using local timezone (avoids UTC off-by-one for non-UTC users)
- Updated `useState` initializers for `dateApplied` and `nextFollowupDate` to use lazy initializers with local date values

## Test plan
- [ ] Open card creation form — verify "Date Applied" defaults to today's date
- [ ] Open card creation form — verify "Next Follow-up" defaults to 7 days from today
- [ ] Test at a time when UTC date differs from local date (e.g., UTC-8 after 4 PM) — verify the correct local date is shown, not UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)