### PR TITLE
Migrate PostgreSQL from Render to Neon

### DIFF
--- a/backend/knexfile.prod.cjs
+++ b/backend/knexfile.prod.cjs
@@ -9,6 +9,7 @@ module.exports = {
     connectionString: dbUrl,
     ssl: requiresSsl ? { rejectUnauthorized: false } : false,
   },
+  searchPath: ['public'],
   migrations: {
     directory: './dist-migrations',
   },


### PR DESCRIPTION
## Summary
- Remove Render-managed PostgreSQL database from `render.yaml`; `DATABASE_URL` is now set as a manual env var pointing to Neon
- Update SSL detection in `knexfile.prod.cjs` to support `.neon.tech` hosts in addition to `.render.com`
- Add `searchPath: ['public']` to fix "no schema selected" error on Neon during migrations

## Test plan
- [ ] Set `DATABASE_URL` in Render dashboard to the Neon connection string
- [ ] Merge this PR — Render will auto-deploy
- [ ] Verify migrations run successfully in deploy logs
- [ ] Verify app connects and data is accessible

https://claude.ai/code/session_01SFhwmW594Fm5LzcSVFbEt8