### PR TITLE
fix: compile migration 009 into dist-migrations and fix build process

### DIFF
--- a/backend/dist-migrations/008_create_todo_items.js
+++ b/backend/dist-migrations/008_create_todo_items.js
@@ -1,0 +1,39 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.up = up;
+exports.down = down;
+async function up(knex) {
+    await knex.raw(`
+    DO $$ BEGIN
+      CREATE TYPE todo_priority AS ENUM ('low', 'medium', 'high', 'urgent');
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+    await knex.raw(`
+    DO $$ BEGIN
+      CREATE TYPE todo_status AS ENUM ('active', 'completed');
+    EXCEPTION
+      WHEN duplicate_object THEN null;
+    END $$;
+  `);
+    await knex.schema.createTable('todo_items', (table) => {
+        table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+        table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+        table.uuid('card_id').nullable().references('id').inTable('cards').onDelete('SET NULL');
+        table.text('description').notNullable();
+        table.specificType('priority', 'todo_priority').notNullable().defaultTo('medium');
+        table.specificType('status', 'todo_status').notNullable().defaultTo('active');
+        table.integer('position').nullable();
+        table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+        table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+        // Indexes for common query patterns
+        table.index(['user_id', 'status']);
+        table.index('card_id');
+    });
+}
+async function down(knex) {
+    await knex.schema.dropTableIfExists('todo_items');
+    await knex.raw('DROP TYPE IF EXISTS todo_priority');
+    await knex.raw('DROP TYPE IF EXISTS todo_status');
+}

--- a/backend/dist-migrations/009_card_notify_trigger.js
+++ b/backend/dist-migrations/009_card_notify_trigger.js
@@ -1,0 +1,59 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.up = up;
+exports.down = down;
+async function up(knex) {
+    await knex.raw(`
+    CREATE OR REPLACE FUNCTION notify_card_event()
+    RETURNS trigger AS $$
+    DECLARE
+      payload TEXT;
+      event_type TEXT;
+      card_id TEXT;
+      user_id TEXT;
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        card_id    := OLD.id;
+        user_id    := OLD.user_id;
+        event_type := 'card.deleted';
+      ELSIF TG_OP = 'INSERT' THEN
+        card_id    := NEW.id;
+        user_id    := NEW.user_id;
+        event_type := 'card.created';
+      ELSIF TG_OP = 'UPDATE' THEN
+        card_id    := NEW.id;
+        user_id    := NEW.user_id;
+        IF OLD.stage_id IS DISTINCT FROM NEW.stage_id THEN
+          event_type := 'card.moved';
+        ELSE
+          event_type := 'card.updated';
+        END IF;
+      END IF;
+
+      -- pg_notify enforces an 8000-byte payload limit; this payload is
+      -- intentionally minimal (event, card_id, user_id) to stay well under it.
+      payload := json_build_object(
+        'event',   event_type,
+        'card_id', card_id,
+        'user_id', user_id
+      )::TEXT;
+
+      PERFORM pg_notify('card_events', payload);
+
+      IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+    // Drop before re-creating so up() is idempotent if re-run after a partial failure.
+    await knex.raw(`DROP TRIGGER IF EXISTS card_notify_trigger ON cards;`);
+    await knex.raw(`
+    CREATE TRIGGER card_notify_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON cards
+    FOR EACH ROW EXECUTE FUNCTION notify_card_event();
+  `);
+}
+async function down(knex) {
+    await knex.raw(`DROP TRIGGER IF EXISTS card_notify_trigger ON cards;`);
+    // CASCADE ensures rollback succeeds even if other objects reference the function.
+    await knex.raw(`DROP FUNCTION IF EXISTS notify_card_event() CASCADE;`);
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "dist/server.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.migrations.json",
     "start": "node dist/server.js",
     "start:prod": "npm run migrate:prod && node dist/server.js",
     "migrate": "knex migrate:latest --knexfile knexfile.ts",

--- a/backend/tsconfig.migrations.json
+++ b/backend/tsconfig.migrations.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-migrations",
+    "rootDir": "./migrations",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["migrations/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Root Cause

The PostgreSQL trigger was never installed in production.

`tsconfig.json` has `"rootDir": "./src"` — `tsc` only compiles `src/` and ignores `migrations/`. The `dist-migrations/` directory is committed to the repo as pre-compiled JS files, but `008` and `009` were never compiled and committed. So `knex migrate:prod` scanned `dist-migrations/`, found no new files, and reported `Already up to date` — silently skipping the trigger installation every deploy.

Confirmed via direct DB query: the `card_notify_trigger` did not exist on the `cards` table in production.

## Changes

- `backend/dist-migrations/008_create_todo_items.js` — compiled and committed
- `backend/dist-migrations/009_card_notify_trigger.js` — compiled and committed (installs the trigger on next deploy)
- `backend/tsconfig.migrations.json` — new tsconfig that compiles `migrations/` → `dist-migrations/`
- `backend/package.json` — build script updated to `tsc && tsc -p tsconfig.migrations.json` so future migrations are always compiled automatically

## Test plan
- [ ] Merge and confirm Render deploy runs migration 009 (look for it in `knex_migrations` table)
- [ ] Verify `card_notify_trigger` exists: `SELECT trigger_name FROM information_schema.triggers WHERE event_object_table = 'cards'`
- [ ] Open two tabs, move a card in one — confirm it updates in the other

🤖 Generated with [Claude Code](https://claude.com/claude-code)