### PR TITLE
fix: switch LLM to Google Gemini and fix multipart email body extraction

### DIFF
--- a/backend/src/services/emailClassifier.ts
+++ b/backend/src/services/emailClassifier.ts
@@ -22,17 +22,24 @@ if (activeProvider === 'anthropic' && !process.env.ANTHROPIC_API_KEY) {
   console.warn('[emailClassifier] ANTHROPIC_API_KEY is not set — email classification will fail');
 }
 
-const anthropicProvider = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
-const googleProvider = createGoogleGenerativeAI({ apiKey: process.env.GOOGLE_AI_API_KEY });
+// Only instantiate the active provider's client — the inactive provider's API
+// key may be absent, and some SDKs validate at construction time.
+const anthropicProvider = activeProvider === 'anthropic'
+  ? createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+  : null;
+const googleProvider = activeProvider === 'google'
+  ? createGoogleGenerativeAI({ apiKey: process.env.GOOGLE_AI_API_KEY })
+  : null;
 
 function getModel() {
-  const provider = process.env.LLM_PROVIDER ?? 'google';
-  switch (provider) {
+  // Use the module-level constant — avoids re-reading env per call and keeps
+  // getModel() consistent with the startup warning above.
+  switch (activeProvider) {
     case 'anthropic':
-      return anthropicProvider('claude-3-haiku-20240307');
+      return anthropicProvider!('claude-3-haiku-20240307');
     case 'google':
     default:
-      return googleProvider('gemini-2.5-flash-lite');
+      return googleProvider!('gemini-2.5-flash-lite');
   }
 }
 

--- a/backend/src/services/gmailService.ts
+++ b/backend/src/services/gmailService.ts
@@ -43,6 +43,38 @@ function verifyOAuthStateToken(state: string): string {
   }
 }
 
+type GmailPart = { mimeType?: string | null; body?: { data?: string | null } | null; parts?: GmailPart[] | null };
+
+function extractTextBody(payload: GmailPart | null | undefined): string {
+  if (!payload) return '';
+  if (payload.mimeType === 'text/plain' && payload.body?.data) {
+    return Buffer.from(payload.body.data, 'base64').toString('utf-8');
+  }
+  if (payload.parts) {
+    // Prefer text/plain at any depth
+    for (const part of payload.parts) {
+      if (part.mimeType === 'text/plain' && part.body?.data) {
+        return Buffer.from(part.body.data, 'base64').toString('utf-8');
+      }
+    }
+    // Recurse into nested multipart containers
+    for (const part of payload.parts) {
+      if (part.mimeType?.startsWith('multipart/')) {
+        const result = extractTextBody(part);
+        if (result) return result;
+      }
+    }
+    // Last resort: strip HTML tags from text/html part
+    for (const part of payload.parts) {
+      if (part.mimeType === 'text/html' && part.body?.data) {
+        const html = Buffer.from(part.body.data, 'base64').toString('utf-8');
+        return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+      }
+    }
+  }
+  return '';
+}
+
 export const gmailService = {
   getAuthUrl(userId: string): string {
     const oauth2Client = createOAuthClient();
@@ -159,13 +191,7 @@ export const gmailService = {
       const dateHeader = headers.find(h => h.name === 'Date')?.value;
       const receivedAt = dateHeader ? new Date(dateHeader) : new Date();
 
-      let body = '';
-      const parts = full.data.payload?.parts ?? [];
-      const textPart = parts.find(p => p.mimeType === 'text/plain') ?? full.data.payload;
-      if (textPart?.body?.data) {
-        body = Buffer.from(textPart.body.data, 'base64').toString('utf-8');
-      }
-      body = body.slice(0, 2000);
+      const body = extractTextBody(full.data.payload).slice(0, 2000);
 
       emails.push({ messageId: msg.id!, subject, sender, body, receivedAt });
     }

--- a/backend/src/services/gmailService.ts
+++ b/backend/src/services/gmailService.ts
@@ -45,8 +45,12 @@ function verifyOAuthStateToken(state: string): string {
 
 type GmailPart = { mimeType?: string | null; body?: { data?: string | null } | null; parts?: GmailPart[] | null };
 
-function extractTextBody(payload: GmailPart | null | undefined): string {
-  if (!payload) return '';
+// depth cap prevents stack overflow on adversarially deep MIME trees (RFC 2046
+// allows arbitrary nesting; real-world emails are at most 3–4 levels deep)
+const MAX_MIME_DEPTH = 10;
+
+function extractTextBody(payload: GmailPart | null | undefined, depth = 0): string {
+  if (!payload || depth > MAX_MIME_DEPTH) return '';
   if (payload.mimeType === 'text/plain' && payload.body?.data) {
     return Buffer.from(payload.body.data, 'base64').toString('utf-8');
   }
@@ -60,7 +64,7 @@ function extractTextBody(payload: GmailPart | null | undefined): string {
     // Recurse into nested multipart containers
     for (const part of payload.parts) {
       if (part.mimeType?.startsWith('multipart/')) {
-        const result = extractTextBody(part);
+        const result = extractTextBody(part, depth + 1);
         if (result) return result;
       }
     }


### PR DESCRIPTION
## Summary
- Switches LLM provider from Anthropic to Google Gemini (`gemini-2.5-flash-lite`) via `@ai-sdk/google`
- Adds `LLM_PROVIDER` env var for zero-code provider switching
- Fixes recursive multipart email body extraction so rejection emails are correctly classified

## Changes
- `emailClassifier.ts`: replaced Anthropic with Google Generative AI provider, added `LLM_PROVIDER` switch
- `gmailService.ts`: replaced flat `parts.find()` body extraction with recursive `extractTextBody()` that handles nested MIME structure (`multipart/mixed > multipart/alternative > text/plain`)
- `package.json`: added `@ai-sdk/google ^1.0.0`, downgraded to `^1.0.0` for `ai@4.x` compatibility
- Committed updated `package-lock.json`

## Root Cause
Rejection emails from Grip Security and Hunters were classified as `not_rejection` because the body extraction returned empty string for nested multipart MIME structures. The LLM only saw the subject line, which lacks clear rejection language.

## Test plan
- [ ] Verify `processed_emails` is empty and `last_sync_at` is NULL (already reset)
- [ ] Run sync — 2 rejection emails should now be classified as `rejection` with high confidence
- [ ] Confirm cards for those companies are moved to Rejected stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)