### PR TITLE
feat: Settings page with Gmail integration scaffold

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import SignupPage from '@/pages/SignupPage';
 import BoardPage from '@/pages/BoardPage';
 import DashboardPage from '@/pages/DashboardPage';
 import TasksPage from '@/pages/TasksPage';
+import SettingsPage from '@/pages/SettingsPage';
 
 export default function App() {
   return (
@@ -24,6 +25,7 @@ export default function App() {
             <Route path="/" element={<BoardPage />} />
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/tasks" element={<TasksPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
           </Route>
         </Routes>
       </AuthProvider>

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
-import { Briefcase, LayoutDashboard, Columns3, CheckSquare, LogOut, User } from 'lucide-react';
+import { Briefcase, LayoutDashboard, Columns3, CheckSquare, LogOut, User, Settings } from 'lucide-react';
 import { useState, useRef, useEffect } from 'react';
 import NotificationBell from './NotificationBell';
 
@@ -75,6 +75,14 @@ export default function Navbar() {
                 <p className="text-sm font-medium text-gray-900">{user?.name}</p>
                 <p className="text-xs text-gray-500 truncate">{user?.email}</p>
               </div>
+              <Link
+                to="/settings"
+                onClick={() => setShowMenu(false)}
+                className="flex w-full items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:bg-gray-50"
+              >
+                <Settings size={14} />
+                Settings
+              </Link>
               <button
                 onClick={() => {
                   setShowMenu(false);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,120 @@
+import { useState, useEffect } from 'react';
+import { Settings, Mail, CheckCircle, AlertTriangle, RefreshCw } from 'lucide-react';
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { gmailApi } from '@/services/api';
+
+type GmailStatus =
+  | { connected: false }
+  | { connected: true; isValid: true; email: string; lastSyncAt: string | null }
+  | { connected: true; isValid: false; email: string; lastSyncAt: string | null };
+
+export default function SettingsPage() {
+  const [gmailStatus, setGmailStatus] = useState<GmailStatus>({ connected: false });
+  const [syncResult] = useState('');
+
+  useEffect(() => {
+    gmailApi
+      .getStatus()
+      .then((data) => setGmailStatus(data))
+      .catch(() => setGmailStatus({ connected: false }));
+  }, []);
+
+  return (
+    <div className="p-6 space-y-6 max-w-3xl mx-auto">
+      <div className="flex items-center gap-2">
+        <Settings size={22} className="text-primary-600" />
+        <h1 className="text-xl font-bold text-gray-900">Settings</h1>
+      </div>
+
+      {/* Gmail Integration card */}
+      <section className="rounded-xl border border-gray-200 bg-white p-6 space-y-4">
+        <div className="flex items-center gap-3">
+          <Mail size={20} className="text-gray-500 shrink-0" />
+          <h2 className="text-base font-semibold text-gray-900">Gmail Integration</h2>
+          {gmailStatus.connected && gmailStatus.isValid && (
+            <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700">
+              <CheckCircle size={11} />
+              Connected
+            </span>
+          )}
+        </div>
+
+        {/* State 3: connected but token revoked */}
+        {gmailStatus.connected && !gmailStatus.isValid && (
+          <div className="flex items-center gap-2 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+            <AlertTriangle size={16} className="shrink-0 text-amber-500" />
+            Gmail connection lost — please reconnect your account.
+          </div>
+        )}
+
+        {/* State 1: disconnected */}
+        {!gmailStatus.connected && (
+          <>
+            <p className="text-sm text-gray-500">
+              Connect your Gmail account to automatically detect rejection emails and update your board.
+            </p>
+            <button
+              onClick={() => {
+                // TODO: wire OAuth
+              }}
+              className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
+            >
+              <Mail size={15} />
+              Connect Gmail
+            </button>
+          </>
+        )}
+
+        {/* State 2: connected and valid */}
+        {gmailStatus.connected && gmailStatus.isValid && (
+          <>
+            <div className="text-sm text-gray-600">
+              <span className="font-medium text-gray-800">{gmailStatus.email}</span>
+            </div>
+            <div className="text-sm text-gray-500">
+              <span className="font-medium text-gray-700">Last synced:</span>{' '}
+              {gmailStatus.lastSyncAt
+                ? formatDistanceToNow(parseISO(gmailStatus.lastSyncAt), { addSuffix: true })
+                : 'Never synced yet'}
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={() => {
+                  // TODO: wire sync
+                }}
+                className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
+              >
+                <RefreshCw size={14} />
+                Sync Now
+              </button>
+              <button
+                onClick={() => {
+                  // TODO: wire disconnect
+                }}
+                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:border-red-300 hover:text-red-600 transition"
+              >
+                Disconnect
+              </button>
+            </div>
+            {syncResult && (
+              <p className="text-sm text-gray-600">{syncResult}</p>
+            )}
+          </>
+        )}
+
+        {/* State 3 reconnect button */}
+        {gmailStatus.connected && !gmailStatus.isValid && (
+          <button
+            onClick={() => {
+              // TODO: wire OAuth
+            }}
+            className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
+          >
+            <Mail size={15} />
+            Reconnect Gmail
+          </button>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -2,22 +2,24 @@ import { useState, useEffect } from 'react';
 import { Settings, Mail, CheckCircle, AlertTriangle, RefreshCw } from 'lucide-react';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { gmailApi } from '@/services/api';
-
-type GmailStatus =
-  | { connected: false }
-  | { connected: true; isValid: true; email: string; lastSyncAt: string | null }
-  | { connected: true; isValid: false; email: string; lastSyncAt: string | null };
+import type { GmailStatusData } from '@/services/api';
 
 export default function SettingsPage() {
-  const [gmailStatus, setGmailStatus] = useState<GmailStatus>({ connected: false });
-  const [syncResult] = useState('');
+  const [gmailStatus, setGmailStatus] = useState<GmailStatusData>({ connected: false });
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     gmailApi
       .getStatus()
       .then((data) => setGmailStatus(data))
-      .catch(() => setGmailStatus({ connected: false }));
+      .catch(() => setGmailStatus({ connected: false }))
+      .finally(() => setLoading(false));
   }, []);
+
+  const isConnectedValid =
+    gmailStatus.connected === true && gmailStatus.isValid === true;
+  const isConnectedInvalid =
+    gmailStatus.connected === true && gmailStatus.isValid === false;
 
   return (
     <div className="p-6 space-y-6 max-w-3xl mx-auto">
@@ -31,7 +33,7 @@ export default function SettingsPage() {
         <div className="flex items-center gap-3">
           <Mail size={20} className="text-gray-500 shrink-0" />
           <h2 className="text-base font-semibold text-gray-900">Gmail Integration</h2>
-          {gmailStatus.connected && gmailStatus.isValid && (
+          {isConnectedValid && (
             <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700">
               <CheckCircle size={11} />
               Connected
@@ -39,80 +41,85 @@ export default function SettingsPage() {
           )}
         </div>
 
-        {/* State 3: connected but token revoked */}
-        {gmailStatus.connected && !gmailStatus.isValid && (
-          <div className="flex items-center gap-2 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
-            <AlertTriangle size={16} className="shrink-0 text-amber-500" />
-            Gmail connection lost — please reconnect your account.
-          </div>
+        {loading && (
+          <div className="skeleton h-10 rounded-lg" />
         )}
 
-        {/* State 1: disconnected */}
-        {!gmailStatus.connected && (
+        {!loading && (
           <>
-            <p className="text-sm text-gray-500">
-              Connect your Gmail account to automatically detect rejection emails and update your board.
-            </p>
-            <button
-              onClick={() => {
-                // TODO: wire OAuth
-              }}
-              className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
-            >
-              <Mail size={15} />
-              Connect Gmail
-            </button>
-          </>
-        )}
+            {/* State 3: connected but token revoked */}
+            {isConnectedInvalid && (
+              <div className="flex items-center gap-2 rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">
+                <AlertTriangle size={16} className="shrink-0 text-amber-500" />
+                Gmail connection lost — please reconnect your account.
+              </div>
+            )}
 
-        {/* State 2: connected and valid */}
-        {gmailStatus.connected && gmailStatus.isValid && (
-          <>
-            <div className="text-sm text-gray-600">
-              <span className="font-medium text-gray-800">{gmailStatus.email}</span>
-            </div>
-            <div className="text-sm text-gray-500">
-              <span className="font-medium text-gray-700">Last synced:</span>{' '}
-              {gmailStatus.lastSyncAt
-                ? formatDistanceToNow(parseISO(gmailStatus.lastSyncAt), { addSuffix: true })
-                : 'Never synced yet'}
-            </div>
-            <div className="flex items-center gap-3">
+            {/* State 1: disconnected */}
+            {!gmailStatus.connected && (
+              <>
+                <p className="text-sm text-gray-500">
+                  Connect your Gmail account to automatically detect rejection emails and update your board.
+                </p>
+                <button
+                  onClick={() => {
+                    // TODO: wire OAuth
+                  }}
+                  className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
+                >
+                  <Mail size={15} />
+                  Connect Gmail
+                </button>
+              </>
+            )}
+
+            {/* State 2: connected and valid */}
+            {isConnectedValid && gmailStatus.connected && (
+              <>
+                <div className="text-sm text-gray-600">
+                  <span className="font-medium text-gray-800">{gmailStatus.email}</span>
+                </div>
+                <div className="text-sm text-gray-500">
+                  <span className="font-medium text-gray-700">Last synced:</span>{' '}
+                  {gmailStatus.lastSyncAt
+                    ? formatDistanceToNow(parseISO(gmailStatus.lastSyncAt), { addSuffix: true })
+                    : 'Never synced yet'}
+                </div>
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={() => {
+                      // TODO: wire sync
+                    }}
+                    className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
+                  >
+                    <RefreshCw size={14} />
+                    Sync Now
+                  </button>
+                  <button
+                    onClick={() => {
+                      // TODO: wire disconnect
+                    }}
+                    className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:border-red-300 hover:text-red-600 transition"
+                  >
+                    Disconnect
+                  </button>
+                </div>
+              </>
+            )}
+
+            {/* State 3 reconnect button */}
+            {isConnectedInvalid && (
               <button
                 onClick={() => {
-                  // TODO: wire sync
+                  // TODO: wire OAuth
                 }}
                 className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
               >
-                <RefreshCw size={14} />
-                Sync Now
+                <Mail size={15} />
+                Reconnect Gmail
               </button>
-              <button
-                onClick={() => {
-                  // TODO: wire disconnect
-                }}
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:border-red-300 hover:text-red-600 transition"
-              >
-                Disconnect
-              </button>
-            </div>
-            {syncResult && (
-              <p className="text-sm text-gray-600">{syncResult}</p>
             )}
           </>
-        )}
-
-        {/* State 3 reconnect button */}
-        {gmailStatus.connected && !gmailStatus.isValid && (
-          <button
-            onClick={() => {
-              // TODO: wire OAuth
-            }}
-            className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
-          >
-            <Mail size={15} />
-            Reconnect Gmail
-          </button>
         )}
       </section>
     </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -225,17 +225,15 @@ export const remindersApi = {
 };
 
 // Gmail API
+export type GmailStatusData =
+  | { connected: false }
+  | { connected: true; isValid: true; email: string; lastSyncAt: string | null }
+  | { connected: true; isValid: false; email: string; lastSyncAt: string | null };
+
 export const gmailApi = {
-  getStatus: async (): Promise<
-    | { connected: false }
-    | { connected: true; isValid: true; email: string; lastSyncAt: string | null }
-    | { connected: true; isValid: false; email: string; lastSyncAt: string | null }
-  > => {
+  getStatus: async (): Promise<GmailStatusData> => {
     const res = await api.get('/gmail/status');
-    return snakeToCamel(res.data.data) as
-      | { connected: false }
-      | { connected: true; isValid: true; email: string; lastSyncAt: string | null }
-      | { connected: true; isValid: false; email: string; lastSyncAt: string | null };
+    return snakeToCamel(res.data.data) as GmailStatusData;
   },
 };
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -224,4 +224,19 @@ export const remindersApi = {
   },
 };
 
+// Gmail API
+export const gmailApi = {
+  getStatus: async (): Promise<
+    | { connected: false }
+    | { connected: true; isValid: true; email: string; lastSyncAt: string | null }
+    | { connected: true; isValid: false; email: string; lastSyncAt: string | null }
+  > => {
+    const res = await api.get('/gmail/status');
+    return snakeToCamel(res.data.data) as
+      | { connected: false }
+      | { connected: true; isValid: true; email: string; lastSyncAt: string | null }
+      | { connected: true; isValid: false; email: string; lastSyncAt: string | null };
+  },
+};
+
 export default api;


### PR DESCRIPTION
## Summary
- Adds a `/settings` protected route with a Gmail integration section
- Three visual states: Disconnected, Connected (valid), and Connection lost (token revoked)
- Gmail status is fetched from `GET /api/gmail/status`; any 404/network error gracefully defaults to disconnected state

## Changes
- `frontend/src/pages/SettingsPage.tsx` — new page with three Gmail integration states driven by API status
- `frontend/src/services/api.ts` — adds `gmailApi.getStatus()` with typed return union
- `frontend/src/components/Layout/Navbar.tsx` — adds "Settings" link above "Sign out" in user dropdown
- `frontend/src/App.tsx` — registers `/settings` inside the protected `AppLayout` route

## Test plan
- [ ] Visit `/settings` while logged in — Gmail section shows "Disconnected" state (API not yet implemented, falls back gracefully)
- [ ] Clicking "Connect Gmail" does nothing (stub, no errors)
- [ ] Visit `/settings` while logged out — should redirect to `/login`
- [ ] Open user dropdown in navbar — "Settings" link appears above "Sign out"; clicking it navigates to `/settings` and closes dropdown
- [ ] Build passes: `npm run build` in `frontend/`

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)