### PR TITLE
fix: add SSL to pgSubscriber pg.Client for Render databases

### DIFF
--- a/backend/src/services/pgSubscriber.ts
+++ b/backend/src/services/pgSubscriber.ts
@@ -50,7 +50,12 @@ async function connect(retryDelay = BASE_RETRY_DELAY_MS): Promise<void> {
     throw new Error('DATABASE_URL environment variable is required for pgSubscriber');
   }
 
-  const client = new Client({ connectionString });
+  const requiresSsl =
+    connectionString.includes('.render.com') || connectionString.includes('.neon.tech');
+  const client = new Client({
+    connectionString,
+    ssl: requiresSsl ? { rejectUnauthorized: false } : false,
+  });
 
   const scheduleReconnect = () => {
     client.end().catch(() => {


### PR DESCRIPTION
## Root Cause

`pgSubscriber` creates a dedicated `pg.Client` outside of Knex to hold the `LISTEN card_events` connection. This client was initialized with only `{ connectionString }` — no SSL config.

Render's PostgreSQL requires SSL. The connection was silently rejected on every attempt, causing `pgSubscriber` to loop in exponential backoff forever without ever calling `LISTEN`. The SSE connection to the browser was open and healthy, but nothing was publishing to it because no DB notifications were being received.

Knex already handles this correctly in `knexfile.prod.cjs`:
```js
const requiresSsl = dbUrl.includes('.render.com') || dbUrl.includes('.neon.tech');
ssl: requiresSsl ? { rejectUnauthorized: false } : false,
```

`pgSubscriber` now uses the identical logic.

## Changes
- `backend/src/services/pgSubscriber.ts` — detect Render/Neon hosts in `DATABASE_URL` and pass `ssl: { rejectUnauthorized: false }` to `pg.Client`

## Test plan
- [ ] Deploy to Render
- [ ] Open two browser tabs on the board
- [ ] Create / move / delete a card in tab 1 → updates appear in tab 2 without refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)