### PR TITLE
feat: persistent real-time notification center

### DIFF
--- a/backend/migrations/011_create_notifications.ts
+++ b/backend/migrations/011_create_notifications.ts
@@ -1,0 +1,45 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('notifications', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.string('title', 255).notNullable();
+    table.text('body').notNullable();
+    table.jsonb('metadata');
+    table.timestamp('read_at', { useTz: true });
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+  });
+
+  await knex.raw(`
+    CREATE OR REPLACE FUNCTION notify_notification_event()
+    RETURNS trigger AS $$
+    DECLARE
+      payload TEXT;
+    BEGIN
+      payload := json_build_object(
+        'user_id',         NEW.user_id,
+        'notification_id', NEW.id
+      )::TEXT;
+
+      PERFORM pg_notify('notification_events', payload);
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+
+  await knex.raw(`DROP TRIGGER IF EXISTS notification_notify_trigger ON notifications;`);
+
+  await knex.raw(`
+    CREATE TRIGGER notification_notify_trigger
+    AFTER INSERT ON notifications
+    FOR EACH ROW EXECUTE FUNCTION notify_notification_event();
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.raw(`DROP TRIGGER IF EXISTS notification_notify_trigger ON notifications;`);
+  await knex.raw(`DROP FUNCTION IF EXISTS notify_notification_event() CASCADE;`);
+  await knex.schema.dropTableIfExists('notifications');
+}

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -81,7 +81,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction): Promise
   };
 
   // Send initial connected event
-  send('data: {"event":"connected"}\n\n');
+  send('event: message\ndata: {"event":"connected"}\n\n');
 
   pgSubscriber.registerClient(userId, res);
 

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -8,6 +8,7 @@ import remindersRouter from './reminders';
 import todosRouter from './todos';
 import autocompleteRouter from './autocomplete';
 import eventsRouter from './events';
+import notificationsRouter from './notifications';
 
 const router = Router();
 
@@ -25,5 +26,6 @@ router.use('/reminders', remindersRouter);
 router.use('/todos', todosRouter);
 router.use('/autocomplete', autocompleteRouter);
 router.use('/events', eventsRouter);
+router.use('/notifications', notificationsRouter);
 
 export default router;

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -1,0 +1,54 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { param } from 'express-validator';
+import { authenticate } from '../middleware/auth';
+import { validate } from '../middleware/validate';
+import { notificationService } from '../services/notificationService';
+
+const router = Router();
+
+// GET /api/notifications
+router.get(
+  '/',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const notifications = await notificationService.list(req.user!.id);
+      res.json({ data: notifications });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+// PATCH /api/notifications/read-all — must come before /:id to avoid route collision
+router.patch(
+  '/read-all',
+  authenticate,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await notificationService.markAllRead(req.user!.id);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+// PATCH /api/notifications/:id/read
+router.patch(
+  '/:id/read',
+  authenticate,
+  validate([
+    param('id').isUUID().withMessage('id must be a valid UUID'),
+  ]),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      await notificationService.markRead(req.params.id, req.user!.id);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+export default router;

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -1,0 +1,49 @@
+import db from '../config/database';
+
+export interface Notification {
+  id: string;
+  user_id: string;
+  title: string;
+  body: string;
+  metadata: Record<string, unknown> | null;
+  read_at: string | null;
+  created_at: string;
+}
+
+export const notificationService = {
+  async create(
+    userId: string,
+    title: string,
+    body: string,
+    metadata?: Record<string, unknown>
+  ): Promise<Notification> {
+    const [notification] = await db('notifications')
+      .insert({
+        user_id: userId,
+        title,
+        body,
+        metadata: metadata ?? null,
+      })
+      .returning('*');
+    return notification;
+  },
+
+  async list(userId: string): Promise<Notification[]> {
+    return db('notifications')
+      .where({ user_id: userId })
+      .orderBy('created_at', 'desc');
+  },
+
+  async markRead(notificationId: string, userId: string): Promise<void> {
+    await db('notifications')
+      .where({ id: notificationId, user_id: userId })
+      .update({ read_at: db.fn.now() });
+  },
+
+  async markAllRead(userId: string): Promise<void> {
+    await db('notifications')
+      .where({ user_id: userId })
+      .whereNull('read_at')
+      .update({ read_at: db.fn.now() });
+  },
+};

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -1,4 +1,5 @@
 import db from '../config/database';
+import { AppError } from '../middleware/errorHandler';
 
 export interface Notification {
   id: string;
@@ -35,6 +36,12 @@ export const notificationService = {
   },
 
   async markRead(notificationId: string, userId: string): Promise<void> {
+    const existing = await db('notifications')
+      .where({ id: notificationId, user_id: userId })
+      .first();
+    if (!existing) {
+      throw new AppError('Notification not found', 404, 'ERR_NOT_FOUND');
+    }
     await db('notifications')
       .where({ id: notificationId, user_id: userId })
       .update({ read_at: db.fn.now() });

--- a/backend/src/services/pgSubscriber.ts
+++ b/backend/src/services/pgSubscriber.ts
@@ -23,7 +23,7 @@ function removeClient(userId: string, res: Response): void {
   }
 }
 
-function notifyUser(userId: string, data: Record<string, unknown>): void {
+function writeToUser(userId: string, sseEvent: string, data: Record<string, unknown>): void {
   const clients = sseClients.get(userId);
   if (!clients) return;
   const dead: Response[] = [];
@@ -31,7 +31,7 @@ function notifyUser(userId: string, data: Record<string, unknown>): void {
     try {
       // res.write() returning false signals backpressure, not a broken connection —
       // only a thrown exception indicates the socket is truly gone.
-      res.write(`data: ${JSON.stringify(data)}\n\n`);
+      res.write(`event: ${sseEvent}\ndata: ${JSON.stringify(data)}\n\n`);
       // Flush past any remaining middleware buffers (e.g. compression)
       (res as unknown as { flush?: () => void }).flush?.();
     } catch {
@@ -77,7 +77,8 @@ async function connect(retryDelay = BASE_RETRY_DELAY_MS): Promise<void> {
   try {
     await client.connect();
     await client.query('LISTEN card_events');
-    logger.info('pgSubscriber connected and listening on card_events');
+    await client.query('LISTEN notification_events');
+    logger.info('pgSubscriber connected and listening on card_events, notification_events');
   } catch (err) {
     logger.error('pgSubscriber failed to connect', { error: (err as Error).message });
     scheduleReconnect();
@@ -88,7 +89,14 @@ async function connect(retryDelay = BASE_RETRY_DELAY_MS): Promise<void> {
     try {
       const payload = JSON.parse(msg.payload ?? '') as Record<string, unknown>;
       const userId = payload.user_id as string;
-      notifyUser(userId, payload);
+
+      if (msg.channel === 'notification_events') {
+        writeToUser(userId, 'notification', {
+          notification_id: payload.notification_id,
+        });
+      } else {
+        writeToUser(userId, 'message', payload);
+      }
     } catch (err) {
       logger.error('pgSubscriber failed to parse notification payload', {
         error: (err as Error).message,

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { Briefcase, LayoutDashboard, Columns3, CheckSquare, LogOut, User } from 'lucide-react';
 import { useState, useRef, useEffect } from 'react';
+import NotificationBell from './NotificationBell';
 
 export default function Navbar() {
   const { user, logout } = useAuth();
@@ -54,36 +55,39 @@ export default function Navbar() {
         </div>
       </div>
 
-      {/* Right: User menu */}
-      <div className="relative" ref={menuRef}>
-        <button
-          onClick={() => setShowMenu(!showMenu)}
-          className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 transition"
-        >
-          <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary-100 text-primary-700">
-            <User size={14} />
-          </div>
-          <span className="hidden sm:inline font-medium">{user?.name}</span>
-        </button>
-
-        {showMenu && (
-          <div className="absolute right-0 top-full mt-1 w-48 rounded-lg border border-gray-200 bg-white py-1 shadow-lg z-50">
-            <div className="px-3 py-2 border-b border-gray-100">
-              <p className="text-sm font-medium text-gray-900">{user?.name}</p>
-              <p className="text-xs text-gray-500 truncate">{user?.email}</p>
+      {/* Right: Notification bell + User menu */}
+      <div className="flex items-center gap-2">
+        <NotificationBell />
+        <div className="relative" ref={menuRef}>
+          <button
+            onClick={() => setShowMenu(!showMenu)}
+            className="flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 transition"
+          >
+            <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary-100 text-primary-700">
+              <User size={14} />
             </div>
-            <button
-              onClick={() => {
-                setShowMenu(false);
-                logout();
-              }}
-              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50"
-            >
-              <LogOut size={14} />
-              Sign out
-            </button>
-          </div>
-        )}
+            <span className="hidden sm:inline font-medium">{user?.name}</span>
+          </button>
+
+          {showMenu && (
+            <div className="absolute right-0 top-full mt-1 w-48 rounded-lg border border-gray-200 bg-white py-1 shadow-lg z-50">
+              <div className="px-3 py-2 border-b border-gray-100">
+                <p className="text-sm font-medium text-gray-900">{user?.name}</p>
+                <p className="text-xs text-gray-500 truncate">{user?.email}</p>
+              </div>
+              <button
+                onClick={() => {
+                  setShowMenu(false);
+                  logout();
+                }}
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50"
+              >
+                <LogOut size={14} />
+                Sign out
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </nav>
   );

--- a/frontend/src/components/Layout/NotificationBell.tsx
+++ b/frontend/src/components/Layout/NotificationBell.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { Bell } from 'lucide-react';
+import { useNotifications } from '@/hooks/useNotifications';
+import NotificationPanel from './NotificationPanel';
+
+export default function NotificationBell() {
+  const { notifications, unreadCount, markRead, markAllRead } = useNotifications();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className="relative flex items-center justify-center rounded-lg p-1.5 text-gray-600 hover:bg-gray-100 transition"
+        aria-label="Notifications"
+      >
+        <Bell size={18} />
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-red-500 px-0.5 text-[10px] font-bold text-white leading-none">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <NotificationPanel
+          notifications={notifications}
+          unreadCount={unreadCount}
+          onRead={markRead}
+          onReadAll={markAllRead}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Layout/NotificationBell.tsx
+++ b/frontend/src/components/Layout/NotificationBell.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { Bell } from 'lucide-react';
 import { useNotifications } from '@/hooks/useNotifications';
 import NotificationPanel from './NotificationPanel';
@@ -6,10 +6,12 @@ import NotificationPanel from './NotificationPanel';
 export default function NotificationBell() {
   const { notifications, unreadCount, markRead, markAllRead } = useNotifications();
   const [open, setOpen] = useState(false);
+  const bellRef = useRef<HTMLButtonElement>(null);
 
   return (
     <div className="relative">
       <button
+        ref={bellRef}
         onClick={() => setOpen((prev) => !prev)}
         className="relative flex items-center justify-center rounded-lg p-1.5 text-gray-600 hover:bg-gray-100 transition"
         aria-label="Notifications"
@@ -29,6 +31,7 @@ export default function NotificationBell() {
           onRead={markRead}
           onReadAll={markAllRead}
           onClose={() => setOpen(false)}
+          triggerRef={bellRef}
         />
       )}
     </div>

--- a/frontend/src/components/Layout/NotificationItem.tsx
+++ b/frontend/src/components/Layout/NotificationItem.tsx
@@ -1,0 +1,42 @@
+import type { Notification } from '@/types';
+
+function timeAgo(date: string): string {
+  const seconds = Math.floor((Date.now() - new Date(date).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+}
+
+interface NotificationItemProps {
+  notification: Notification;
+  onRead: (id: string) => void;
+}
+
+export default function NotificationItem({ notification, onRead }: NotificationItemProps) {
+  const isUnread = notification.readAt === null;
+
+  return (
+    <div
+      onClick={() => { if (isUnread) onRead(notification.id); }}
+      className={`flex gap-3 px-4 py-3 border-l-4 transition-colors ${
+        isUnread
+          ? 'border-primary-500 bg-primary-50 cursor-pointer hover:bg-primary-100'
+          : 'border-transparent bg-white cursor-default'
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <p className={`text-sm ${isUnread ? 'font-semibold text-gray-900' : 'font-normal text-gray-500'}`}>
+          {notification.title}
+        </p>
+        <p className={`text-sm mt-0.5 ${isUnread ? 'text-gray-700' : 'text-gray-400'}`}>
+          {notification.body}
+        </p>
+        <p className="text-xs text-gray-400 mt-1">{timeAgo(notification.createdAt)}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Layout/NotificationItem.tsx
+++ b/frontend/src/components/Layout/NotificationItem.tsx
@@ -19,24 +19,32 @@ interface NotificationItemProps {
 export default function NotificationItem({ notification, onRead }: NotificationItemProps) {
   const isUnread = notification.readAt === null;
 
+  const content = (
+    <div className="min-w-0 flex-1 text-left">
+      <p className={`text-sm ${isUnread ? 'font-semibold text-gray-900' : 'font-normal text-gray-500'}`}>
+        {notification.title}
+      </p>
+      <p className={`text-sm mt-0.5 ${isUnread ? 'text-gray-700' : 'text-gray-400'}`}>
+        {notification.body}
+      </p>
+      <p className="text-xs text-gray-400 mt-1">{timeAgo(notification.createdAt)}</p>
+    </div>
+  );
+
+  if (isUnread) {
+    return (
+      <button
+        onClick={() => onRead(notification.id)}
+        className="flex w-full gap-3 px-4 py-3 border-l-4 border-primary-500 bg-primary-50 hover:bg-primary-100 transition-colors"
+      >
+        {content}
+      </button>
+    );
+  }
+
   return (
-    <div
-      onClick={() => { if (isUnread) onRead(notification.id); }}
-      className={`flex gap-3 px-4 py-3 border-l-4 transition-colors ${
-        isUnread
-          ? 'border-primary-500 bg-primary-50 cursor-pointer hover:bg-primary-100'
-          : 'border-transparent bg-white cursor-default'
-      }`}
-    >
-      <div className="min-w-0 flex-1">
-        <p className={`text-sm ${isUnread ? 'font-semibold text-gray-900' : 'font-normal text-gray-500'}`}>
-          {notification.title}
-        </p>
-        <p className={`text-sm mt-0.5 ${isUnread ? 'text-gray-700' : 'text-gray-400'}`}>
-          {notification.body}
-        </p>
-        <p className="text-xs text-gray-400 mt-1">{timeAgo(notification.createdAt)}</p>
-      </div>
+    <div className="flex gap-3 px-4 py-3 border-l-4 border-transparent bg-white">
+      {content}
     </div>
   );
 }

--- a/frontend/src/components/Layout/NotificationPanel.tsx
+++ b/frontend/src/components/Layout/NotificationPanel.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+import { Bell } from 'lucide-react';
+import type { Notification } from '@/types';
+import NotificationItem from './NotificationItem';
+
+interface NotificationPanelProps {
+  notifications: Notification[];
+  unreadCount: number;
+  onRead: (id: string) => void;
+  onReadAll: () => void;
+  onClose: () => void;
+}
+
+export default function NotificationPanel({
+  notifications,
+  unreadCount,
+  onRead,
+  onReadAll,
+  onClose,
+}: NotificationPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute right-0 top-full mt-1 w-80 rounded-lg border border-gray-200 bg-white shadow-lg z-50 flex flex-col"
+    >
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+        <span className="text-sm font-semibold text-gray-900">Notifications</span>
+        <button
+          onClick={onReadAll}
+          disabled={unreadCount === 0}
+          className="text-xs text-primary-600 hover:text-primary-800 disabled:text-gray-300 disabled:cursor-not-allowed transition-colors"
+        >
+          Mark all as read
+        </button>
+      </div>
+
+      <div className="overflow-y-auto max-h-96 divide-y divide-gray-100">
+        {notifications.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-400">
+            <Bell size={32} className="mb-2" />
+            <p className="text-sm">No notifications</p>
+          </div>
+        ) : (
+          notifications.map((notification) => (
+            <NotificationItem
+              key={notification.id}
+              notification={notification}
+              onRead={onRead}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Layout/NotificationPanel.tsx
+++ b/frontend/src/components/Layout/NotificationPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, RefObject } from 'react';
 import { Bell } from 'lucide-react';
 import type { Notification } from '@/types';
 import NotificationItem from './NotificationItem';
@@ -9,6 +9,7 @@ interface NotificationPanelProps {
   onRead: (id: string) => void;
   onReadAll: () => void;
   onClose: () => void;
+  triggerRef: RefObject<HTMLButtonElement>;
 }
 
 export default function NotificationPanel({
@@ -17,18 +18,24 @@ export default function NotificationPanel({
   onRead,
   onReadAll,
   onClose,
+  triggerRef,
 }: NotificationPanelProps) {
   const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(e.target as Node) &&
+        triggerRef.current &&
+        !triggerRef.current.contains(e.target as Node)
+      ) {
         onClose();
       }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, [onClose]);
+  }, [onClose, triggerRef]);
 
   return (
     <div

--- a/frontend/src/components/Layout/NotificationPanel.tsx
+++ b/frontend/src/components/Layout/NotificationPanel.tsx
@@ -9,7 +9,7 @@ interface NotificationPanelProps {
   onRead: (id: string) => void;
   onReadAll: () => void;
   onClose: () => void;
-  triggerRef: RefObject<HTMLButtonElement>;
+  triggerRef: RefObject<HTMLButtonElement | null>;
 }
 
 export default function NotificationPanel({

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState, useCallback } from 'react';
+import type { Notification } from '@/types';
+import { notificationService } from '@/services/notificationService';
+import { API_BASE_URL } from '@/services/api';
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  useEffect(() => {
+    notificationService.fetchNotifications().then(setNotifications).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    if (!token) return;
+
+    const es = new EventSource(`${API_BASE_URL}/events?token=${encodeURIComponent(token)}`);
+
+    es.addEventListener('notification', async (event: MessageEvent) => {
+      try {
+        JSON.parse(event.data as string);
+      } catch (err) {
+        console.error('[useNotifications] Failed to parse SSE payload:', err);
+        return;
+      }
+
+      try {
+        const all = await notificationService.fetchNotifications();
+        setNotifications(all);
+      } catch (err) {
+        console.error('[useNotifications] Failed to fetch notification:', err);
+      }
+    });
+
+    es.onerror = (err) => {
+      console.error('[useNotifications] SSE connection error:', err);
+      const currentToken = localStorage.getItem('accessToken');
+      if (currentToken && currentToken !== token) {
+        es.close();
+      }
+    };
+
+    return () => {
+      es.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const unreadCount = notifications.filter((n) => n.readAt === null).length;
+
+  const markRead = useCallback(async (id: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, readAt: new Date().toISOString() } : n))
+    );
+    try {
+      await notificationService.markRead(id);
+    } catch (err) {
+      console.error('[useNotifications] Failed to mark read:', err);
+    }
+  }, []);
+
+  const markAllRead = useCallback(async () => {
+    const now = new Date().toISOString();
+    setNotifications((prev) =>
+      prev.map((n) => (n.readAt === null ? { ...n, readAt: now } : n))
+    );
+    try {
+      await notificationService.markAllRead();
+    } catch (err) {
+      console.error('[useNotifications] Failed to mark all read:', err);
+    }
+  }, []);
+
+  return { notifications, unreadCount, markRead, markAllRead };
+}

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -16,14 +16,7 @@ export function useNotifications() {
 
     const es = new EventSource(`${API_BASE_URL}/events?token=${encodeURIComponent(token)}`);
 
-    es.addEventListener('notification', async (event: MessageEvent) => {
-      try {
-        JSON.parse(event.data as string);
-      } catch (err) {
-        console.error('[useNotifications] Failed to parse SSE payload:', err);
-        return;
-      }
-
+    es.addEventListener('notification', async () => {
       try {
         const all = await notificationService.fetchNotifications();
         setNotifications(all);
@@ -49,27 +42,31 @@ export function useNotifications() {
   const unreadCount = notifications.filter((n) => n.readAt === null).length;
 
   const markRead = useCallback(async (id: string) => {
-    setNotifications((prev) =>
-      prev.map((n) => (n.id === id ? { ...n, readAt: new Date().toISOString() } : n))
+    const prev = notifications;
+    setNotifications((ns) =>
+      ns.map((n) => (n.id === id ? { ...n, readAt: new Date().toISOString() } : n))
     );
     try {
       await notificationService.markRead(id);
     } catch (err) {
       console.error('[useNotifications] Failed to mark read:', err);
+      setNotifications(prev);
     }
-  }, []);
+  }, [notifications]);
 
   const markAllRead = useCallback(async () => {
+    const prev = notifications;
     const now = new Date().toISOString();
-    setNotifications((prev) =>
-      prev.map((n) => (n.readAt === null ? { ...n, readAt: now } : n))
+    setNotifications((ns) =>
+      ns.map((n) => (n.readAt === null ? { ...n, readAt: now } : n))
     );
     try {
       await notificationService.markAllRead();
     } catch (err) {
       console.error('[useNotifications] Failed to mark all read:', err);
+      setNotifications(prev);
     }
-  }, []);
+  }, [notifications]);
 
   return { notifications, unreadCount, markRead, markAllRead };
 }

--- a/frontend/src/services/notificationService.ts
+++ b/frontend/src/services/notificationService.ts
@@ -1,0 +1,18 @@
+import api from './api';
+import { snakeToCamel } from '@/utils/caseTransform';
+import type { Notification } from '@/types';
+
+export const notificationService = {
+  async fetchNotifications(): Promise<Notification[]> {
+    const res = await api.get('/notifications');
+    return snakeToCamel(res.data.data) as Notification[];
+  },
+
+  async markRead(id: string): Promise<void> {
+    await api.patch(`/notifications/${id}/read`);
+  },
+
+  async markAllRead(): Promise<void> {
+    await api.patch('/notifications/read-all');
+  },
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -79,3 +79,13 @@ export interface Todo {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface Notification {
+  id: string;
+  userId: string;
+  title: string;
+  body: string;
+  metadata: Record<string, unknown> | null;
+  readAt: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary
- Adds a fully persistent notification center with backend storage, REST API, PostgreSQL NOTIFY trigger, and real-time SSE delivery
- Builds the UI: bell icon with unread badge, sliding panel with scrollable list, per-item and mark-all-read actions
- Extends the existing SSE infrastructure (pgSubscriber) with a second channel (`notification_events`) without breaking card events

## Changes
- **Migration 011**: `notifications` table + INSERT trigger that fires `pg_notify('notification_events', ...)`
- **Backend service**: `notificationService` with `create`, `list`, `markRead`, `markAllRead`
- **Backend routes**: `GET /api/notifications`, `PATCH /api/notifications/:id/read`, `PATCH /api/notifications/read-all`
- **pgSubscriber**: listens on both `card_events` and `notification_events`; uses named SSE events (`event: message` / `event: notification`) so frontend consumers can selectively subscribe
- **Frontend service**: `notificationService` wrapping the shared axios instance
- **`useNotifications` hook**: initial fetch + SSE real-time updates + optimistic `markRead`/`markAllRead`
- **UI components**: `NotificationBell`, `NotificationPanel`, `NotificationItem` — single hook instance at Bell level, state passed down as props
- **Navbar**: `NotificationBell` inserted between nav links and user menu

## Test plan
- [ ] Run migration — `notifications` table created, trigger installed
- [ ] POST a notification directly in SQL, verify SSE fires and badge increments in browser
- [ ] Click notification item — turns gray, border disappears
- [ ] "Mark all as read" — all items go muted, badge disappears, button disabled
- [ ] Click bell again — panel closes; click again — panel reopens with same state
- [ ] Empty state shows bell icon + "No notifications"
- [ ] Board card events still work (create/move/delete) — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)