### PR TITLE
feat: simplify card creation — show only 3 primary fields by default

### DIFF
--- a/frontend/src/components/Card/CardForm.tsx
+++ b/frontend/src/components/Card/CardForm.tsx
@@ -178,11 +178,12 @@ export default function CardForm({ stageId, stages, onClose, onCreated }: CardFo
           <button
             type="button"
             onClick={() => setShowMore((v) => !v)}
+            aria-expanded={showMore}
             className="flex items-center gap-1 text-sm text-primary-600 hover:text-primary-700 font-medium"
           >
             <ChevronDown
               size={16}
-              className={showMore ? 'rotate-180 transition-transform' : 'transition-transform'}
+              className={`transition-transform${showMore ? ' rotate-180' : ''}`}
             />
             {showMore ? 'Show fewer fields' : 'Show more fields'}
           </button>


### PR DESCRIPTION
## Summary
- Card creation modal now shows only Stage, Company Name, Role Title, and Application URL by default
- All other fields are collapsed behind a "Show more fields" toggle with animated chevron
- Submit button renamed to "Add" for a quicker feel

## Changes
- `CardForm.tsx`: Added `showMore` state, extracted Application URL as standalone field, wrapped 11 secondary fields in conditional render, added toggle button with `ChevronDown` icon, updated submit label

## Test plan
- [ ] Open board → click `+` on any column → verify only 4 fields visible
- [ ] Fill Company Name + Role Title → click "Add" → card created with defaults
- [ ] Click "Show more fields" → all secondary fields appear
- [ ] Fill secondary fields → "Add" → card saved with those values
- [ ] Toggle closed → secondary fields hide, primary values preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)