### PR TITLE
fix: switch default LLM provider to Google Gemini

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,3 +15,9 @@ CORS_ORIGIN=http://localhost:5173
 
 # Logging
 LOG_LEVEL=debug
+
+# LLM (email classifier)
+# Provider to use for email classification. Options: 'google' (default), 'anthropic'
+LLM_PROVIDER=google
+GOOGLE_AI_API_KEY=your-google-ai-api-key
+ANTHROPIC_API_KEY=your-anthropic-api-key

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",
+        "@ai-sdk/google": "^3.0.72",
         "ai": "^4.0.0",
         "bcryptjs": "^2.4.3",
         "compression": "^1.8.1",
@@ -58,6 +59,51 @@
       },
       "peerDependencies": {
         "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "3.0.72",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.72.tgz",
+      "integrity": "sha512-9EVG0AdUhs0hJ2+sqRb4IURZnsBahuU1CQELu+hfItm0wUTzxnVhIbQ4/jJkG/QFPtBUvMefCwDT7HX8T2HVbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -1157,6 +1203,12 @@
         "color": "^5.0.2",
         "text-hex": "1.0.x"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -2805,6 +2857,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.0.0",
-        "@ai-sdk/google": "^3.0.72",
+        "@ai-sdk/google": "^1.0.0",
         "ai": "^4.0.0",
         "bcryptjs": "^2.4.3",
         "compression": "^1.8.1",
@@ -62,48 +62,19 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.72",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.72.tgz",
-      "integrity": "sha512-9EVG0AdUhs0hJ2+sqRb4IURZnsBahuU1CQELu+hfItm0wUTzxnVhIbQ4/jJkG/QFPtBUvMefCwDT7HX8T2HVbQ==",
+      "version": "1.2.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-1.2.22.tgz",
+      "integrity": "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.27"
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.27",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
-      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
+        "zod": "^3.0.0"
       }
     },
     "node_modules/@ai-sdk/provider": {
@@ -1203,12 +1174,6 @@
         "color": "^5.0.2",
         "text-hex": "1.0.x"
       }
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -2857,15 +2822,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.0.0",
+    "@ai-sdk/google": "^3.0.72",
     "ai": "^4.0.0",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.0.0",
-    "@ai-sdk/google": "^3.0.0",
+    "@ai-sdk/google": "^1.0.0",
     "ai": "^4.0.0",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.0.0",
-    "@ai-sdk/google": "^3.0.72",
+    "@ai-sdk/google": "^3.0.0",
     "ai": "^4.0.0",
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.1",

--- a/backend/src/services/emailClassifier.ts
+++ b/backend/src/services/emailClassifier.ts
@@ -1,5 +1,6 @@
 import { generateObject } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { z } from 'zod';
 
 const classificationSchema = z.object({
@@ -10,15 +11,17 @@ const classificationSchema = z.object({
 
 export type EmailClassification = z.infer<typeof classificationSchema>;
 
-// Instantiate the provider once at module level rather than on every call
 const anthropicProvider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+const googleProvider = createGoogleGenerativeAI({ apiKey: process.env.GOOGLE_AI_API_KEY });
 
 function getModel() {
-  const provider = process.env.LLM_PROVIDER ?? 'anthropic';
+  const provider = process.env.LLM_PROVIDER ?? 'google';
   switch (provider) {
     case 'anthropic':
-    default:
       return anthropicProvider('claude-3-haiku-20240307');
+    case 'google':
+    default:
+      return googleProvider('gemini-2.5-flash-lite');
   }
 }
 

--- a/backend/src/services/emailClassifier.ts
+++ b/backend/src/services/emailClassifier.ts
@@ -11,6 +11,17 @@ const classificationSchema = z.object({
 
 export type EmailClassification = z.infer<typeof classificationSchema>;
 
+// Instantiate providers once at module level rather than on every call.
+// Warn at startup if the active provider's key is missing so misconfiguration
+// is caught early rather than surfacing as a cryptic SDK error at runtime.
+const activeProvider = process.env.LLM_PROVIDER ?? 'google';
+if (activeProvider === 'google' && !process.env.GOOGLE_AI_API_KEY) {
+  console.warn('[emailClassifier] GOOGLE_AI_API_KEY is not set — email classification will fail');
+}
+if (activeProvider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
+  console.warn('[emailClassifier] ANTHROPIC_API_KEY is not set — email classification will fail');
+}
+
 const anthropicProvider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 const googleProvider = createGoogleGenerativeAI({ apiKey: process.env.GOOGLE_AI_API_KEY });
 


### PR DESCRIPTION
## Summary
- Adds `@ai-sdk/google` as a dependency to support Google Generative AI models
- Changes the default LLM provider from Anthropic to Google (`gemini-2.5-flash-lite`)
- Anthropic (`claude-3-haiku-20240307`) remains selectable via `LLM_PROVIDER=anthropic`

## Changes
- `backend/src/services/emailClassifier.ts`: import and instantiate `createGoogleGenerativeAI`, update `getModel()` to default to `google`, add `GOOGLE_AI_API_KEY` env var usage
- `backend/package.json` + `backend/package-lock.json`: add `@ai-sdk/google` dependency

## Test plan
- [ ] Set `GOOGLE_AI_API_KEY` in the backend environment
- [ ] Verify email classification works end-to-end with the Google provider (default, no `LLM_PROVIDER` set)
- [ ] Set `LLM_PROVIDER=anthropic` and verify Anthropic classification still works
- [ ] Verify `LLM_PROVIDER=google` explicitly also routes to Google

🤖 Generated with [Claude Code](https://claude.com/claude-code)