### PR TITLE
feat: wire useCardEvents into BoardPage for live kanban updates

### DIFF
--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -8,7 +8,7 @@ import CardDetail from '@/components/Card/CardDetail';
 import CardForm from '@/components/Card/CardForm';
 import StageForm from '@/components/Board/StageForm';
 import TodoPanel from '@/components/Todo/TodoPanel';
-import { useCardEvents } from '../hooks/useCardEvents';
+import { useCardEvents } from '@/hooks/useCardEvents';
 
 export default function BoardPage() {
   const [stages, setStages] = useState<Stage[]>([]);

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -8,6 +8,7 @@ import CardDetail from '@/components/Card/CardDetail';
 import CardForm from '@/components/Card/CardForm';
 import StageForm from '@/components/Board/StageForm';
 import TodoPanel from '@/components/Todo/TodoPanel';
+import { useCardEvents } from '../hooks/useCardEvents';
 
 export default function BoardPage() {
   const [stages, setStages] = useState<Stage[]>([]);
@@ -22,6 +23,8 @@ export default function BoardPage() {
   const [showStageForm, setShowStageForm] = useState(false);
   const [editingStage, setEditingStage] = useState<Stage | undefined>(undefined);
   const [deleteConfirmStage, setDeleteConfirmStage] = useState<Stage | null>(null);
+
+  useCardEvents({ setCards });
 
   const fetchData = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- Imports the `useCardEvents` hook into `BoardPage`
- Calls `useCardEvents({ setCards })` after state declarations so an SSE connection is established when the board mounts
- Completes the pub/sub pipeline: PostgreSQL trigger → pgSubscriber → SSE endpoint → `useCardEvents` hook → live board updates

## Changes
- `frontend/src/pages/BoardPage.tsx`: added import for `useCardEvents` and a single hook call after state declarations

## Test plan
- [ ] Open the kanban board in one browser tab; create/update/delete a card in another tab or via the API — the board in the first tab should update in real time without refreshing
- [ ] Verify no TypeScript errors: `cd frontend && npx tsc --noEmit`
- [ ] Confirm a single SSE connection is opened (Network tab → EventStream) and closes cleanly on unmount

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)