### PR TITLE
feat: add role title autocomplete to card creation form

### DIFF
--- a/frontend/src/components/AutocompleteDropdown.tsx
+++ b/frontend/src/components/AutocompleteDropdown.tsx
@@ -4,6 +4,7 @@ import { Loader2 } from 'lucide-react';
 interface AutocompleteDropdownProps {
   suggestions: string[];
   isLoading: boolean;
+  highlightedIndex?: number;
   onSelect: (word: string) => void;
   onDismiss: () => void;
 }
@@ -11,6 +12,7 @@ interface AutocompleteDropdownProps {
 export default function AutocompleteDropdown({
   suggestions,
   isLoading,
+  highlightedIndex = -1,
   onSelect,
   onDismiss,
 }: AutocompleteDropdownProps) {
@@ -57,22 +59,29 @@ export default function AutocompleteDropdown({
             Loading…
           </li>
         ) : (
-          visibleSuggestions.map((word) => (
-            <li key={word} role="option" aria-selected={false}>
-              <button
-                type="button"
-                dir="auto"
-                className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-primary-50 hover:text-primary-700 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:bg-primary-50 focus:text-primary-700"
-                onMouseDown={(e) => {
-                  // Prevent the parent input from losing focus before click registers
-                  e.preventDefault();
-                }}
-                onClick={() => onSelect(word)}
-              >
-                {word}
-              </button>
-            </li>
-          ))
+          visibleSuggestions.map((word, idx) => {
+            const isHighlighted = idx === highlightedIndex;
+            return (
+              <li key={word} role="option" aria-selected={isHighlighted}>
+                <button
+                  type="button"
+                  dir="auto"
+                  className={`w-full px-3 py-2 text-left text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500/20 ${
+                    isHighlighted
+                      ? 'bg-primary-50 text-primary-700'
+                      : 'text-gray-700 hover:bg-primary-50 hover:text-primary-700 focus:bg-primary-50 focus:text-primary-700'
+                  }`}
+                  onMouseDown={(e) => {
+                    // Prevent the parent input from losing focus before click registers
+                    e.preventDefault();
+                  }}
+                  onClick={() => onSelect(word)}
+                >
+                  {word}
+                </button>
+              </li>
+            );
+          })
         )}
       </ul>
     </div>

--- a/frontend/src/components/Card/CardForm.tsx
+++ b/frontend/src/components/Card/CardForm.tsx
@@ -3,6 +3,8 @@ import { cardsApi } from '@/services/api';
 import type { Card, Stage } from '@/types';
 import { X, Plus, ChevronDown } from 'lucide-react';
 import { useAutoResize } from '@/hooks/useAutoResize';
+import { useStringAutocomplete } from '@/hooks/useStringAutocomplete';
+import AutocompleteDropdown from '@/components/AutocompleteDropdown';
 
 function toLocalDateStr(date: Date): string {
   const year = date.getFullYear();
@@ -80,13 +82,15 @@ function clearDraft(): void {
 interface CardFormProps {
   stageId: string;
   stages: Stage[];
+  roleTitleSuggestions?: string[];
   onClose: () => void;
   onCreated: (card: Card) => void;
 }
 
-export default function CardForm({ stageId, stages, onClose, onCreated }: CardFormProps) {
+export default function CardForm({ stageId, stages, roleTitleSuggestions = [], onClose, onCreated }: CardFormProps) {
   const [companyName, setCompanyName] = useState('');
   const [roleTitle, setRoleTitle] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [applicationUrl, setApplicationUrl] = useState('');
   const [careersUrl, setCareersUrl] = useState('');
   const [source, setSource] = useState('');
@@ -114,6 +118,9 @@ export default function CardForm({ stageId, stages, onClose, onCreated }: CardFo
   const [error, setError] = useState('');
   const [showDraftBanner, setShowDraftBanner] = useState(false);
   const notesRef = useAutoResize(notes);
+
+  const roleTitleMatches = useStringAutocomplete(roleTitleSuggestions, roleTitle);
+  const showRoleTitleDropdown = roleTitle.length >= 1 && roleTitleMatches.length > 0;
 
   useEffect(() => {
     const draft = loadDraft();
@@ -274,7 +281,7 @@ export default function CardForm({ stageId, stages, onClose, onCreated }: CardFo
                 placeholder="Acme Inc."
               />
             </div>
-            <div>
+            <div className="relative">
               <label className="label-text">
                 Role Title <span className="text-red-500">*</span>
               </label>
@@ -282,10 +289,41 @@ export default function CardForm({ stageId, stages, onClose, onCreated }: CardFo
                 type="text"
                 required
                 value={roleTitle}
-                onChange={(e) => setRoleTitle(e.target.value)}
+                onChange={(e) => {
+                  setRoleTitle(e.target.value);
+                  setHighlightedIndex(-1);
+                }}
+                onKeyDown={(e) => {
+                  if (!showRoleTitleDropdown) return;
+                  if (e.key === 'ArrowDown') {
+                    e.preventDefault();
+                    setHighlightedIndex((i) => Math.min(i + 1, roleTitleMatches.length - 1));
+                  } else if (e.key === 'ArrowUp') {
+                    e.preventDefault();
+                    setHighlightedIndex((i) => Math.max(i - 1, 0));
+                  } else if (e.key === 'Enter' && highlightedIndex >= 0) {
+                    e.preventDefault();
+                    setRoleTitle(roleTitleMatches[highlightedIndex]);
+                    setHighlightedIndex(-1);
+                  } else if (e.key === 'Escape') {
+                    setHighlightedIndex(-1);
+                  }
+                }}
                 className="input-field"
                 placeholder="Senior Frontend Engineer"
+                autoComplete="off"
               />
+              {showRoleTitleDropdown && (
+                <AutocompleteDropdown
+                  suggestions={roleTitleMatches}
+                  isLoading={false}
+                  onSelect={(value) => {
+                    setRoleTitle(value);
+                    setHighlightedIndex(-1);
+                  }}
+                  onDismiss={() => setHighlightedIndex(-1)}
+                />
+              )}
             </div>
           </div>
 

--- a/frontend/src/components/Card/CardForm.tsx
+++ b/frontend/src/components/Card/CardForm.tsx
@@ -317,6 +317,7 @@ export default function CardForm({ stageId, stages, roleTitleSuggestions = [], o
                 <AutocompleteDropdown
                   suggestions={roleTitleMatches}
                   isLoading={false}
+                  highlightedIndex={highlightedIndex}
                   onSelect={(value) => {
                     setRoleTitle(value);
                     setHighlightedIndex(-1);

--- a/frontend/src/hooks/useStringAutocomplete.ts
+++ b/frontend/src/hooks/useStringAutocomplete.ts
@@ -1,0 +1,17 @@
+/**
+ * Generic autocomplete hook for plain string arrays.
+ * Returns up to 5 candidates whose lowercased value starts with the lowercased query.
+ * Returns an empty array when query is empty.
+ */
+export function useStringAutocomplete(candidates: string[], query: string): string[] {
+  if (query === '') return [];
+  const lower = query.toLowerCase();
+  const results: string[] = [];
+  for (const c of candidates) {
+    if (c.toLowerCase().startsWith(lower)) {
+      results.push(c);
+      if (results.length === 5) break;
+    }
+  }
+  return results;
+}

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -191,6 +191,7 @@ export default function BoardPage() {
         <CardForm
           stageId={createStageId}
           stages={stages}
+          roleTitleSuggestions={Array.from(new Set(cards.map((c) => c.roleTitle).filter(Boolean))).sort()}
           onClose={() => setShowCreateForm(false)}
           onCreated={handleCardCreated}
         />

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { stagesApi, cardsApi } from '@/services/api';
 import type { Stage, Card, CardFilters } from '@/types';
 import Board from '@/components/Board/Board';
@@ -151,6 +151,11 @@ export default function BoardPage() {
     }
   };
 
+  const roleTitleSuggestions = useMemo(
+    () => Array.from(new Set(cards.map((c) => c.roleTitle))).sort(),
+    [cards],
+  );
+
   const stageCardCount = deleteConfirmStage
     ? cards.filter((c) => c.stageId === deleteConfirmStage.id).length
     : 0;
@@ -191,7 +196,7 @@ export default function BoardPage() {
         <CardForm
           stageId={createStageId}
           stages={stages}
-          roleTitleSuggestions={Array.from(new Set(cards.map((c) => c.roleTitle).filter(Boolean))).sort()}
+          roleTitleSuggestions={roleTitleSuggestions}
           onClose={() => setShowCreateForm(false)}
           onCreated={handleCardCreated}
         />


### PR DESCRIPTION
## Summary
- Adds a generic `useStringAutocomplete` hook (case-insensitive prefix match, up to 5 results)
- Derives `roleTitleSuggestions` from the already-loaded `cards` state in `BoardPage` and passes it to `CardForm`
- Renders the existing `AutocompleteDropdown` below the Role Title input with keyboard navigation (ArrowUp/Down, Enter, Escape) and click-to-select

## Changes
- **New:** `frontend/src/hooks/useStringAutocomplete.ts` — pure, reusable hook, no external deps
- **Modified:** `frontend/src/pages/BoardPage.tsx` — derive deduplicated, sorted role title list from cards; pass as prop
- **Modified:** `frontend/src/components/Card/CardForm.tsx` — accept `roleTitleSuggestions` prop, add `highlightedIndex` state, keyboard handling, and dropdown rendering

## Test plan
- [ ] Open the card creation form with at least one existing card that has a role title
- [ ] Type the first letter of that role title — the dropdown should appear with matching suggestions
- [ ] Use ArrowDown/ArrowUp to navigate; Enter should fill the field and close the dropdown
- [ ] Press Escape — dropdown should close without changing the field value
- [ ] Click a suggestion — field should be filled and dropdown should close
- [ ] Verify no dropdown appears when the role title field is empty
- [ ] Verify no dropdown appears when there are no matching suggestions
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)