### PR TITLE
feat: todo count badge on kanban card preview

### DIFF
--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -195,7 +195,9 @@ export const cardService = {
       .where('cards.user_id', userId)
       .select(
         'cards.*',
-        'stages.name as stage_name'
+        'stages.name as stage_name',
+        db.raw(`(SELECT COUNT(*) FROM todo_items WHERE todo_items.card_id = cards.id)::int AS total_todo_count`),
+        db.raw(`(SELECT COUNT(*) FROM todo_items WHERE todo_items.card_id = cards.id AND todo_items.status = 'active')::int AS active_todo_count`)
       )
       .orderBy('cards.position', 'asc');
 

--- a/frontend/src/components/Card/CardPreview.tsx
+++ b/frontend/src/components/Card/CardPreview.tsx
@@ -101,11 +101,11 @@ export default function CardPreview({ card }: CardPreviewProps) {
             </span>
           )}
         </div>
-        {card.totalTodoCount > 0 && (
+        {(card.totalTodoCount ?? 0) > 0 && (
           <span className={`flex items-center gap-0.5 text-[10px] ${
-            card.activeTodoCount > 0 ? 'text-violet-500' : 'text-gray-400'
+            (card.activeTodoCount ?? 0) > 0 ? 'text-violet-500' : 'text-gray-400'
           }`}>
-            {card.activeTodoCount > 0
+            {(card.activeTodoCount ?? 0) > 0
               ? <ListTodo size={10} />
               : <CheckSquare size={10} />
             }

--- a/frontend/src/components/Card/CardPreview.tsx
+++ b/frontend/src/components/Card/CardPreview.tsx
@@ -1,5 +1,5 @@
 import type { Card } from '@/types';
-import { MapPin, Monitor, Home, Building2, Clock, CalendarClock, DollarSign } from 'lucide-react';
+import { MapPin, Monitor, Home, Building2, Clock, CalendarClock, DollarSign, ListTodo, CheckSquare } from 'lucide-react';
 import { formatDistanceToNow, parseISO, differenceInDays } from 'date-fns';
 
 const priorityConfig: Record<string, { class: string; label: string }> = {
@@ -101,6 +101,17 @@ export default function CardPreview({ card }: CardPreviewProps) {
             </span>
           )}
         </div>
+        {card.totalTodoCount > 0 && (
+          <span className={`flex items-center gap-0.5 text-[10px] ${
+            card.activeTodoCount > 0 ? 'text-violet-500' : 'text-gray-400'
+          }`}>
+            {card.activeTodoCount > 0
+              ? <ListTodo size={10} />
+              : <CheckSquare size={10} />
+            }
+            {card.totalTodoCount}
+          </span>
+        )}
       </div>
 
       {/* Tech stack tags */}

--- a/frontend/src/components/Todo/TodoPanel.tsx
+++ b/frontend/src/components/Todo/TodoPanel.tsx
@@ -67,7 +67,7 @@ function SortableTodoItem({
   );
 }
 
-export default function TodoPanel(): JSX.Element {
+export default function TodoPanel({ onTodoMutated }: { onTodoMutated?: () => void }): JSX.Element {
   const [isOpen, setIsOpen] = useState(false);
   const [todos, setTodos] = useState<Todo[]>([]);
   const [hasFetched, setHasFetched] = useState(false);
@@ -166,14 +166,19 @@ export default function TodoPanel(): JSX.Element {
 
   // Stable callbacks so SortableTodoItem does not re-render on every parent render
   const handleTodoUpdate = useCallback(
-    (updated: Todo) =>
-      setTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t))),
-    []
+    (updated: Todo) => {
+      setTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
+      onTodoMutated?.();
+    },
+    [onTodoMutated]
   );
 
   const handleTodoDelete = useCallback(
-    (id: string) => setTodos((prev) => prev.filter((t) => t.id !== id)),
-    []
+    (id: string) => {
+      setTodos((prev) => prev.filter((t) => t.id !== id));
+      onTodoMutated?.();
+    },
+    [onTodoMutated]
   );
 
   return (

--- a/frontend/src/components/Todo/TodoPanel.tsx
+++ b/frontend/src/components/Todo/TodoPanel.tsx
@@ -167,8 +167,13 @@ export default function TodoPanel({ onTodoMutated }: { onTodoMutated?: () => voi
   // Stable callbacks so SortableTodoItem does not re-render on every parent render
   const handleTodoUpdate = useCallback(
     (updated: Todo) => {
-      setTodos((prev) => prev.map((t) => (t.id === updated.id ? updated : t)));
-      onTodoMutated?.();
+      setTodos((prev) => {
+        const existing = prev.find((t) => t.id === updated.id);
+        if (existing && (existing.status !== updated.status || existing.cardId !== updated.cardId)) {
+          onTodoMutated?.();
+        }
+        return prev.map((t) => (t.id === updated.id ? updated : t));
+      });
     },
     [onTodoMutated]
   );

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -157,7 +157,7 @@ export default function BoardPage() {
       <ReminderBanner />
       <SearchBar filters={filters} onFiltersChange={setFilters} stages={stages} />
       <div className="px-4 mb-4">
-        <TodoPanel />
+        <TodoPanel onTodoMutated={fetchData} />
       </div>
       <div className="flex-1 px-4 pb-4">
         <Board

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,8 +38,8 @@ export interface Card {
   companyIconUrl?: string;
   createdAt: string;
   updatedAt: string;
-  activeTodoCount: number;
-  totalTodoCount: number;
+  activeTodoCount?: number;
+  totalTodoCount?: number;
 }
 
 export interface CardActivity {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,6 +38,8 @@ export interface Card {
   companyIconUrl?: string;
   createdAt: string;
   updatedAt: string;
+  activeTodoCount: number;
+  totalTodoCount: number;
 }
 
 export interface CardActivity {


### PR DESCRIPTION
## Summary
- Kanban cards now show a compact badge with the number of linked todos
- Violet `ListTodo` icon when there are active todos; gray `CheckSquare` when all done; hidden when none
- Badge stays in sync after todo mutations (no page reload needed)

## Changes
- `cardService.ts`: two COUNT subqueries added to `getAllCards`
- `types/index.ts`: `activeTodoCount` and `totalTodoCount` added to `Card`
- `CardPreview.tsx`: badge rendered in footer row right side
- `BoardPage.tsx`: passes `onTodoMutated={fetchData}` to `TodoPanel`
- `TodoPanel.tsx`: accepts `onTodoMutated` prop, calls it on update/delete

## Test plan
- [ ] Card with active todos shows violet badge with correct total count
- [ ] Card with all todos completed shows gray badge with correct total count
- [ ] Card with no todos shows no badge
- [ ] Completing a todo on a linked card updates the badge without page reload
- [ ] Deleting a todo updates the badge
- [ ] TypeScript compiles without errors

Closes #55, closes #56, closes #57
Relates to PRD #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)