### PR TITLE
fix: use direct Neon connection in pgSubscriber for LISTEN/NOTIFY

### DIFF
--- a/backend/src/services/pgSubscriber.ts
+++ b/backend/src/services/pgSubscriber.ts
@@ -52,10 +52,16 @@ async function connect(retryDelay = BASE_RETRY_DELAY_MS): Promise<void> {
     throw new Error('DATABASE_URL environment variable is required for pgSubscriber');
   }
 
+  // Neon routes pooled connections through PgBouncer (transaction mode), which
+  // silently accepts LISTEN but never delivers NOTIFY events. Strip '-pooler'
+  // from the hostname to force a direct connection for this dedicated listener.
+  const directConnectionString = connectionString.replace('-pooler.', '.');
+
   const requiresSsl =
-    connectionString.includes('.render.com') || connectionString.includes('.neon.tech');
+    directConnectionString.includes('.render.com') ||
+    directConnectionString.includes('.neon.tech');
   const client = new Client({
-    connectionString,
+    connectionString: directConnectionString,
     ssl: requiresSsl ? { rejectUnauthorized: false } : false,
   });
 


### PR DESCRIPTION
## Root Cause

Neon's connection pooler uses PgBouncer in **transaction mode**. In this mode, `LISTEN` is silently accepted by the pooler but NOTIFY events are never delivered — each command may be routed to a different backend connection, so the LISTEN state established on one connection is never seen by the notification dispatcher.

Confirmed via diagnostic: manually sending `pg_notify('card_events', ...)` directly to the DB produced no event in the browser's SSE stream, even though `pgSubscriber` had logged `"connected and listening on card_events"`.

The pooler URL is identifiable by `-pooler.` in the hostname:
```
ep-bitter-grass-amvxxm1d-pooler.c-5.us-east-1.aws.neon.tech  ← pooler
ep-bitter-grass-amvxxm1d.c-5.us-east-1.aws.neon.tech          ← direct
```

## Fix

One line in `pgSubscriber.ts` — strip `-pooler.` from the `DATABASE_URL` hostname before connecting. The dedicated `pg.Client` now connects directly to Neon, bypassing PgBouncer. Knex and all other DB operations continue using the pooler URL unchanged.

## Test plan
- [ ] Deploy and check Render logs for `"pgSubscriber connected and listening on card_events"`
- [ ] Open two browser tabs on the board
- [ ] Move a card in tab 1 → appears in correct column in tab 2 without refresh
- [ ] Create/delete a card in tab 1 → tab 2 updates instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)