### PR TITLE
fix: fix SSE connection in production

### DIFF
--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -73,7 +73,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction): Promise
 
   pgSubscriber.registerClient(userId, res);
 
-  const heartbeat = setInterval(() => res.write(': heartbeat\n\n'), 30_000);
+  const heartbeat = setInterval(() => res.write(': heartbeat\n\n'), 25_000);
 
   req.on('close', () => {
     clearInterval(heartbeat);

--- a/frontend/src/hooks/useAutocomplete.ts
+++ b/frontend/src/hooks/useAutocomplete.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import trieWorker from '@/workers/trieWorker';
+import { API_BASE_URL } from '@/services/api';
 
 // Sequence counter shared across all instances so each query can be
 // matched back to the instance that issued it.
@@ -55,8 +56,7 @@ export function useAutocomplete(): UseAutocompleteResult {
     initializedRef.current = true;
     setIsLoading(true);
 
-    const baseUrl = import.meta.env.VITE_API_URL ?? '/api';
-    fetch(`${baseUrl}/autocomplete/words`)
+    fetch(`${API_BASE_URL}/autocomplete/words`)
       .then((res) => {
         if (!res.ok) {
           throw new Error(`Failed to fetch words: ${res.status}`);

--- a/frontend/src/hooks/useCardEvents.ts
+++ b/frontend/src/hooks/useCardEvents.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { Card } from '@/types';
-import { cardsApi } from '@/services/api';
+import { cardsApi, API_BASE_URL } from '@/services/api';
 
 interface UseCardEventsProps {
   setCards: React.Dispatch<React.SetStateAction<Card[]>>;
@@ -11,8 +11,7 @@ export function useCardEvents({ setCards }: UseCardEventsProps): void {
     const token = localStorage.getItem('accessToken');
     if (!token) return;
 
-    const baseUrl = import.meta.env.VITE_API_URL || '/api';
-    const es = new EventSource(`${baseUrl}/events?token=${encodeURIComponent(token)}`);
+    const es = new EventSource(`${API_BASE_URL}/events?token=${encodeURIComponent(token)}`);
 
     es.onmessage = async (event: MessageEvent) => {
       let payload: { event: string; cardId: string };

--- a/frontend/src/hooks/useCardEvents.ts
+++ b/frontend/src/hooks/useCardEvents.ts
@@ -11,7 +11,8 @@ export function useCardEvents({ setCards }: UseCardEventsProps): void {
     const token = localStorage.getItem('accessToken');
     if (!token) return;
 
-    const es = new EventSource(`/api/events?token=${encodeURIComponent(token)}`);
+    const baseUrl = import.meta.env.VITE_API_URL || '/api';
+    const es = new EventSource(`${baseUrl}/events?token=${encodeURIComponent(token)}`);
 
     es.onmessage = async (event: MessageEvent) => {
       let payload: { event: string; cardId: string };

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,8 +2,10 @@ import axios from 'axios';
 import type { Card, CardActivity, CardFilters, DashboardData, Stage, Todo, User } from '@/types';
 import { snakeToCamel, camelToSnake } from '@/utils/caseTransform';
 
+export const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: API_BASE_URL,
   headers: { 'Content-Type': 'application/json' },
 });
 
@@ -63,8 +65,7 @@ api.interceptors.response.use(
       }
 
       try {
-        const baseUrl = import.meta.env.VITE_API_URL || '/api';
-        const { data } = await axios.post(`${baseUrl}/auth/refresh`, { refreshToken });
+        const { data } = await axios.post(`${API_BASE_URL}/auth/refresh`, { refreshToken });
         const newToken = data.accessToken;
         localStorage.setItem('accessToken', newToken);
         if (data.refreshToken) {


### PR DESCRIPTION
## Summary
- Fixes `useCardEvents` to use `VITE_API_URL` env var instead of a hardcoded relative URL, so the `EventSource` connects to the correct backend host in production
- Reduces SSE heartbeat interval from 30s to 25s to reliably beat Render's proxy timeout

## Root Cause
Two silent failures in production:

**1. Wrong EventSource URL**
The hook used `/api/events` (relative). In dev, Vite proxies this to `localhost:3001`. In production there is no proxy — the browser hits the frontend's own origin, which has no SSE endpoint. The Axios instance already reads `VITE_API_URL` correctly; the `EventSource` now does the same.

**2. Heartbeat race with Render timeout**
Render's infrastructure drops connections with no response data after ~30 seconds. The heartbeat fired at exactly 30s — too close to the cutoff. Reduced to 25s.

## Changes
- `frontend/src/hooks/useCardEvents.ts` — use `import.meta.env.VITE_API_URL || '/api'` as base URL
- `backend/src/routes/events.ts` — heartbeat interval `30_000` → `25_000`

## Test plan
- [ ] Confirm `VITE_API_URL` is set in the frontend's Render/static-site env vars pointing to the backend URL
- [ ] Deploy and open two tabs — create/move/delete a card in one tab, confirm it updates in the other
- [ ] Check Network tab: `GET <backend>/api/events` shows as open EventStream

🤖 Generated with [Claude Code](https://claude.com/claude-code)