### PR TITLE
feat: trie data structure in Web Worker for autocomplete

### DIFF
--- a/frontend/src/workers/trie.worker.ts
+++ b/frontend/src/workers/trie.worker.ts
@@ -32,12 +32,10 @@ function getWordsWithPrefix(prefix: string, limit: number): string[] {
   const results: string[] = [];
 
   function dfs(current: TrieNode, path: string): void {
-    if (results.length >= limit) return;
     if (current.isEnd) {
       results.push(path);
     }
     for (const [char, child] of current.children) {
-      if (results.length >= limit) return;
       dfs(child, path + char);
     }
   }
@@ -53,6 +51,7 @@ self.onmessage = (event: MessageEvent) => {
     | { type: 'query'; prefix: string };
 
   if (data.type === 'build') {
+    if (!Array.isArray(data.words)) return;
     for (const word of data.words) {
       insert(word);
     }

--- a/frontend/src/workers/trie.worker.ts
+++ b/frontend/src/workers/trie.worker.ts
@@ -1,0 +1,66 @@
+interface TrieNode {
+  children: Map<string, TrieNode>;
+  isEnd: boolean;
+}
+
+function createNode(): TrieNode {
+  return { children: new Map(), isEnd: false };
+}
+
+const root: TrieNode = createNode();
+
+function insert(word: string): void {
+  let node = root;
+  for (const char of word) {
+    if (!node.children.has(char)) {
+      node.children.set(char, createNode());
+    }
+    node = node.children.get(char)!;
+  }
+  node.isEnd = true;
+}
+
+function getWordsWithPrefix(prefix: string, limit: number): string[] {
+  let node = root;
+  for (const char of prefix) {
+    if (!node.children.has(char)) {
+      return [];
+    }
+    node = node.children.get(char)!;
+  }
+
+  const results: string[] = [];
+
+  function dfs(current: TrieNode, path: string): void {
+    if (results.length >= limit) return;
+    if (current.isEnd) {
+      results.push(path);
+    }
+    for (const [char, child] of current.children) {
+      if (results.length >= limit) return;
+      dfs(child, path + char);
+    }
+  }
+
+  dfs(node, prefix);
+  results.sort();
+  return results.slice(0, limit);
+}
+
+self.onmessage = (event: MessageEvent) => {
+  const data = event.data as
+    | { type: 'build'; words: string[] }
+    | { type: 'query'; prefix: string };
+
+  if (data.type === 'build') {
+    for (const word of data.words) {
+      insert(word);
+    }
+    self.postMessage({ type: 'ready' });
+  } else if (data.type === 'query') {
+    const suggestions = getWordsWithPrefix(data.prefix, 5);
+    self.postMessage({ type: 'results', suggestions });
+  }
+};
+
+export type {};

--- a/frontend/src/workers/trieWorker.ts
+++ b/frontend/src/workers/trieWorker.ts
@@ -1,6 +1,3 @@
-// Singleton trie Web Worker instance — created once at module level.
-// All autocomplete consumers share this single worker to avoid duplicate
-// trie builds and unnecessary memory usage.
 const trieWorker = new Worker(new URL('./trie.worker.ts', import.meta.url), {
   type: 'module',
 });

--- a/frontend/src/workers/trieWorker.ts
+++ b/frontend/src/workers/trieWorker.ts
@@ -1,0 +1,8 @@
+// Singleton trie Web Worker instance — created once at module level.
+// All autocomplete consumers share this single worker to avoid duplicate
+// trie builds and unnecessary memory usage.
+const trieWorker = new Worker(new URL('./trie.worker.ts', import.meta.url), {
+  type: 'module',
+});
+
+export default trieWorker;


### PR DESCRIPTION
## Summary
- Implements a prefix trie data structure that runs inside a Web Worker, keeping 100K+ word insertions off the main thread
- Responds to `{ type: 'build', words }` by building the trie and posting `{ type: 'ready' }` when complete
- Responds to `{ type: 'query', prefix }` by returning up to 5 alphabetically sorted matching words as `{ type: 'results', suggestions }`

## Changes
- `frontend/src/workers/trie.worker.ts` — trie worker implementation (TrieNode structure, insert, DFS prefix search, message handler)
- `frontend/src/workers/trieWorker.ts` — singleton Worker export using Vite's `new Worker(new URL(...))` syntax

## Test plan
- [ ] Import `trieWorker` from `trieWorker.ts` in a component and send a `build` message with a list of Hebrew words; verify `ready` message is received
- [ ] Send a `query` message with a known prefix; verify up to 5 alphabetically sorted matches are returned
- [ ] Send a `query` with a prefix that has no matches; verify an empty `suggestions` array is returned
- [ ] Verify `trieWorker` is the same instance across multiple imports (singleton)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)