### PR TITLE
feat: Gmail rejection agent

### DIFF
--- a/.github/workflows/gmail-sync.yml
+++ b/.github/workflows/gmail-sync.yml
@@ -11,7 +11,11 @@ jobs:
     steps:
       - name: Trigger Gmail Sync
         run: |
-          curl -s -o /dev/null -w "%{http_code}" \
+          RESPONSE=$(curl --fail-with-body \
+            -s -w "\nHTTP_STATUS:%{http_code}" \
             -X POST "${{ secrets.RENDER_SYNC_URL }}/api/gmail/sync" \
             -H "Authorization: Bearer ${{ secrets.CRON_API_KEY }}" \
-            --fail
+            -H "Content-Type: application/json")
+          echo "$RESPONSE"
+          HTTP_CODE=$(echo "$RESPONSE" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+          echo "HTTP status: $HTTP_CODE"

--- a/.github/workflows/gmail-sync.yml
+++ b/.github/workflows/gmail-sync.yml
@@ -1,0 +1,17 @@
+name: Gmail Sync
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Gmail Sync
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" \
+            -X POST "${{ secrets.RENDER_SYNC_URL }}/api/gmail/sync" \
+            -H "Authorization: Bearer ${{ secrets.CRON_API_KEY }}" \
+            --fail

--- a/backend/migrations/012_add_is_rejection_stage_to_stages.ts
+++ b/backend/migrations/012_add_is_rejection_stage_to_stages.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('stages', (table) => {
+    table.boolean('is_rejection_stage').notNullable().defaultTo(false);
+  });
+  await knex.raw(`UPDATE stages SET is_rejection_stage = true WHERE name = 'Rejected'`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('stages', (table) => {
+    table.dropColumn('is_rejection_stage');
+  });
+}

--- a/backend/migrations/013_create_gmail_tokens.ts
+++ b/backend/migrations/013_create_gmail_tokens.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('gmail_tokens', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').notNullable().unique().references('id').inTable('users').onDelete('CASCADE');
+    table.string('gmail_address', 255).notNullable();
+    table.text('access_token').notNullable();
+    table.text('refresh_token').notNullable();
+    table.timestamp('token_expiry', { useTz: true }).notNullable();
+    table.boolean('is_valid').notNullable().defaultTo(true);
+    table.timestamp('last_sync_at', { useTz: true }).nullable();
+    table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now());
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('gmail_tokens');
+}

--- a/backend/migrations/013_create_gmail_tokens.ts
+++ b/backend/migrations/013_create_gmail_tokens.ts
@@ -2,7 +2,7 @@ import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('gmail_tokens', (table) => {
-    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('user_id').notNullable().unique().references('id').inTable('users').onDelete('CASCADE');
     table.string('gmail_address', 255).notNullable();
     table.text('access_token').notNullable();
@@ -10,8 +10,8 @@ export async function up(knex: Knex): Promise<void> {
     table.timestamp('token_expiry', { useTz: true }).notNullable();
     table.boolean('is_valid').notNullable().defaultTo(true);
     table.timestamp('last_sync_at', { useTz: true }).nullable();
-    table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
-    table.timestamp('updated_at', { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
+    table.timestamp('updated_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
   });
 }
 

--- a/backend/migrations/014_create_processed_emails.ts
+++ b/backend/migrations/014_create_processed_emails.ts
@@ -2,13 +2,13 @@ import { Knex } from 'knex';
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('processed_emails', (table) => {
-    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
     table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
     table.string('gmail_message_id', 255).notNullable();
     table.text('subject').nullable();
     table.string('sender', 255).nullable();
     table.timestamp('received_at', { useTz: true }).nullable();
-    table.timestamp('processed_at', { useTz: true }).defaultTo(knex.fn.now());
+    table.timestamp('processed_at', { useTz: true }).notNullable().defaultTo(knex.fn.now());
     table.string('action', 50).notNullable();
     table.uuid('card_id').nullable().references('id').inTable('cards').onDelete('SET NULL');
     table.decimal('confidence', 5, 2).nullable();

--- a/backend/migrations/014_create_processed_emails.ts
+++ b/backend/migrations/014_create_processed_emails.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('processed_emails', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE');
+    table.string('gmail_message_id', 255).notNullable();
+    table.text('subject').nullable();
+    table.string('sender', 255).nullable();
+    table.timestamp('received_at', { useTz: true }).nullable();
+    table.timestamp('processed_at', { useTz: true }).defaultTo(knex.fn.now());
+    table.string('action', 50).notNullable();
+    table.uuid('card_id').nullable().references('id').inTable('cards').onDelete('SET NULL');
+    table.decimal('confidence', 5, 2).nullable();
+    table.string('extracted_company', 255).nullable();
+
+    table.unique(['user_id', 'gmail_message_id']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('processed_emails');
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "jobflow-backend",
       "version": "1.0.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^1.0.0",
+        "ai": "^4.0.0",
         "bcryptjs": "^2.4.3",
         "compression": "^1.8.1",
         "cors": "^2.8.5",
@@ -15,11 +17,13 @@
         "express": "^4.21.0",
         "express-rate-limit": "^7.5.1",
         "express-validator": "^7.2.0",
+        "googleapis": "^140.0.0",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "pg": "^8.13.0",
         "uuid": "^10.0.0",
-        "winston": "^3.14.0"
+        "winston": "^3.14.0",
+        "zod": "^3.23.0"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -38,6 +42,92 @@
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.5.4"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.2.12.tgz",
+      "integrity": "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1012,6 +1102,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -1187,6 +1286,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -1484,6 +1589,41 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1706,6 +1846,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -1724,6 +1884,15 @@
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
       "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2366,6 +2535,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -2406,6 +2584,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -2747,6 +2931,12 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2912,6 +3102,50 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3032,6 +3266,76 @@
         "node": ">= 6"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "140.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-140.0.1.tgz",
+      "integrity": "sha512-ZGvBX4mQcFXO9ACnVNg6Aqy3KtBPB5zTuue43YVLxwn8HSv8jB7w+uDKoIPSoWuxGROgnj2kbng6acXncOQRNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3050,6 +3354,19 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -3149,6 +3466,42 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -4084,12 +4437,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4102,6 +4470,35 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -4561,6 +4958,24 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4583,6 +4998,26 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5111,6 +5546,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -5267,6 +5712,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -5709,6 +6160,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tarn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
@@ -5738,6 +6202,18 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tildify": {
       "version": "2.0.0",
@@ -5776,6 +6252,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -6098,6 +6580,21 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6174,6 +6671,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6350,6 +6863,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,8 @@
     "lint": "eslint src/"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^1.0.0",
+    "ai": "^4.0.0",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",
     "cors": "^2.8.5",
@@ -24,11 +26,13 @@
     "express": "^4.21.0",
     "express-rate-limit": "^7.5.1",
     "express-validator": "^7.2.0",
+    "googleapis": "^140.0.0",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
     "pg": "^8.13.0",
     "uuid": "^10.0.0",
-    "winston": "^3.14.0"
+    "winston": "^3.14.0",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/backend/src/routes/gmail.ts
+++ b/backend/src/routes/gmail.ts
@@ -1,0 +1,63 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import db from '../config/database';
+import { authenticate } from '../middleware/auth';
+import { gmailService } from '../services/gmailService';
+import { syncUserGmail } from '../services/gmailSyncService';
+
+const router = Router();
+
+router.get('/auth', authenticate, (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const url = gmailService.getAuthUrl(req.user!.id);
+    res.json({ url });
+  } catch (err) { next(err); }
+});
+
+router.get('/callback', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { code, state } = req.query as { code: string; state: string };
+    await gmailService.handleCallback(code, state);
+    const frontendUrl = process.env.FRONTEND_URL ?? 'http://localhost:5173';
+    res.redirect(`${frontendUrl}/settings?gmail=connected`);
+  } catch (err) { next(err); }
+});
+
+router.get('/status', authenticate, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const status = await gmailService.getStatus(req.user!.id);
+    res.json({ data: status });
+  } catch (err) { next(err); }
+});
+
+router.delete('/disconnect', authenticate, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await gmailService.disconnect(req.user!.id);
+    res.status(204).send();
+  } catch (err) { next(err); }
+});
+
+router.post('/sync', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const cronKey = process.env.CRON_API_KEY;
+    const authHeader = req.headers.authorization ?? '';
+    const isCron = cronKey && authHeader === `Bearer ${cronKey}`;
+
+    if (isCron) {
+      const tokens = await db('gmail_tokens').where({ is_valid: true }).select('user_id');
+      const results: Record<string, unknown> = {};
+      for (const { user_id } of tokens) {
+        results[user_id] = await syncUserGmail(user_id);
+      }
+      return res.json({ results });
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      authenticate(req as Request, res as Response, (err?: unknown) => (err ? reject(err) : resolve()));
+    });
+
+    const summary = await syncUserGmail((req as Request).user!.id);
+    res.json({ data: summary });
+  } catch (err) { next(err); }
+});
+
+export default router;

--- a/backend/src/routes/gmail.ts
+++ b/backend/src/routes/gmail.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
+import { timingSafeEqual, createHash } from 'crypto';
 import db from '../config/database';
 import { authenticate } from '../middleware/auth';
 import { gmailService } from '../services/gmailService';
@@ -6,9 +7,19 @@ import { syncUserGmail } from '../services/gmailSyncService';
 
 const router = Router();
 
-router.get('/auth', authenticate, (req: Request, res: Response, next: NextFunction) => {
+/**
+ * Constant-time string comparison to avoid timing side-channels when
+ * validating the CRON_API_KEY secret.
+ */
+function safeCompare(a: string, b: string): boolean {
+  const ha = createHash('sha256').update(a).digest();
+  const hb = createHash('sha256').update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
+
+router.get('/auth', authenticate, async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const url = gmailService.getAuthUrl(req.user!.id);
+    const url = await gmailService.getAuthUrl(req.user!.id);
     res.json({ url });
   } catch (err) { next(err); }
 });
@@ -40,7 +51,7 @@ router.post('/sync', async (req: Request, res: Response, next: NextFunction) => 
   try {
     const cronKey = process.env.CRON_API_KEY;
     const authHeader = req.headers.authorization ?? '';
-    const isCron = cronKey && authHeader === `Bearer ${cronKey}`;
+    const isCron = !!cronKey && safeCompare(authHeader, `Bearer ${cronKey}`);
 
     if (isCron) {
       const tokens = await db('gmail_tokens').where({ is_valid: true }).select('user_id');

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -9,6 +9,7 @@ import todosRouter from './todos';
 import autocompleteRouter from './autocomplete';
 import eventsRouter from './events';
 import notificationsRouter from './notifications';
+import gmailRouter from './gmail';
 
 const router = Router();
 
@@ -27,5 +28,6 @@ router.use('/todos', todosRouter);
 router.use('/autocomplete', autocompleteRouter);
 router.use('/events', eventsRouter);
 router.use('/notifications', notificationsRouter);
+router.use('/gmail', gmailRouter);
 
 export default router;

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -85,6 +85,7 @@ async function createDefaultStages(userId: string): Promise<void> {
     name,
     position: index,
     is_default: true,
+    is_rejection_stage: name === 'Rejected',
   }));
 
   await db('stages').insert(stages);

--- a/backend/src/services/emailClassifier.ts
+++ b/backend/src/services/emailClassifier.ts
@@ -10,19 +10,39 @@ const classificationSchema = z.object({
 
 export type EmailClassification = z.infer<typeof classificationSchema>;
 
+// Instantiate the provider once at module level rather than on every call
+const anthropicProvider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
 function getModel() {
   const provider = process.env.LLM_PROVIDER ?? 'anthropic';
   switch (provider) {
     case 'anthropic':
     default:
-      return createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })('claude-haiku-20240307');
+      return anthropicProvider('claude-3-haiku-20240307');
   }
+}
+
+/**
+ * Strip patterns that are commonly used in prompt-injection attacks before
+ * interpolating external content (email subject / body) into an LLM prompt.
+ * This is a defence-in-depth measure (OWASP LLM01); the XML-tag delimiters
+ * below are the primary boundary enforcement.
+ */
+function sanitizeForPrompt(s: string, maxLen: number): string {
+  return s
+    .replace(/```/g, "'''")       // break out of code fences
+    .replace(/---+/g, '–––') // break markdown separators
+    .replace(/\n{4,}/g, '\n\n\n') // collapse excessive blank lines
+    .slice(0, maxLen);
 }
 
 export async function classifyEmail(
   subject: string,
   body: string
 ): Promise<EmailClassification> {
+  const safeSubject = sanitizeForPrompt(subject, 200);
+  const safeBody = sanitizeForPrompt(body, 2000);
+
   const { object } = await generateObject({
     model: getModel(),
     schema: classificationSchema,
@@ -30,10 +50,10 @@ export async function classifyEmail(
 
 A rejection email typically says the company decided not to move forward with the candidate, they went with other candidates, or the position has been filled.
 
-Subject: ${subject}
-
-Body:
-${body}
+<email>
+<subject>${safeSubject}</subject>
+<body>${safeBody}</body>
+</email>
 
 Return your analysis as JSON.`,
   });

--- a/backend/src/services/emailClassifier.ts
+++ b/backend/src/services/emailClassifier.ts
@@ -1,0 +1,41 @@
+import { generateObject } from 'ai';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { z } from 'zod';
+
+const classificationSchema = z.object({
+  isRejection: z.boolean(),
+  companyName: z.string().nullable(),
+  confidence: z.number().min(0).max(1),
+});
+
+export type EmailClassification = z.infer<typeof classificationSchema>;
+
+function getModel() {
+  const provider = process.env.LLM_PROVIDER ?? 'anthropic';
+  switch (provider) {
+    case 'anthropic':
+    default:
+      return createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })('claude-haiku-20240307');
+  }
+}
+
+export async function classifyEmail(
+  subject: string,
+  body: string
+): Promise<EmailClassification> {
+  const { object } = await generateObject({
+    model: getModel(),
+    schema: classificationSchema,
+    prompt: `You are analyzing job application emails. Determine if this email is a rejection from a job application process.
+
+A rejection email typically says the company decided not to move forward with the candidate, they went with other candidates, or the position has been filled.
+
+Subject: ${subject}
+
+Body:
+${body}
+
+Return your analysis as JSON.`,
+  });
+  return object;
+}

--- a/backend/src/services/gmailService.ts
+++ b/backend/src/services/gmailService.ts
@@ -1,8 +1,12 @@
 import { google } from 'googleapis';
+import jwt from 'jsonwebtoken';
 import db from '../config/database';
 import { notificationService } from './notificationService';
+import { AppError } from '../middleware/errorHandler';
 
 const SCOPES = ['https://www.googleapis.com/auth/gmail.readonly'];
+// OAuth state nonces expire after 10 minutes
+const OAUTH_STATE_TTL_S = 10 * 60;
 
 function createOAuthClient() {
   return new google.auth.OAuth2(
@@ -12,18 +16,49 @@ function createOAuthClient() {
   );
 }
 
+/**
+ * Creates a short-lived, signed JWT that embeds the userId.
+ * Used as the OAuth `state` parameter to prevent CSRF on the callback.
+ * The JWT is signed with JWT_SECRET and expires in 10 minutes.
+ */
+function createOAuthStateToken(userId: string): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new AppError('JWT_SECRET is not configured', 500, 'ERR_INTERNAL');
+  return jwt.sign({ userId, purpose: 'oauth_state' }, secret, { expiresIn: OAUTH_STATE_TTL_S });
+}
+
+/**
+ * Verifies an OAuth state JWT and returns the embedded userId.
+ * Throws AppError(400) if the token is missing, tampered with, or expired.
+ */
+function verifyOAuthStateToken(state: string): string {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new AppError('JWT_SECRET is not configured', 500, 'ERR_INTERNAL');
+  try {
+    const payload = jwt.verify(state, secret) as { userId: string; purpose: string };
+    if (payload.purpose !== 'oauth_state') throw new Error('wrong purpose');
+    return payload.userId;
+  } catch {
+    throw new AppError('Invalid or expired OAuth state', 400, 'ERR_INVALID_STATE');
+  }
+}
+
 export const gmailService = {
   getAuthUrl(userId: string): string {
     const oauth2Client = createOAuthClient();
+    const state = createOAuthStateToken(userId);
     return oauth2Client.generateAuthUrl({
       access_type: 'offline',
       scope: SCOPES,
       prompt: 'consent',
-      state: userId,
+      state,
     });
   },
 
-  async handleCallback(code: string, userId: string): Promise<void> {
+  async handleCallback(code: string, state: string): Promise<void> {
+    // Verify the CSRF state token and extract the userId
+    const userId = verifyOAuthStateToken(state);
+
     const oauth2Client = createOAuthClient();
     const { tokens } = await oauth2Client.getToken(code);
     oauth2Client.setCredentials(tokens);
@@ -95,11 +130,11 @@ export const gmailService = {
     return google.gmail({ version: 'v1', auth: oauth2Client });
   },
 
-  async fetchUnreadEmails(userId: string, gmailClient: ReturnType<typeof google.gmail>) {
-    const token = await db('gmail_tokens').where({ user_id: userId }).first();
-    const sinceDate = token?.last_sync_at
-      ? new Date(token.last_sync_at)
-      : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  async fetchUnreadEmails(
+    gmailClient: ReturnType<typeof google.gmail>,
+    lastSyncAt: Date | null
+  ) {
+    const sinceDate = lastSyncAt ?? new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const afterEpoch = Math.floor(sinceDate.getTime() / 1000);
 
     const listRes = await gmailClient.users.messages.list({

--- a/backend/src/services/gmailService.ts
+++ b/backend/src/services/gmailService.ts
@@ -1,0 +1,140 @@
+import { google } from 'googleapis';
+import db from '../config/database';
+import { notificationService } from './notificationService';
+
+const SCOPES = ['https://www.googleapis.com/auth/gmail.readonly'];
+
+function createOAuthClient() {
+  return new google.auth.OAuth2(
+    process.env.GOOGLE_CLIENT_ID,
+    process.env.GOOGLE_CLIENT_SECRET,
+    process.env.GOOGLE_REDIRECT_URI ?? `${process.env.BACKEND_URL}/api/gmail/callback`
+  );
+}
+
+export const gmailService = {
+  getAuthUrl(userId: string): string {
+    const oauth2Client = createOAuthClient();
+    return oauth2Client.generateAuthUrl({
+      access_type: 'offline',
+      scope: SCOPES,
+      prompt: 'consent',
+      state: userId,
+    });
+  },
+
+  async handleCallback(code: string, userId: string): Promise<void> {
+    const oauth2Client = createOAuthClient();
+    const { tokens } = await oauth2Client.getToken(code);
+    oauth2Client.setCredentials(tokens);
+
+    const gmail = google.gmail({ version: 'v1', auth: oauth2Client });
+    const profile = await gmail.users.getProfile({ userId: 'me' });
+    const gmailAddress = profile.data.emailAddress!;
+
+    await db('gmail_tokens')
+      .insert({
+        user_id: userId,
+        gmail_address: gmailAddress,
+        access_token: tokens.access_token!,
+        refresh_token: tokens.refresh_token!,
+        token_expiry: new Date(tokens.expiry_date!),
+        is_valid: true,
+      })
+      .onConflict('user_id')
+      .merge(['access_token', 'refresh_token', 'token_expiry', 'gmail_address', 'is_valid', 'updated_at']);
+  },
+
+  async getStatus(userId: string) {
+    const token = await db('gmail_tokens').where({ user_id: userId }).first();
+    if (!token) return { connected: false as const };
+    return {
+      connected: true as const,
+      email: token.gmail_address,
+      last_sync_at: token.last_sync_at,
+      is_valid: token.is_valid,
+    };
+  },
+
+  async disconnect(userId: string): Promise<void> {
+    await db('gmail_tokens').where({ user_id: userId }).del();
+  },
+
+  async getValidClient(userId: string) {
+    const token = await db('gmail_tokens').where({ user_id: userId, is_valid: true }).first();
+    if (!token) return null;
+
+    const oauth2Client = createOAuthClient();
+    oauth2Client.setCredentials({
+      access_token: token.access_token,
+      refresh_token: token.refresh_token,
+      expiry_date: new Date(token.token_expiry).getTime(),
+    });
+
+    const expiryMs = new Date(token.token_expiry).getTime();
+    if (Date.now() > expiryMs - 5 * 60 * 1000) {
+      try {
+        const { credentials } = await oauth2Client.refreshAccessToken();
+        oauth2Client.setCredentials(credentials);
+        await db('gmail_tokens').where({ user_id: userId }).update({
+          access_token: credentials.access_token!,
+          token_expiry: new Date(credentials.expiry_date!),
+          updated_at: db.fn.now(),
+        });
+      } catch {
+        await db('gmail_tokens').where({ user_id: userId }).update({ is_valid: false, updated_at: db.fn.now() });
+        await notificationService.create(
+          userId,
+          'Gmail connection lost',
+          'Your Gmail connection has expired. Reconnect in Settings.'
+        );
+        return null;
+      }
+    }
+
+    return google.gmail({ version: 'v1', auth: oauth2Client });
+  },
+
+  async fetchUnreadEmails(userId: string, gmailClient: ReturnType<typeof google.gmail>) {
+    const token = await db('gmail_tokens').where({ user_id: userId }).first();
+    const sinceDate = token?.last_sync_at
+      ? new Date(token.last_sync_at)
+      : new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const afterEpoch = Math.floor(sinceDate.getTime() / 1000);
+
+    const listRes = await gmailClient.users.messages.list({
+      userId: 'me',
+      q: `is:unread (in:inbox OR in:promotions) after:${afterEpoch}`,
+      maxResults: 50,
+    });
+
+    const messages = listRes.data.messages ?? [];
+    const emails = [];
+
+    for (const msg of messages) {
+      const full = await gmailClient.users.messages.get({
+        userId: 'me',
+        id: msg.id!,
+        format: 'full',
+      });
+
+      const headers = full.data.payload?.headers ?? [];
+      const subject = headers.find(h => h.name === 'Subject')?.value ?? '';
+      const sender = headers.find(h => h.name === 'From')?.value ?? '';
+      const dateHeader = headers.find(h => h.name === 'Date')?.value;
+      const receivedAt = dateHeader ? new Date(dateHeader) : new Date();
+
+      let body = '';
+      const parts = full.data.payload?.parts ?? [];
+      const textPart = parts.find(p => p.mimeType === 'text/plain') ?? full.data.payload;
+      if (textPart?.body?.data) {
+        body = Buffer.from(textPart.body.data, 'base64').toString('utf-8');
+      }
+      body = body.slice(0, 2000);
+
+      emails.push({ messageId: msg.id!, subject, sender, body, receivedAt });
+    }
+
+    return emails;
+  },
+};

--- a/backend/src/services/gmailSyncService.ts
+++ b/backend/src/services/gmailSyncService.ts
@@ -1,0 +1,127 @@
+import db from '../config/database';
+import { gmailService } from './gmailService';
+import { classifyEmail } from './emailClassifier';
+import { cardService } from './cardService';
+import { notificationService } from './notificationService';
+
+function normalize(str: string): string {
+  return str.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function isContainsMatch(cardCompany: string, extractedCompany: string): boolean {
+  const a = normalize(cardCompany);
+  const b = normalize(extractedCompany);
+  return a.includes(b) || b.includes(a);
+}
+
+export interface SyncSummary {
+  scanned: number;
+  moved: number;
+  ambiguous: number;
+  noMatch: number;
+  lowConfidence: number;
+  notRejection: number;
+}
+
+export async function syncUserGmail(userId: string): Promise<SyncSummary> {
+  const summary: SyncSummary = { scanned: 0, moved: 0, ambiguous: 0, noMatch: 0, lowConfidence: 0, notRejection: 0 };
+
+  const gmailClient = await gmailService.getValidClient(userId);
+  if (!gmailClient) return summary;
+
+  const emails = await gmailService.fetchUnreadEmails(userId, gmailClient);
+  const rejectionStage = await db('stages').where({ user_id: userId, is_rejection_stage: true }).first();
+  if (!rejectionStage) return summary;
+
+  for (const email of emails) {
+    const alreadyProcessed = await db('processed_emails')
+      .where({ user_id: userId, gmail_message_id: email.messageId })
+      .first();
+    if (alreadyProcessed) continue;
+
+    summary.scanned++;
+
+    let classification;
+    try {
+      classification = await classifyEmail(email.subject, email.body);
+    } catch {
+      continue;
+    }
+
+    const baseLog = {
+      user_id: userId,
+      gmail_message_id: email.messageId,
+      subject: email.subject,
+      sender: email.sender,
+      received_at: email.receivedAt,
+      confidence: classification.confidence,
+      extracted_company: classification.companyName,
+    };
+
+    if (!classification.isRejection) {
+      await db('processed_emails').insert({ ...baseLog, action: 'not_rejection' });
+      summary.notRejection++;
+      continue;
+    }
+
+    if (classification.confidence < 0.9) {
+      await db('processed_emails').insert({ ...baseLog, action: 'low_confidence' });
+      await notificationService.create(
+        userId,
+        'Possible rejection — needs review',
+        `An email from ${classification.companyName ?? 'unknown company'} may be a rejection (low confidence)`,
+        { gmailMessageId: email.messageId }
+      );
+      summary.lowConfidence++;
+      continue;
+    }
+
+    if (!classification.companyName) {
+      await db('processed_emails').insert({ ...baseLog, action: 'no_match' });
+      summary.noMatch++;
+      continue;
+    }
+
+    const cards = await db('cards')
+      .join('stages', 'cards.stage_id', 'stages.id')
+      .where({ 'cards.user_id': userId })
+      .where('stages.is_rejection_stage', false)
+      .select('cards.*', 'stages.name as stage_name');
+
+    const matches = cards.filter(c => isContainsMatch(c.company_name, classification.companyName!));
+
+    if (matches.length === 0) {
+      await db('processed_emails').insert({ ...baseLog, action: 'no_match' });
+      await notificationService.create(
+        userId,
+        'Rejection email — no card found',
+        `Received a rejection from ${classification.companyName} but no matching card was found`,
+        { gmailMessageId: email.messageId, extractedCompany: classification.companyName }
+      );
+      summary.noMatch++;
+    } else if (matches.length > 1) {
+      await db('processed_emails').insert({ ...baseLog, action: 'ambiguous_match' });
+      await notificationService.create(
+        userId,
+        'Rejection email needs review',
+        `Received a rejection from ${classification.companyName} but multiple cards match`,
+        { gmailMessageId: email.messageId, extractedCompany: classification.companyName }
+      );
+      summary.ambiguous++;
+    } else {
+      const card = matches[0];
+      await cardService.moveCard(card.id, userId, rejectionStage.id, 0);
+      await db('processed_emails').insert({ ...baseLog, action: 'moved_to_rejected', card_id: card.id });
+      await notificationService.create(
+        userId,
+        'Application marked as Rejected',
+        `${card.company_name} – ${card.role_title} was moved to Rejected`,
+        { cardId: card.id, gmailMessageId: email.messageId }
+      );
+      summary.moved++;
+    }
+  }
+
+  await db('gmail_tokens').where({ user_id: userId }).update({ last_sync_at: db.fn.now(), updated_at: db.fn.now() });
+  return summary;
+}

--- a/backend/src/services/gmailSyncService.ts
+++ b/backend/src/services/gmailSyncService.ts
@@ -1,4 +1,5 @@
 import db from '../config/database';
+import logger from '../config/logger';
 import { gmailService } from './gmailService';
 import { classifyEmail } from './emailClassifier';
 import { cardService } from './cardService';
@@ -11,6 +12,9 @@ function normalize(str: string): string {
 function isContainsMatch(cardCompany: string, extractedCompany: string): boolean {
   const a = normalize(cardCompany);
   const b = normalize(extractedCompany);
+  // Reject matches where the extracted company name is too short (≤3 chars)
+  // to avoid over-matching (e.g. "AI" matches every company name).
+  if (b.length <= 3) return false;
   return a.includes(b) || b.includes(a);
 }
 
@@ -26,25 +30,55 @@ export interface SyncSummary {
 export async function syncUserGmail(userId: string): Promise<SyncSummary> {
   const summary: SyncSummary = { scanned: 0, moved: 0, ambiguous: 0, noMatch: 0, lowConfidence: 0, notRejection: 0 };
 
+  const gmailToken = await db('gmail_tokens').where({ user_id: userId, is_valid: true }).first();
+  if (!gmailToken) return summary;
+
   const gmailClient = await gmailService.getValidClient(userId);
   if (!gmailClient) return summary;
 
-  const emails = await gmailService.fetchUnreadEmails(userId, gmailClient);
-  const rejectionStage = await db('stages').where({ user_id: userId, is_rejection_stage: true }).first();
+  const lastSyncAt: Date | null = gmailToken.last_sync_at ? new Date(gmailToken.last_sync_at) : null;
+  const emails = await gmailService.fetchUnreadEmails(gmailClient, lastSyncAt);
+
+  // Hoist both lookup queries above the loop to avoid per-email round-trips
+  const [rejectionStage, cards] = await Promise.all([
+    db('stages').where({ user_id: userId, is_rejection_stage: true }).first(),
+    db('cards')
+      .join('stages', 'cards.stage_id', 'stages.id')
+      .where({ 'cards.user_id': userId })
+      .where('stages.is_rejection_stage', false)
+      .select('cards.*', 'stages.name as stage_name'),
+  ]);
   if (!rejectionStage) return summary;
 
+  // Batch-check which message IDs have already been processed (avoids N+1)
+  const messageIds = emails.map(e => e.messageId);
+  const processedRows = messageIds.length > 0
+    ? await db('processed_emails')
+        .where({ user_id: userId })
+        .whereIn('gmail_message_id', messageIds)
+        .select('gmail_message_id')
+    : [];
+  const processedSet = new Set(processedRows.map((r: { gmail_message_id: string }) => r.gmail_message_id));
+
   for (const email of emails) {
-    const alreadyProcessed = await db('processed_emails')
-      .where({ user_id: userId, gmail_message_id: email.messageId })
-      .first();
-    if (alreadyProcessed) continue;
+    if (processedSet.has(email.messageId)) continue;
 
     summary.scanned++;
 
     let classification;
     try {
       classification = await classifyEmail(email.subject, email.body);
-    } catch {
+    } catch (err) {
+      logger.error('Email classification failed', { userId, messageId: email.messageId, error: err });
+      // Mark as classifier_error so this email is not retried indefinitely
+      await db('processed_emails').insert({
+        user_id: userId,
+        gmail_message_id: email.messageId,
+        subject: email.subject,
+        sender: email.sender,
+        received_at: email.receivedAt,
+        action: 'classifier_error',
+      }).catch(() => {});
       continue;
     }
 
@@ -81,12 +115,6 @@ export async function syncUserGmail(userId: string): Promise<SyncSummary> {
       summary.noMatch++;
       continue;
     }
-
-    const cards = await db('cards')
-      .join('stages', 'cards.stage_id', 'stages.id')
-      .where({ 'cards.user_id': userId })
-      .where('stages.is_rejection_stage', false)
-      .select('cards.*', 'stages.name as stage_name');
 
     const matches = cards.filter(c => isContainsMatch(c.company_name, classification.companyName!));
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,12 +1,16 @@
 import { useState, useEffect } from 'react';
 import { Settings, Mail, CheckCircle, AlertTriangle, RefreshCw } from 'lucide-react';
 import { formatDistanceToNow, parseISO } from 'date-fns';
+import { useLocation } from 'react-router-dom';
 import { gmailApi } from '@/services/api';
-import type { GmailStatusData } from '@/services/api';
+import type { GmailStatusData, SyncSummary } from '@/services/api';
 
 export default function SettingsPage() {
   const [gmailStatus, setGmailStatus] = useState<GmailStatusData>({ connected: false });
   const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState<SyncSummary | null>(null);
+  const location = useLocation();
 
   useEffect(() => {
     gmailApi
@@ -14,12 +18,36 @@ export default function SettingsPage() {
       .then((data) => setGmailStatus(data))
       .catch(() => setGmailStatus({ connected: false }))
       .finally(() => setLoading(false));
-  }, []);
+  }, [location.search]);
 
   const isConnectedValid =
     gmailStatus.connected === true && gmailStatus.isValid === true;
   const isConnectedInvalid =
     gmailStatus.connected === true && gmailStatus.isValid === false;
+
+  async function handleConnect() {
+    const url = await gmailApi.getAuthUrl();
+    window.location.href = url;
+  }
+
+  async function handleSync() {
+    setSyncing(true);
+    setSyncResult(null);
+    try {
+      const result = await gmailApi.sync();
+      setSyncResult(result);
+      const updated = await gmailApi.getStatus();
+      setGmailStatus(updated);
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  async function handleDisconnect() {
+    await gmailApi.disconnect();
+    setGmailStatus({ connected: false });
+    setSyncResult(null);
+  }
 
   return (
     <div className="p-6 space-y-6 max-w-3xl mx-auto">
@@ -62,9 +90,7 @@ export default function SettingsPage() {
                   Connect your Gmail account to automatically detect rejection emails and update your board.
                 </p>
                 <button
-                  onClick={() => {
-                    // TODO: wire OAuth
-                  }}
+                  onClick={handleConnect}
                   className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
                 >
                   <Mail size={15} />
@@ -85,20 +111,22 @@ export default function SettingsPage() {
                     ? formatDistanceToNow(parseISO(gmailStatus.lastSyncAt), { addSuffix: true })
                     : 'Never synced yet'}
                 </div>
+                {syncResult && (
+                  <p className="text-sm text-gray-600">
+                    {syncResult.scanned} emails scanned · {syncResult.moved} card{syncResult.moved !== 1 ? 's' : ''} moved to Rejected
+                  </p>
+                )}
                 <div className="flex items-center gap-3">
                   <button
-                    onClick={() => {
-                      // TODO: wire sync
-                    }}
-                    className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
+                    onClick={handleSync}
+                    disabled={syncing}
+                    className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition disabled:opacity-60"
                   >
-                    <RefreshCw size={14} />
-                    Sync Now
+                    <RefreshCw size={14} className={syncing ? 'animate-spin' : ''} />
+                    {syncing ? 'Syncing…' : 'Sync Now'}
                   </button>
                   <button
-                    onClick={() => {
-                      // TODO: wire disconnect
-                    }}
+                    onClick={handleDisconnect}
                     className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:border-red-300 hover:text-red-600 transition"
                   >
                     Disconnect
@@ -110,9 +138,7 @@ export default function SettingsPage() {
             {/* State 3 reconnect button */}
             {isConnectedInvalid && (
               <button
-                onClick={() => {
-                  // TODO: wire OAuth
-                }}
+                onClick={handleConnect}
                 className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition"
               >
                 <Mail size={15} />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ export default function SettingsPage() {
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(false);
   const [syncResult, setSyncResult] = useState<SyncSummary | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
   const location = useLocation();
 
   useEffect(() => {
@@ -33,20 +34,29 @@ export default function SettingsPage() {
   async function handleSync() {
     setSyncing(true);
     setSyncResult(null);
+    setSyncError(null);
     try {
       const result = await gmailApi.sync();
       setSyncResult(result);
       const updated = await gmailApi.getStatus();
       setGmailStatus(updated);
+    } catch {
+      setSyncError('Sync failed. Please try again.');
     } finally {
       setSyncing(false);
     }
   }
 
   async function handleDisconnect() {
-    await gmailApi.disconnect();
-    setGmailStatus({ connected: false });
-    setSyncResult(null);
+    if (!window.confirm('Disconnect Gmail? This will stop automatic rejection detection.')) return;
+    try {
+      await gmailApi.disconnect();
+      setGmailStatus({ connected: false });
+      setSyncResult(null);
+      setSyncError(null);
+    } catch {
+      setSyncError('Failed to disconnect. Please try again.');
+    }
   }
 
   return (
@@ -115,6 +125,9 @@ export default function SettingsPage() {
                   <p className="text-sm text-gray-600">
                     {syncResult.scanned} emails scanned · {syncResult.moved} card{syncResult.moved !== 1 ? 's' : ''} moved to Rejected
                   </p>
+                )}
+                {syncError && (
+                  <p className="text-sm text-red-600">{syncError}</p>
                 )}
                 <div className="flex items-center gap-3">
                   <button

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -230,10 +230,30 @@ export type GmailStatusData =
   | { connected: true; isValid: true; email: string; lastSyncAt: string | null }
   | { connected: true; isValid: false; email: string; lastSyncAt: string | null };
 
+export interface SyncSummary {
+  scanned: number;
+  moved: number;
+  ambiguous: number;
+  noMatch: number;
+  lowConfidence: number;
+  notRejection: number;
+}
+
 export const gmailApi = {
   getStatus: async (): Promise<GmailStatusData> => {
     const res = await api.get('/gmail/status');
     return snakeToCamel(res.data.data) as GmailStatusData;
+  },
+  getAuthUrl: async (): Promise<string> => {
+    const res = await api.get<{ url: string }>('/gmail/auth');
+    return res.data.url;
+  },
+  sync: async (): Promise<SyncSummary> => {
+    const res = await api.post('/gmail/sync');
+    return snakeToCamel(res.data.data) as SyncSummary;
+  },
+  disconnect: async (): Promise<void> => {
+    await api.delete('/gmail/disconnect');
   },
 };
 


### PR DESCRIPTION
## Summary
- Full Gmail OAuth2 flow — connect, disconnect, token refresh, revocation handling
- Email classifier using Vercel AI SDK + Claude Haiku, provider-switchable via `LLM_PROVIDER` env var
- Sync engine: fetches unread Gmail, classifies each email, matches to cards by company name, moves matched card to Rejected stage
- All outcomes logged to `processed_emails` (dedup + observability), notifications created for every event
- Settings page fully wired: Connect, Sync Now (with spinner + result summary), Disconnect
- GitHub Actions cron job triggers sync every 30 minutes

## Changes
- `migrations/012`: `is_rejection_stage` flag on `stages` table + backfill
- `migrations/013`: `gmail_tokens` table
- `migrations/014`: `processed_emails` table
- `authService`: new users get `is_rejection_stage=true` on Rejected stage
- `emailClassifier.ts`: Vercel AI SDK wrapper, Zod-validated output
- `gmailService.ts`: OAuth2, token storage/refresh, unread email fetching
- `gmailSyncService.ts`: full sync orchestration
- `routes/gmail.ts`: `/auth`, `/callback`, `/status`, `/disconnect`, `/sync`
- `SettingsPage.tsx`: all buttons wired
- `.github/workflows/gmail-sync.yml`: 30-min cron

## Test plan
- [ ] Connect Gmail via Settings page — OAuth flow completes, connected state shown
- [ ] Sync Now returns summary (e.g. "3 emails scanned · 1 card moved to Rejected")
- [ ] Rejection email with matching card → card moves to Rejected column + notification appears
- [ ] Ambiguous/no-match cases → notification appears, card not moved
- [ ] Disconnect removes token, settings returns to disconnected state
- [ ] GitHub Actions workflow_dispatch triggers sync successfully (after issue #92 secrets are set)

## Related issues
Closes #87, #88, #89, #90, #91, #93
Parent PRD: #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)