### PR TITLE
fix: restore vertical scroll on board page when task list is open

### DIFF
--- a/frontend/src/components/Todo/TodoPanel.tsx
+++ b/frontend/src/components/Todo/TodoPanel.tsx
@@ -215,7 +215,7 @@ export default function TodoPanel(): JSX.Element {
         style={{
           maxHeight: isOpen ? '500px' : '0',
           opacity: isOpen ? 1 : 0,
-          overflow: 'hidden',
+          overflowY: 'auto',
           transition: 'max-height 0.3s ease-in-out, opacity 0.2s ease-in-out',
         }}
       >

--- a/frontend/src/components/Todo/TodoPanel.tsx
+++ b/frontend/src/components/Todo/TodoPanel.tsx
@@ -215,7 +215,7 @@ export default function TodoPanel(): JSX.Element {
         style={{
           maxHeight: isOpen ? '500px' : '0',
           opacity: isOpen ? 1 : 0,
-          overflowY: 'auto',
+          overflowY: isOpen ? 'auto' : 'hidden',
           transition: 'max-height 0.3s ease-in-out, opacity 0.2s ease-in-out',
         }}
       >

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -153,13 +153,13 @@ export default function BoardPage() {
     : 0;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full overflow-y-auto">
       <ReminderBanner />
       <SearchBar filters={filters} onFiltersChange={setFilters} stages={stages} />
       <div className="px-4 mb-4">
         <TodoPanel />
       </div>
-      <div className="flex-1 overflow-hidden px-4 pb-4">
+      <div className="flex-1 px-4 pb-4">
         <Board
           stages={stages}
           cards={cards}


### PR DESCRIPTION
## Summary
- Fixes board page being unreachable when task list is open with many items
- Task list now scrolls internally at 500px max-height
- Page scrolls vertically so board is always accessible below the task list

## Changes
- `TodoPanel.tsx`: `overflow: hidden` → `overflowY: auto` on collapsible body
- `BoardPage.tsx`: add `overflow-y-auto` to root div
- `BoardPage.tsx`: remove `overflow-hidden` from board wrapper

## Test plan
- [ ] Open board page, expand task list, add many tasks — verify internal scroll at ~500px
- [ ] With task list open, scroll the page down — verify board is visible and reachable
- [ ] Verify board column card scroll still works (no regression)
- [ ] Check other pages (e.g. settings) are unaffected

Closes #48
Relates to PRD #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)