### PR TITLE
fix: read card_id (snake_case) from SSE payload

### DIFF
--- a/frontend/src/hooks/useCardEvents.ts
+++ b/frontend/src/hooks/useCardEvents.ts
@@ -14,7 +14,7 @@ export function useCardEvents({ setCards }: UseCardEventsProps): void {
     const es = new EventSource(`${API_BASE_URL}/events?token=${encodeURIComponent(token)}`);
 
     es.onmessage = async (event: MessageEvent) => {
-      let payload: { event: string; cardId: string };
+      let payload: { event: string; card_id: string };
       try {
         payload = JSON.parse(event.data as string);
       } catch (err) {
@@ -22,7 +22,8 @@ export function useCardEvents({ setCards }: UseCardEventsProps): void {
         return;
       }
 
-      const { event: eventName, cardId } = payload;
+      // Payload uses snake_case from the PostgreSQL trigger — not transformed by the API layer
+      const { event: eventName, card_id: cardId } = payload;
 
       switch (eventName) {
         case 'card.created': {


### PR DESCRIPTION
## Root Cause

The PostgreSQL trigger emits raw JSON with snake_case keys:
```json
{"event": "card.updated", "card_id": "...", "user_id": "..."}
```

The frontend hook typed the payload as `{ event: string; cardId: string }` and destructured `cardId` — which was always `undefined` since the actual key is `card_id`. Every card event triggered a fetch to `/api/cards/undefined` → 500 error.

The API layer's snake→camelCase transformation only applies to REST responses. SSE payloads come directly from the trigger and are never transformed.

## Fix

One-line change in `useCardEvents.ts`:
```typescript
// before
let payload: { event: string; cardId: string };
const { event: eventName, cardId } = payload;

// after  
let payload: { event: string; card_id: string };
const { event: eventName, card_id: cardId } = payload;
```

## Test plan
- [ ] Move a card → second tab updates to correct column instantly
- [ ] Edit a card → second tab reflects the change
- [ ] Delete a card → second tab removes it immediately
- [ ] No more `/api/cards/undefined` 500 errors in Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)