### PR TITLE
fix: skip cards with empty normalized name in company matching

### DIFF
--- a/backend/src/services/gmailSyncService.ts
+++ b/backend/src/services/gmailSyncService.ts
@@ -12,9 +12,9 @@ function normalize(str: string): string {
 function isContainsMatch(cardCompany: string, extractedCompany: string): boolean {
   const a = normalize(cardCompany);
   const b = normalize(extractedCompany);
-  // Reject matches where the extracted company name is too short (≤3 chars)
-  // to avoid over-matching (e.g. "AI" matches every company name).
-  if (b.length <= 3) return false;
+  // Skip cards whose name has no ASCII alphanumeric characters (e.g. Hebrew-only names)
+  // and skip extracted names that are too short to be meaningful.
+  if (a.length === 0 || b.length <= 3) return false;
   return a.includes(b) || b.includes(a);
 }
 


### PR DESCRIPTION
## Summary
- Adds a guard in `isContainsMatch` so cards whose name normalizes to an empty string are never matched against any extracted company
- Prevents Hebrew-only card names (e.g. `מפאת`) from triggering `ambiguous_match` on every rejection email

## Root cause
`normalize()` strips non-ASCII characters. A card named entirely in Hebrew normalizes to `''`. In JavaScript, `"anystring".includes("")` is always `true`, so the card matched every extracted company name. With 2+ such matches the sync classified the result as `ambiguous_match`, blocking every rejection email from being processed.

## Changes
- `backend/src/services/gmailSyncService.ts` — added `a.length === 0` guard in `isContainsMatch` alongside the existing `b.length <= 3` guard

## Test plan
- [ ] Truncate the `processed_emails` table and reset `last_sync_at` to NULL on the affected account
- [ ] Re-run Gmail sync and verify rejection emails now link to the correct card instead of returning `ambiguous_match`
- [ ] Confirm Hebrew-only cards produce no match (not an ambiguous match) in the sync log

🤖 Generated with [Claude Code](https://claude.com/claude-code)