### PR TITLE
Migrate database from Render to Neon PostgreSQL

### DIFF
--- a/backend/knexfile.prod.cjs
+++ b/backend/knexfile.prod.cjs
@@ -1,12 +1,13 @@
 require('dotenv').config();
 
-const isExternal = (process.env.DATABASE_URL || '').includes('.render.com');
+const dbUrl = process.env.DATABASE_URL || '';
+const requiresSsl = dbUrl.includes('.render.com') || dbUrl.includes('.neon.tech');
 
 module.exports = {
   client: 'pg',
   connection: {
-    connectionString: process.env.DATABASE_URL,
-    ssl: isExternal ? { rejectUnauthorized: false } : false,
+    connectionString: dbUrl,
+    ssl: requiresSsl ? { rejectUnauthorized: false } : false,
   },
   migrations: {
     directory: './dist-migrations',

--- a/render.yaml
+++ b/render.yaml
@@ -11,9 +11,7 @@ services:
       - key: NODE_ENV
         value: production
       - key: DATABASE_URL
-        fromDatabase:
-          name: jobflow-db
-          property: connectionString
+        sync: false
       - key: JWT_SECRET
         generateValue: true
       - key: JWT_REFRESH_SECRET
@@ -23,8 +21,3 @@ services:
       - key: PORT
         value: 3001
 
-databases:
-  - name: jobflow-db
-    plan: free
-    databaseName: jobflow
-    region: oregon


### PR DESCRIPTION
- Update knexfile.prod.cjs to enable SSL for neon.tech hosts
- Remove Render-managed DB from render.yaml; DATABASE_URL is now a manual env var

https://claude.ai/code/session_01SFhwmW594Fm5LzcSVFbEt8