### PR TITLE
feat: add useAutocomplete hook with lazy init and debounced trie queries

### DIFF
--- a/frontend/src/hooks/useAutocomplete.ts
+++ b/frontend/src/hooks/useAutocomplete.ts
@@ -1,0 +1,69 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import trieWorker from '@/workers/trieWorker';
+
+interface UseAutocompleteResult {
+  suggestions: string[];
+  isLoading: boolean;
+  triggerInit: () => void;
+  query: (prefix: string) => void;
+}
+
+export function useAutocomplete(): UseAutocompleteResult {
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const initializedRef = useRef(false);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const data = event.data as
+        | { type: 'ready' }
+        | { type: 'results'; suggestions: string[] };
+
+      if (data.type === 'ready') {
+        setIsLoading(false);
+      } else if (data.type === 'results') {
+        setSuggestions(data.suggestions);
+      }
+    };
+
+    trieWorker.addEventListener('message', handleMessage);
+    return () => {
+      trieWorker.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  const triggerInit = useCallback(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+    setIsLoading(true);
+
+    fetch('/api/autocomplete/words')
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to fetch words: ${res.status}`);
+        }
+        return res.json() as Promise<{ source: string; words: string[] }>;
+      })
+      .then((data) => {
+        trieWorker.postMessage({ type: 'build', words: data.words });
+      })
+      .catch(() => {
+        setIsLoading(false);
+        initializedRef.current = false;
+      });
+  }, []);
+
+  const query = useCallback((prefix: string) => {
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      trieWorker.postMessage({ type: 'query', prefix });
+    }, 150);
+  }, []);
+
+  return { suggestions, isLoading, triggerInit, query };
+}

--- a/frontend/src/hooks/useAutocomplete.ts
+++ b/frontend/src/hooks/useAutocomplete.ts
@@ -1,6 +1,10 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import trieWorker from '@/workers/trieWorker';
 
+// Sequence counter shared across all instances so each query can be
+// matched back to the instance that issued it.
+let globalSeq = 0;
+
 interface UseAutocompleteResult {
   suggestions: string[];
   isLoading: boolean;
@@ -13,24 +17,36 @@ export function useAutocomplete(): UseAutocompleteResult {
   const [isLoading, setIsLoading] = useState(false);
 
   const initializedRef = useRef(false);
+  const isReadyRef = useRef(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The seq number this instance assigned to its most recent query.
+  const lastSeqRef = useRef<number>(-1);
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       const data = event.data as
         | { type: 'ready' }
-        | { type: 'results'; suggestions: string[] };
+        | { type: 'results'; suggestions: string[]; seq: number };
 
       if (data.type === 'ready') {
+        isReadyRef.current = true;
         setIsLoading(false);
       } else if (data.type === 'results') {
-        setSuggestions(data.suggestions);
+        // Only accept results that this instance requested.
+        if (data.seq === lastSeqRef.current) {
+          setSuggestions(data.suggestions);
+        }
       }
     };
 
     trieWorker.addEventListener('message', handleMessage);
     return () => {
       trieWorker.removeEventListener('message', handleMessage);
+      // Cancel any pending debounce to avoid posting to the worker after unmount.
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
     };
   }, []);
 
@@ -39,7 +55,8 @@ export function useAutocomplete(): UseAutocompleteResult {
     initializedRef.current = true;
     setIsLoading(true);
 
-    fetch('/api/autocomplete/words')
+    const baseUrl = import.meta.env.VITE_API_URL ?? '/api';
+    fetch(`${baseUrl}/autocomplete/words`)
       .then((res) => {
         if (!res.ok) {
           throw new Error(`Failed to fetch words: ${res.status}`);
@@ -56,12 +73,17 @@ export function useAutocomplete(): UseAutocompleteResult {
   }, []);
 
   const query = useCallback((prefix: string) => {
+    // Do not send queries before the trie has been built.
+    if (!isReadyRef.current) return;
+
     if (debounceTimerRef.current !== null) {
       clearTimeout(debounceTimerRef.current);
     }
     debounceTimerRef.current = setTimeout(() => {
       debounceTimerRef.current = null;
-      trieWorker.postMessage({ type: 'query', prefix });
+      const seq = ++globalSeq;
+      lastSeqRef.current = seq;
+      trieWorker.postMessage({ type: 'query', prefix, seq });
     }, 150);
   }, []);
 

--- a/frontend/src/workers/trie.worker.ts
+++ b/frontend/src/workers/trie.worker.ts
@@ -48,7 +48,7 @@ function getWordsWithPrefix(prefix: string, limit: number): string[] {
 self.onmessage = (event: MessageEvent) => {
   const data = event.data as
     | { type: 'build'; words: string[] }
-    | { type: 'query'; prefix: string };
+    | { type: 'query'; prefix: string; seq: number };
 
   if (data.type === 'build') {
     if (!Array.isArray(data.words)) return;
@@ -58,7 +58,7 @@ self.onmessage = (event: MessageEvent) => {
     self.postMessage({ type: 'ready' });
   } else if (data.type === 'query') {
     const suggestions = getWordsWithPrefix(data.prefix, 5);
-    self.postMessage({ type: 'results', suggestions });
+    self.postMessage({ type: 'results', suggestions, seq: data.seq });
   }
 };
 


### PR DESCRIPTION
## Summary
- Adds `useAutocomplete` hook at `frontend/src/hooks/useAutocomplete.ts`
- Lazily fetches `GET /api/autocomplete/words` and builds the trie worker on first focus (via `triggerInit()`)
- Debounces prefix queries to the trie worker by 150ms using `useRef` + `setTimeout` — no external library

## Changes
- New file: `frontend/src/hooks/useAutocomplete.ts`
- Uses the singleton `trieWorker` from `frontend/src/workers/trieWorker.ts`
- `isLoading` is `true` from `triggerInit()` until the worker posts `{ type: 'ready' }`
- On fetch failure, resets `initializedRef` so the next focus attempt can retry
- Returns `{ suggestions, isLoading, triggerInit, query }` — generic, not coupled to any specific component

## Test plan
- [ ] Call `triggerInit()` on first input focus — verify fetch to `/api/autocomplete/words` fires only once
- [ ] `isLoading` becomes `true` on first `triggerInit()` and `false` after worker signals ready
- [ ] Type rapidly into an autocomplete input — verify the trie worker only receives a query after 150ms of inactivity
- [ ] Simulate a network failure for `/api/autocomplete/words` — verify `isLoading` returns to `false` and a retry works on next focus
- [ ] Confirm `triggerInit()` is a no-op on all subsequent calls after the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)