### PR TITLE
feat: add Knex migration for PostgreSQL card notify trigger

### DIFF
--- a/backend/migrations/009_card_notify_trigger.ts
+++ b/backend/migrations/009_card_notify_trigger.ts
@@ -28,6 +28,8 @@ export async function up(knex: Knex): Promise<void> {
         END IF;
       END IF;
 
+      -- pg_notify enforces an 8000-byte payload limit; this payload is
+      -- intentionally minimal (event, card_id, user_id) to stay well under it.
       payload := json_build_object(
         'event',   event_type,
         'card_id', card_id,
@@ -41,6 +43,9 @@ export async function up(knex: Knex): Promise<void> {
     $$ LANGUAGE plpgsql;
   `);
 
+  // Drop before re-creating so up() is idempotent if re-run after a partial failure.
+  await knex.raw(`DROP TRIGGER IF EXISTS card_notify_trigger ON cards;`);
+
   await knex.raw(`
     CREATE TRIGGER card_notify_trigger
     AFTER INSERT OR UPDATE OR DELETE ON cards
@@ -50,5 +55,6 @@ export async function up(knex: Knex): Promise<void> {
 
 export async function down(knex: Knex): Promise<void> {
   await knex.raw(`DROP TRIGGER IF EXISTS card_notify_trigger ON cards;`);
-  await knex.raw(`DROP FUNCTION IF EXISTS notify_card_event();`);
+  // CASCADE ensures rollback succeeds even if other objects reference the function.
+  await knex.raw(`DROP FUNCTION IF EXISTS notify_card_event() CASCADE;`);
 }

--- a/backend/migrations/009_card_notify_trigger.ts
+++ b/backend/migrations/009_card_notify_trigger.ts
@@ -1,0 +1,54 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.raw(`
+    CREATE OR REPLACE FUNCTION notify_card_event()
+    RETURNS trigger AS $$
+    DECLARE
+      payload TEXT;
+      event_type TEXT;
+      card_id TEXT;
+      user_id TEXT;
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        card_id    := OLD.id;
+        user_id    := OLD.user_id;
+        event_type := 'card.deleted';
+      ELSIF TG_OP = 'INSERT' THEN
+        card_id    := NEW.id;
+        user_id    := NEW.user_id;
+        event_type := 'card.created';
+      ELSIF TG_OP = 'UPDATE' THEN
+        card_id    := NEW.id;
+        user_id    := NEW.user_id;
+        IF OLD.stage_id IS DISTINCT FROM NEW.stage_id THEN
+          event_type := 'card.moved';
+        ELSE
+          event_type := 'card.updated';
+        END IF;
+      END IF;
+
+      payload := json_build_object(
+        'event',   event_type,
+        'card_id', card_id,
+        'user_id', user_id
+      )::TEXT;
+
+      PERFORM pg_notify('card_events', payload);
+
+      IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+
+  await knex.raw(`
+    CREATE TRIGGER card_notify_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON cards
+    FOR EACH ROW EXECUTE FUNCTION notify_card_event();
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`DROP TRIGGER IF EXISTS card_notify_trigger ON cards;`);
+  await knex.raw(`DROP FUNCTION IF EXISTS notify_card_event();`);
+}


### PR DESCRIPTION
## Summary
- Adds `backend/migrations/009_card_notify_trigger.ts`, a Knex migration that installs a PL/pgSQL trigger on the `cards` table
- The `notify_card_event()` function fires `pg_notify('card_events', payload)` on every INSERT, UPDATE, and DELETE, emitting `card.created`, `card.updated`, `card.moved`, or `card.deleted` events
- The `down()` function idempotently drops both the trigger and the function

## Changes
- New migration file `009_card_notify_trigger.ts` with `up()` and `down()` implementations
- `up()`: creates the PL/pgSQL function with `CREATE OR REPLACE FUNCTION`, then attaches `card_notify_trigger` via `CREATE TRIGGER AFTER INSERT OR UPDATE OR DELETE ON cards FOR EACH ROW`
- `down()`: drops trigger and function with `IF EXISTS` guards

## Test plan
- [ ] Run `npm run migrate` in the backend and verify no errors
- [ ] Connect to the database and confirm `notify_card_event` function exists (`\df notify_card_event`)
- [ ] Confirm `card_notify_trigger` exists on the `cards` table (`\d cards`)
- [ ] `LISTEN card_events;` in psql, then INSERT/UPDATE/DELETE a card row and verify the correct JSON payload arrives on the channel
- [ ] Run `npm run migrate:rollback` and verify the trigger and function are removed cleanly

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)