### PR TITLE
feat: linked tasks in CardDetail

### DIFF
--- a/frontend/src/components/Card/CardDetail.tsx
+++ b/frontend/src/components/Card/CardDetail.tsx
@@ -14,15 +14,9 @@ import {
   Plus,
   Unlink,
 } from 'lucide-react';
-
-const TODO_PRIORITY_CONFIG: Record<Todo['priority'], { cssClass: string; label: string }> = {
-  urgent: { cssClass: 'priority-critical', label: 'Urgent' },
-  high:   { cssClass: 'priority-high',     label: 'High'   },
-  medium: { cssClass: 'priority-medium',   label: 'Medium' },
-  low:    { cssClass: 'priority-low',      label: 'Low'    },
-};
 import { format, parseISO } from 'date-fns';
 import { useAutoResize } from '@/hooks/useAutoResize';
+import { TODO_PRIORITY_CONFIG } from '@/utils/todoPriority';
 
 interface CardDetailProps {
   cardId: string;
@@ -76,6 +70,25 @@ export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: Ca
       console.error('Failed to create linked todo:', err);
     } finally {
       setAddingTodo(false);
+    }
+  };
+
+  const handleToggleTodo = async (todo: Todo) => {
+    const newStatus = todo.status === 'active' ? 'completed' : 'active';
+    try {
+      const updated = await todosApi.updateTodo(todo.id, { status: newStatus });
+      setLinkedTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+    } catch (err) {
+      console.error('Failed to toggle todo:', err);
+    }
+  };
+
+  const handleUnlinkTodo = async (todo: Todo) => {
+    try {
+      const updated = await todosApi.updateTodo(todo.id, { cardId: null });
+      setLinkedTodos((prev) => prev.filter((t) => t.id !== updated.id));
+    } catch (err) {
+      console.error('Failed to unlink todo:', err);
     }
   };
 
@@ -143,6 +156,8 @@ export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: Ca
   }
 
   if (!card) return null;
+
+  const activeTodoCount = linkedTodos.filter((t) => t.status === 'active').length;
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
@@ -517,9 +532,9 @@ export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: Ca
             <h3 className="text-sm font-semibold text-gray-900 mb-3 flex items-center gap-2">
               <CheckSquare size={14} />
               Tasks
-              {linkedTodos.filter((t) => t.status === 'active').length > 0 && (
+              {activeTodoCount > 0 && (
                 <span className="inline-flex items-center justify-center min-w-[1.25rem] h-5 rounded-full bg-primary-100 text-primary-700 text-[11px] font-semibold px-1.5">
-                  {linkedTodos.filter((t) => t.status === 'active').length}
+                  {activeTodoCount}
                 </span>
               )}
             </h3>
@@ -561,15 +576,7 @@ export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: Ca
                   <input
                     type="checkbox"
                     checked={todo.status === 'completed'}
-                    onChange={async () => {
-                      const newStatus = todo.status === 'active' ? 'completed' : 'active';
-                      try {
-                        const updated = await todosApi.updateTodo(todo.id, { status: newStatus });
-                        setLinkedTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
-                      } catch (err) {
-                        console.error('Failed to toggle todo:', err);
-                      }
-                    }}
+                    onChange={() => handleToggleTodo(todo)}
                     className="w-4 h-4 shrink-0 cursor-pointer accent-primary-600"
                   />
                   <span
@@ -586,14 +593,7 @@ export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: Ca
                     {todo.description}
                   </span>
                   <button
-                    onClick={async () => {
-                      try {
-                        const updated = await todosApi.updateTodo(todo.id, { cardId: null });
-                        setLinkedTodos((prev) => prev.filter((t) => t.id !== updated.id));
-                      } catch (err) {
-                        console.error('Failed to unlink todo:', err);
-                      }
-                    }}
+                    onClick={() => handleUnlinkTodo(todo)}
                     className="p-1 rounded text-gray-300 hover:text-amber-500 hover:bg-amber-50 transition opacity-0 group-hover:opacity-100 shrink-0"
                     aria-label="Unlink task from card"
                     title="Unlink from card"

--- a/frontend/src/components/Card/CardDetail.tsx
+++ b/frontend/src/components/Card/CardDetail.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react';
-import { cardsApi } from '@/services/api';
-import type { Card, CardActivity } from '@/types';
+import { useState, useEffect, useRef } from 'react';
+import { cardsApi, todosApi } from '@/services/api';
+import type { Card, CardActivity, Todo } from '@/types';
 import {
   X,
   Trash2,
@@ -10,7 +10,17 @@ import {
   MessageSquare,
   Send,
   AlertCircle,
+  CheckSquare,
+  Plus,
+  Unlink,
 } from 'lucide-react';
+
+const TODO_PRIORITY_CONFIG: Record<Todo['priority'], { cssClass: string; label: string }> = {
+  urgent: { cssClass: 'priority-critical', label: 'Urgent' },
+  high:   { cssClass: 'priority-high',     label: 'High'   },
+  medium: { cssClass: 'priority-medium',   label: 'Medium' },
+  low:    { cssClass: 'priority-low',      label: 'Low'    },
+};
 import { format, parseISO } from 'date-fns';
 import { useAutoResize } from '@/hooks/useAutoResize';
 
@@ -24,6 +34,7 @@ interface CardDetailProps {
 export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: CardDetailProps) {
   const [card, setCard] = useState<Card | null>(null);
   const [activities, setActivities] = useState<CardActivity[]>([]);
+  const [linkedTodos, setLinkedTodos] = useState<Todo[]>([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [editData, setEditData] = useState<Partial<Card>>({});
@@ -31,20 +42,42 @@ export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: Ca
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [techStackInput, setTechStackInput] = useState('');
   const [tagsInput, setTagsInput] = useState('');
+  const [newTodoDescription, setNewTodoDescription] = useState('');
+  const [addingTodo, setAddingTodo] = useState(false);
+  const todoInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    cardsApi
-      .getCard(cardId)
-      .then(({ card: c, activities: a }) => {
+    Promise.all([
+      cardsApi.getCard(cardId),
+      todosApi.getTodos({ cardId }),
+    ])
+      .then(([{ card: c, activities: a }, todos]) => {
         setCard(c);
         setActivities(a);
         setEditData(c);
         setTechStackInput(c.techStack.join(', '));
         setTagsInput(c.tags.join(', '));
+        setLinkedTodos(todos);
       })
       .catch(console.error)
       .finally(() => setLoading(false));
   }, [cardId]);
+
+  const handleAddLinkedTodo = async () => {
+    const trimmed = newTodoDescription.trim();
+    if (!trimmed) return;
+    setAddingTodo(true);
+    try {
+      const created = await todosApi.createTodo({ description: trimmed, priority: 'medium', cardId });
+      setLinkedTodos((prev) => [created, ...prev]);
+      setNewTodoDescription('');
+      todoInputRef.current?.focus();
+    } catch (err) {
+      console.error('Failed to create linked todo:', err);
+    } finally {
+      setAddingTodo(false);
+    }
+  };
 
   const handleSave = async () => {
     if (!card) return;
@@ -476,6 +509,99 @@ export default function CardDetail({ cardId, onClose, onUpdated, onDeleted }: Ca
               {activities.length === 0 && (
                 <p className="text-sm text-gray-400 text-center py-4">No activity yet</p>
               )}
+            </div>
+          </div>
+
+          {/* Linked Tasks */}
+          <div className="border-t border-gray-200 pt-5">
+            <h3 className="text-sm font-semibold text-gray-900 mb-3 flex items-center gap-2">
+              <CheckSquare size={14} />
+              Tasks
+              {linkedTodos.filter((t) => t.status === 'active').length > 0 && (
+                <span className="inline-flex items-center justify-center min-w-[1.25rem] h-5 rounded-full bg-primary-100 text-primary-700 text-[11px] font-semibold px-1.5">
+                  {linkedTodos.filter((t) => t.status === 'active').length}
+                </span>
+              )}
+            </h3>
+
+            {/* Add linked task */}
+            <div className="flex gap-2 mb-3">
+              <input
+                ref={todoInputRef}
+                type="text"
+                value={newTodoDescription}
+                onChange={(e) => setNewTodoDescription(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleAddLinkedTodo()}
+                placeholder="Add a task for this card..."
+                className="input-field flex-1 text-sm"
+                disabled={addingTodo}
+              />
+              <button
+                onClick={handleAddLinkedTodo}
+                disabled={addingTodo || !newTodoDescription.trim()}
+                className="rounded-lg bg-gray-100 px-3 text-gray-500 hover:bg-gray-200 hover:text-gray-700 transition disabled:opacity-40"
+                aria-label="Add task"
+              >
+                <Plus size={14} />
+              </button>
+            </div>
+
+            {/* Todo list */}
+            <div className="space-y-1">
+              {linkedTodos.length === 0 && (
+                <p className="text-sm text-gray-400 text-center py-3">No tasks linked to this card.</p>
+              )}
+              {linkedTodos.map((todo) => (
+                <div
+                  key={todo.id}
+                  className={`flex items-center gap-2 py-1.5 px-2 rounded-lg hover:bg-gray-50 group ${
+                    todo.status === 'completed' ? 'opacity-60' : ''
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={todo.status === 'completed'}
+                    onChange={async () => {
+                      const newStatus = todo.status === 'active' ? 'completed' : 'active';
+                      try {
+                        const updated = await todosApi.updateTodo(todo.id, { status: newStatus });
+                        setLinkedTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+                      } catch (err) {
+                        console.error('Failed to toggle todo:', err);
+                      }
+                    }}
+                    className="w-4 h-4 shrink-0 cursor-pointer accent-primary-600"
+                  />
+                  <span
+                    className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium shrink-0 ${TODO_PRIORITY_CONFIG[todo.priority].cssClass}`}
+                  >
+                    {TODO_PRIORITY_CONFIG[todo.priority].label}
+                  </span>
+                  <span
+                    className={`flex-1 text-sm min-w-0 truncate ${
+                      todo.status === 'completed' ? 'line-through text-gray-400' : 'text-gray-800'
+                    }`}
+                    title={todo.description}
+                  >
+                    {todo.description}
+                  </span>
+                  <button
+                    onClick={async () => {
+                      try {
+                        const updated = await todosApi.updateTodo(todo.id, { cardId: null });
+                        setLinkedTodos((prev) => prev.filter((t) => t.id !== updated.id));
+                      } catch (err) {
+                        console.error('Failed to unlink todo:', err);
+                      }
+                    }}
+                    className="p-1 rounded text-gray-300 hover:text-amber-500 hover:bg-amber-50 transition opacity-0 group-hover:opacity-100 shrink-0"
+                    aria-label="Unlink task from card"
+                    title="Unlink from card"
+                  >
+                    <Unlink size={12} />
+                  </button>
+                </div>
+              ))}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Tasks section added to the CardDetail modal, showing todos linked to that specific card

## Changes
- `CardDetail`: fetches linked todos on open (`GET /api/todos?cardId=`), renders Tasks section below Activity Timeline
- Add-task input creates todos pre-linked to the card (`POST /api/todos` with `cardId`)
- Checkbox toggles active/completed inline
- Unlink button (hover) sets `cardId: null` — removes from this card's list but todo survives
- Completed linked todos stay visible with strikethrough (they do not disappear)

## Dependencies
Stacks on top of #24 (`feature/todo-panel-board`). Merge #24 first.

## Test plan
- [ ] Open a card → Tasks section appears below Activity
- [ ] Add task → appears immediately linked to card
- [ ] Complete task → strikethrough, stays visible
- [ ] Unlink → removed from this card's list, survives in /tasks page
- [ ] Tasks added here appear in the todo panel with T chip

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)