### PR TITLE
fix: flush SSE writes past compression middleware buffering

### DIFF
--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -61,6 +61,11 @@ router.get('/', async (req: Request, res: Response, next: NextFunction): Promise
     return;
   }
 
+  // Disable compression for this response — the compression middleware buffers
+  // writes into a gzip stream, preventing heartbeats from reaching the proxy.
+  // Clearing accept-encoding tells the middleware to skip compression here.
+  req.headers['accept-encoding'] = 'identity';
+
   // Set SSE headers
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
@@ -68,12 +73,19 @@ router.get('/', async (req: Request, res: Response, next: NextFunction): Promise
   res.setHeader('X-Accel-Buffering', 'no'); // disables nginx buffering
   res.flushHeaders();
 
+  // Helper: write and immediately flush past any remaining middleware buffers
+  const send = (chunk: string) => {
+    res.write(chunk);
+    // compression middleware adds res.flush(); call it if present
+    (res as unknown as { flush?: () => void }).flush?.();
+  };
+
   // Send initial connected event
-  res.write('data: {"event":"connected"}\n\n');
+  send('data: {"event":"connected"}\n\n');
 
   pgSubscriber.registerClient(userId, res);
 
-  const heartbeat = setInterval(() => res.write(': heartbeat\n\n'), 25_000);
+  const heartbeat = setInterval(() => send(': heartbeat\n\n'), 25_000);
 
   req.on('close', () => {
     clearInterval(heartbeat);

--- a/backend/src/services/pgSubscriber.ts
+++ b/backend/src/services/pgSubscriber.ts
@@ -32,6 +32,8 @@ function notifyUser(userId: string, data: Record<string, unknown>): void {
       // res.write() returning false signals backpressure, not a broken connection —
       // only a thrown exception indicates the socket is truly gone.
       res.write(`data: ${JSON.stringify(data)}\n\n`);
+      // Flush past any remaining middleware buffers (e.g. compression)
+      (res as unknown as { flush?: () => void }).flush?.();
     } catch {
       dead.push(res);
     }


### PR DESCRIPTION
## Root Cause

The `compression` middleware (gzip/brotli) wraps `res.write()` in a compressed stream that internally buffers output before flushing. This meant SSE heartbeats and event payloads were sitting in the compression buffer rather than being sent over the wire immediately.

Render's proxy saw no activity on the connection and dropped it every 30–80 seconds. The browser's `EventSource` auto-reconnected, causing the repeated connect/disconnect loop visible in logs.

`X-Accel-Buffering: no` only disables nginx-level buffering — it has no effect on Express's own compression stream.

## Fix

Two layers of defense in `backend/src/routes/events.ts` and `backend/src/services/pgSubscriber.ts`:

1. **Disable compression for SSE responses** — set `req.headers['accept-encoding'] = 'identity'` before `flushHeaders()`. This tells the compression middleware to skip gzip/brotli for this response entirely.

2. **Explicit flush after every write** — call `res.flush()` (added to the Response object by the compression middleware) after each `res.write()`. Even if compression somehow activates, the flush forces bytes out immediately.

## What this fixes
- SSE connections no longer drop every 30–80s
- Heartbeats reliably reach Render's proxy, keeping the connection alive
- Event payloads (card notifications) are delivered immediately instead of being buffered

## Still needed from user
Confirm the `pgSubscriber connected and listening on card_events` log appears at the top of the current deploy's Render logs — this verifies the DB trigger + LISTEN side is working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)