### PR TITLE
feat: update last_interaction_date on kanban column move

### DIFF
--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -405,6 +405,7 @@ export const cardService = {
           stage_id: stageId,
           position,
           updated_at: trx.fn.now(),
+          ...(oldStageId !== stageId ? { last_interaction_date: trx.fn.now() } : {}),
         });
     });
 

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -51,9 +51,11 @@ export default function BoardPage() {
     try {
       const updatedCard = await cardsApi.moveCard(cardId, newStageId, newPosition);
       setCards((prev) =>
-        prev.map((c) =>
-          c.id === cardId ? { ...c, lastInteractionDate: updatedCard.lastInteractionDate } : c
-        )
+        prev.map((c) => {
+          if (c.id !== cardId) return c;
+          if (c.lastInteractionDate === updatedCard.lastInteractionDate) return c;
+          return { ...c, lastInteractionDate: updatedCard.lastInteractionDate };
+        })
       );
     } catch {
       fetchData();

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -49,7 +49,12 @@ export default function BoardPage() {
       )
     );
     try {
-      await cardsApi.moveCard(cardId, newStageId, newPosition);
+      const updatedCard = await cardsApi.moveCard(cardId, newStageId, newPosition);
+      setCards((prev) =>
+        prev.map((c) =>
+          c.id === cardId ? { ...c, lastInteractionDate: updatedCard.lastInteractionDate } : c
+        )
+      );
     } catch {
       fetchData();
     }


### PR DESCRIPTION
## Summary
- Automatically sets `last_interaction_date` to today when a card is moved to a different column
- Syncs the updated date into board state immediately after a successful move (no refresh needed)

## Changes
- `backend/src/services/cardService.ts`: add conditional `last_interaction_date: trx.fn.now()` inside the `moveCard` transaction, guarded by `oldStageId !== stageId`
- `frontend/src/pages/BoardPage.tsx`: use the card returned by `cardsApi.moveCard` to patch `lastInteractionDate` in local state

## Test plan
- [ ] Drag a card to a different column — verify `last_interaction_date` updates in the DB and the card preview shows 0 days since interaction
- [ ] Reorder a card within the same column — verify `last_interaction_date` is unchanged
- [ ] Simulate a failed move (network error) — verify the board rolls back correctly via `fetchData()`

Closes #43
Closes #44
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)