### PR TITLE
feat: useCardEvents hook for real-time SSE board updates (#63)

### DIFF
--- a/frontend/src/hooks/useCardEvents.ts
+++ b/frontend/src/hooks/useCardEvents.ts
@@ -3,7 +3,6 @@ import type { Card } from '@/types';
 import { cardsApi } from '@/services/api';
 
 interface UseCardEventsProps {
-  cards: Card[];
   setCards: React.Dispatch<React.SetStateAction<Card[]>>;
 }
 
@@ -12,7 +11,7 @@ export function useCardEvents({ setCards }: UseCardEventsProps): void {
     const token = localStorage.getItem('accessToken');
     if (!token) return;
 
-    const es = new EventSource(`/api/events?token=${token}`);
+    const es = new EventSource(`/api/events?token=${encodeURIComponent(token)}`);
 
     es.onmessage = async (event: MessageEvent) => {
       let payload: { event: string; cardId: string };
@@ -29,7 +28,11 @@ export function useCardEvents({ setCards }: UseCardEventsProps): void {
         case 'card.created': {
           try {
             const { card } = await cardsApi.getCard(cardId);
-            setCards((prev) => [...prev, card]);
+            // Guard against duplicates — the optimistic update from the local
+            // create handler may have already inserted this card into state.
+            setCards((prev) =>
+              prev.some((c) => c.id === card.id) ? prev : [...prev, card]
+            );
           } catch (err) {
             console.error('[useCardEvents] Failed to fetch created card:', err);
           }
@@ -63,12 +66,22 @@ export function useCardEvents({ setCards }: UseCardEventsProps): void {
 
     es.onerror = (err) => {
       console.error('[useCardEvents] SSE connection error:', err);
-      // EventSource auto-reconnects by default; no manual reconnect needed
+      // EventSource auto-reconnects by default. On reconnect it will reuse the
+      // same URL (with the original token). If the access token has been
+      // silently refreshed while the connection was open, close this instance
+      // so the parent can re-mount with the current token.
+      const currentToken = localStorage.getItem('accessToken');
+      if (currentToken && currentToken !== token) {
+        es.close();
+      }
     };
 
     return () => {
       es.close();
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // setCards is a stable useState dispatcher — safe to omit from deps.
+    // The effect intentionally runs once per mount so a single SSE connection
+    // is opened for the lifetime of the component.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 }

--- a/frontend/src/hooks/useCardEvents.ts
+++ b/frontend/src/hooks/useCardEvents.ts
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import type { Card } from '@/types';
+import { cardsApi } from '@/services/api';
+
+interface UseCardEventsProps {
+  cards: Card[];
+  setCards: React.Dispatch<React.SetStateAction<Card[]>>;
+}
+
+export function useCardEvents({ setCards }: UseCardEventsProps): void {
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    if (!token) return;
+
+    const es = new EventSource(`/api/events?token=${token}`);
+
+    es.onmessage = async (event: MessageEvent) => {
+      let payload: { event: string; cardId: string };
+      try {
+        payload = JSON.parse(event.data as string);
+      } catch (err) {
+        console.error('[useCardEvents] Failed to parse SSE payload:', err);
+        return;
+      }
+
+      const { event: eventName, cardId } = payload;
+
+      switch (eventName) {
+        case 'card.created': {
+          try {
+            const { card } = await cardsApi.getCard(cardId);
+            setCards((prev) => [...prev, card]);
+          } catch (err) {
+            console.error('[useCardEvents] Failed to fetch created card:', err);
+          }
+          break;
+        }
+
+        case 'card.updated':
+        case 'card.moved': {
+          try {
+            const { card } = await cardsApi.getCard(cardId);
+            setCards((prev) => prev.map((c) => (c.id === cardId ? card : c)));
+          } catch (err) {
+            console.error(`[useCardEvents] Failed to fetch ${eventName} card:`, err);
+          }
+          break;
+        }
+
+        case 'card.deleted': {
+          setCards((prev) => prev.filter((c) => c.id !== cardId));
+          break;
+        }
+
+        case 'connected':
+          // No-op — server sends this to confirm the SSE stream is open
+          break;
+
+        default:
+          break;
+      }
+    };
+
+    es.onerror = (err) => {
+      console.error('[useCardEvents] SSE connection error:', err);
+      // EventSource auto-reconnects by default; no manual reconnect needed
+    };
+
+    return () => {
+      es.close();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}


### PR DESCRIPTION
## Summary
- Implements the `useCardEvents` React hook that opens an `EventSource` connection to `/api/events?token=<jwt>` and surgically updates board card state on incoming server-sent events
- Handles `card.created`, `card.updated`, `card.moved`, `card.deleted`, and `connected` event types
- Returns early (no connection) when no access token is present in localStorage

## Changes
- `frontend/src/hooks/useCardEvents.ts` — new hook with single `useEffect` whose dependency array is `[]` so the SSE connection is opened once per mount and torn down on unmount
- `card.created` / `card.updated` / `card.moved` each call `cardsApi.getCard(id)` to get the fully transformed `Card` object before mutating state
- `card.deleted` filters without a network fetch
- `es.onerror` logs the error; browser-native auto-reconnect handles transient failures

## Test plan
- [ ] Hook connects to SSE stream after login and logs `connected` event (no-op)
- [ ] Creating a card in another tab/session causes it to appear on the board without a page refresh
- [ ] Updating a card in another session updates the card in place on the board
- [ ] Moving a card in another session reflects the correct column on the board
- [ ] Deleting a card in another session removes it from the board
- [ ] Logging out and back in re-opens the connection with the new token
- [ ] `npx tsc --noEmit` passes with no errors

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)