### PR TITLE
refactor: client-side board search with useDeferredValue and React.memo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,189 @@
+# Claude Instructions for JobFlow
+
+## Branch Rule — Applies to ALL Code Changes
+
+**Every code change — feature, bug fix, refactor, experiment, or anything else — must live on a dedicated branch. No exceptions. Never commit directly to `main`.**
+
+If Claude does not know the purpose of the change, it must ask the user before writing any code:
+> "Before I start, what is the goal of this change? (new feature, bug fix, refactor, learning experiment, etc.) — I need this to name the branch correctly."
+
+**Branch naming convention by type:**
+
+| Purpose | Prefix | Example |
+|---------|--------|---------|
+| New feature | `feature/` | `feature/drag-and-drop-cards` |
+| Bug fix | `fix/` | `fix/search-not-clearing-filters` |
+| Refactor / cleanup | `refactor/` | `refactor/client-side-search` |
+| Learning / experiment | `experiment/` | `experiment/use-deferred-value` |
+| Chore / config / deps | `chore/` | `chore/upgrade-react-19` |
+| Docs | `docs/` | `docs/api-reference` |
+
+Branch off the latest `main` unless the user specifies otherwise:
+```bash
+git checkout main
+git pull origin main
+git checkout -b <prefix>/<short-kebab-case-description>
+```
+
+---
+
+## Development Workflow
+
+Every code change must follow this exact workflow — no exceptions.
+
+---
+
+### Step 1: Create a Branch
+
+Before writing any code, determine the purpose and create the appropriate branch (see Branch Rule above). If the purpose is unclear, ask first.
+
+---
+
+### Step 2: Implement the Change
+
+Make all code changes on the branch. Keep changes focused — only modify what is necessary for the stated purpose. Do not refactor unrelated code, add unnecessary comments, or over-engineer.
+
+**External dependencies must be verified before use.** If a plan or task requires calling an external API, loading from a third-party URL, or depending on any service outside the codebase, Claude must confirm it is reachable and working before writing code that depends on it. If research agents report that a dependency is unreachable, broken, or returns errors — stop, surface this to the user, and agree on an alternative before proceeding. Never implement code that relies on a dependency known to be broken.
+
+---
+
+### Step 3: Commit the Changes
+
+Stage and commit with a clear, structured commit message.
+
+**Commit message format:**
+```
+<type>: <concise summary in imperative mood>
+
+<body — what changed and why, not how>
+- bullet points for multiple changes
+- reference any relevant context
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+**Types:** `feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`
+
+Example:
+```
+feat: add drag-and-drop reordering for kanban cards
+
+- Cards can now be dragged between columns
+- Order persists to the backend via PATCH /api/cards/:id
+- Drag handle shown on hover to avoid accidental drags
+```
+
+Commands:
+```bash
+git add <specific files>
+git commit -m "$(cat <<'EOF'
+feat: your message here
+
+- detail 1
+- detail 2
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Step 4: Create a Pull Request
+
+Push the branch and open a PR from the branch to `main`.
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<concise PR title>" --body "$(cat <<'EOF'
+## Summary
+- What this PR does (1-3 bullets)
+
+## Changes
+- List of key changes
+
+## Test plan
+- [ ] Manual test steps or scenarios
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL to the user so they can see it.
+
+---
+
+### Step 5: Run Code Review Agent
+
+**This step is mandatory and must run after Step 4 (PR creation) — no exceptions.**
+Any code review that happened during implementation (e.g. as part of a plan file's internal agent phases) does NOT count as this step. Even if a review was already done, this step must still run independently after the PR exists.
+
+The goal is that the human can see the entire review process directly on GitHub — review comments first, then a follow-up commit with the fixes. The sequence must always be:
+
+1. Post review comments on the PR
+2. Fix the issues
+3. Push a fix commit
+
+**Never commit fixes before posting the review comments.** The comments must appear on GitHub before the fix commit, so the human can see what was found and why it was fixed.
+
+After the PR is created, run a Code Review agent on the feature branch changes. The agent must:
+
+**5a. Review the diff** and evaluate:
+- **Best practices** — idiomatic code, consistency with the existing codebase
+- **Code efficiency** — unnecessary re-renders, N+1 queries, redundant operations
+- **Security issues** — XSS, injection, exposed secrets, insecure defaults, OWASP Top 10
+- **Code quality** — readability, naming, dead code, missing error handling at system boundaries
+
+**5b. Post review comments on GitHub** using `gh pr review` — before making any fixes. Use `--comment` to post inline comments and a general summary. Every issue found must appear as a comment on the PR. If no issues are found, post a comment confirming the review passed.
+
+```bash
+gh pr review <PR-number> --comment --body "..."
+```
+
+**5c. Fix all issues found**, then push a fix commit on the feature branch:
+
+```bash
+git add <files>
+git commit -m "$(cat <<'EOF'
+fix: address code review findings
+
+- <issue 1 and why it was fixed>
+- <issue 2 and why it was fixed>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+git push origin <branch-name>
+```
+
+If there are no issues, skip the fix commit — but still post the passing review comment in 5b.
+
+After the fix commit is pushed, the agent summarizes:
+1. What issues were found and posted as review comments
+2. What was fixed and committed
+
+---
+
+### Step 6: Work is Done — Await Human Review
+
+After the code review agent finishes, the workflow is complete.
+
+**Claude must never merge the feature branch into main.**
+Only the human can approve and merge the PR. This is a hard rule.
+
+---
+
+## Summary
+
+| Step | Who | Action |
+|------|-----|--------|
+| 0 | Claude | Determine purpose → ask if unclear → name and create branch |
+| 1 | Claude | Create branch (feature/, fix/, refactor/, experiment/, chore/, docs/) |
+| 2 | Claude | Implement the change |
+| 3 | Claude | Commit with clear message |
+| 4 | Claude | Push and create PR to main |
+| 5a | Claude (agent) | Review diff — evaluate best practices, efficiency, security, quality |
+| 5b | Claude (agent) | Post all findings as GitHub PR review comments (before any fixes) |
+| 5c | Claude (agent) | Fix issues + push fix commit (or confirm passing if none found) |
+| 6 | Human | Review PR and merge when satisfied |

--- a/frontend/src/components/Board/Board.tsx
+++ b/frontend/src/components/Board/Board.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, memo } from 'react';
 import {
   DndContext,
   DragOverlay,
@@ -33,7 +33,7 @@ interface BoardProps {
 
 type DragType = 'card' | 'column' | null;
 
-export default function Board({
+function Board({
   stages, cards, loading, onMoveCard, onCardClick, onAddCard,
   onEditStage, onDeleteStage, onReorderStages, onResizeStage, onAddStage,
 }: BoardProps) {
@@ -219,3 +219,5 @@ export default function Board({
     </DndContext>
   );
 }
+
+export default memo(Board);

--- a/frontend/src/components/Board/Board.tsx
+++ b/frontend/src/components/Board/Board.tsx
@@ -19,7 +19,10 @@ import { Plus } from 'lucide-react';
 
 interface BoardProps {
   stages: Stage[];
+  /** Full card set — used for DnD position calculations. */
   cards: Card[];
+  /** Filtered card set — used only for rendering per column. Defaults to cards when not provided. */
+  displayCards?: Card[];
   loading: boolean;
   onMoveCard: (cardId: string, stageId: string, position: number) => void;
   onCardClick: (cardId: string) => void;
@@ -34,9 +37,10 @@ interface BoardProps {
 type DragType = 'card' | 'column' | null;
 
 function Board({
-  stages, cards, loading, onMoveCard, onCardClick, onAddCard,
+  stages, cards, displayCards, loading, onMoveCard, onCardClick, onAddCard,
   onEditStage, onDeleteStage, onReorderStages, onResizeStage, onAddStage,
 }: BoardProps) {
+  const renderCards = displayCards ?? cards;
   const [activeCard, setActiveCard] = useState<Card | null>(null);
   const [activeColumn, setActiveColumn] = useState<Stage | null>(null);
   const [dragType, setDragType] = useState<DragType>(null);
@@ -46,12 +50,22 @@ function Board({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
+  // Full card set — used for DnD position calculations to avoid position corruption when search filters are active.
   const getCardsByStage = useCallback(
     (stageId: string) =>
       cards
         .filter((c) => c.stageId === stageId)
         .sort((a, b) => a.position - b.position),
     [cards]
+  );
+
+  // Display card set — used for rendering per column (may be a filtered subset).
+  const getDisplayCardsByStage = useCallback(
+    (stageId: string) =>
+      renderCards
+        .filter((c) => c.stageId === stageId)
+        .sort((a, b) => a.position - b.position),
+    [renderCards]
   );
 
   const sortedStages = [...stages].sort((a, b) => a.position - b.position);
@@ -174,7 +188,7 @@ function Board({
             <SortableColumn
               key={stage.id}
               stage={stage}
-              cards={getCardsByStage(stage.id)}
+              cards={getDisplayCardsByStage(stage.id)}
               onCardClick={onCardClick}
               onAddCard={() => onAddCard(stage.id)}
               onEditStage={onEditStage || (() => {})}

--- a/frontend/src/components/Board/Column.tsx
+++ b/frontend/src/components/Board/Column.tsx
@@ -136,7 +136,7 @@ export default function Column({ stage, cards, onCardClick, onAddCard, onEditSta
       <SortableContext items={cardIds} strategy={verticalListSortingStrategy}>
         <div ref={setNodeRef} className="board-column-cards min-h-[60px]">
           {cards.map((card) => (
-            <SortableCard key={card.id} card={card} onClick={() => onCardClick(card.id)} />
+            <SortableCard key={card.id} card={card} onCardClick={onCardClick} />
           ))}
         </div>
       </SortableContext>

--- a/frontend/src/components/Board/SortableCard.tsx
+++ b/frontend/src/components/Board/SortableCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { Card } from '@/types';
@@ -5,10 +6,10 @@ import CardPreview from '@/components/Card/CardPreview';
 
 interface SortableCardProps {
   card: Card;
-  onClick: () => void;
+  onCardClick: (id: string) => void;
 }
 
-export default function SortableCard({ card, onClick }: SortableCardProps) {
+function SortableCard({ card, onCardClick }: SortableCardProps) {
   const {
     attributes,
     listeners,
@@ -30,12 +31,13 @@ export default function SortableCard({ card, onClick }: SortableCardProps) {
       {...attributes}
       {...listeners}
       className={`board-card ${isDragging ? 'board-card-ghost' : ''}`}
-      onClick={(e) => {
-        // Don't fire click when finishing a drag
-        if (!isDragging) onClick();
+      onClick={() => {
+        if (!isDragging) onCardClick(card.id);
       }}
     >
       <CardPreview card={card} />
     </div>
   );
 }
+
+export default memo(SortableCard);

--- a/frontend/src/components/Board/SortableCard.tsx
+++ b/frontend/src/components/Board/SortableCard.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { Card } from '@/types';
@@ -24,6 +24,10 @@ function SortableCard({ card, onCardClick }: SortableCardProps) {
     transition,
   };
 
+  const handleClick = useCallback(() => {
+    if (!isDragging) onCardClick(card.id);
+  }, [isDragging, onCardClick, card.id]);
+
   return (
     <div
       ref={setNodeRef}
@@ -31,9 +35,7 @@ function SortableCard({ card, onCardClick }: SortableCardProps) {
       {...attributes}
       {...listeners}
       className={`board-card ${isDragging ? 'board-card-ghost' : ''}`}
-      onClick={() => {
-        if (!isDragging) onCardClick(card.id);
-      }}
+      onClick={handleClick}
     >
       <CardPreview card={card} />
     </div>

--- a/frontend/src/components/Search/SearchBar.tsx
+++ b/frontend/src/components/Search/SearchBar.tsx
@@ -1,46 +1,34 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import type { CardFilters, Stage } from '@/types';
 import { Search, X, SlidersHorizontal } from 'lucide-react';
 import { useAutocomplete } from '@/hooks/useAutocomplete';
 import AutocompleteDropdown from '@/components/AutocompleteDropdown';
 
 interface SearchBarProps {
-  filters: CardFilters;
-  onFiltersChange: (filters: CardFilters) => void;
+  filters: Omit<CardFilters, 'search'>;
+  onFiltersChange: (filters: Omit<CardFilters, 'search'>) => void;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
   stages: Stage[];
 }
 
-export default function SearchBar({ filters, onFiltersChange, stages }: SearchBarProps) {
-  const [searchText, setSearchText] = useState(filters.search || '');
+export default function SearchBar({ filters, onFiltersChange, searchQuery, onSearchChange, stages }: SearchBarProps) {
   const [showFilters, setShowFilters] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const { suggestions, isLoading, triggerInit, query } = useAutocomplete();
 
+  // Drive the trie autocomplete from the controlled searchQuery prop
   useEffect(() => {
-    debounceRef.current = setTimeout(() => {
-      const newSearch = searchText || undefined;
-      if (newSearch !== filters.search) {
-        onFiltersChange({ ...filters, search: newSearch });
-      }
-    }, 300);
-    return () => clearTimeout(debounceRef.current);
-  }, [searchText]);
-
-  useEffect(() => {
-    if (!searchText) return;
-    query(searchText);
-  }, [searchText, query]);
+    if (!searchQuery) return;
+    query(searchQuery);
+  }, [searchQuery, query]);
 
   const handleSelect = useCallback(
     (word: string) => {
-      setSearchText(word);
+      onSearchChange(word);
       setInputFocused(false);
-      // Cancel the pending debounce and fire immediately
-      clearTimeout(debounceRef.current);
-      onFiltersChange({ ...filters, search: word || undefined });
     },
-    [filters, onFiltersChange],
+    [onSearchChange],
   );
 
   const handleDismiss = useCallback(() => {
@@ -49,10 +37,10 @@ export default function SearchBar({ filters, onFiltersChange, stages }: SearchBa
 
   const showDropdown = inputFocused && (isLoading || suggestions.length > 0);
 
-  const hasActiveFilters = filters.stageId || filters.priority || filters.workMode;
+  const hasActiveFilters = filters.stageId || filters.priority || filters.workMode || searchQuery;
 
   const clearFilters = () => {
-    setSearchText('');
+    onSearchChange('');
     setInputFocused(false);
     onFiltersChange({});
   };
@@ -72,8 +60,8 @@ export default function SearchBar({ filters, onFiltersChange, stages }: SearchBa
           <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
           <input
             type="text"
-            value={searchText}
-            onChange={(e) => setSearchText(e.target.value)}
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
             onFocus={() => {
               setInputFocused(true);
               triggerInit();
@@ -89,9 +77,9 @@ export default function SearchBar({ filters, onFiltersChange, stages }: SearchBa
               onDismiss={handleDismiss}
             />
           )}
-          {searchText && (
+          {searchQuery && (
             <button
-              onClick={() => setSearchText('')}
+              onClick={() => onSearchChange('')}
               className="absolute right-2.5 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
             >
               <X size={14} />

--- a/frontend/src/components/Search/SearchBar.tsx
+++ b/frontend/src/components/Search/SearchBar.tsx
@@ -98,7 +98,7 @@ export default function SearchBar({ filters, onFiltersChange, searchQuery, onSea
         >
           <SlidersHorizontal size={14} />
           Filters
-          {hasActiveFilters && (
+          {[filters.stageId, filters.priority, filters.workMode].filter(Boolean).length > 0 && (
             <span className="flex h-4 w-4 items-center justify-center rounded-full bg-primary-600 text-[10px] text-white">
               {[filters.stageId, filters.priority, filters.workMode].filter(Boolean).length}
             </span>

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useDeferredValue } from 'react';
 import { stagesApi, cardsApi } from '@/services/api';
 import type { Stage, Card, CardFilters } from '@/types';
 import Board from '@/components/Board/Board';
@@ -10,11 +10,24 @@ import StageForm from '@/components/Board/StageForm';
 import TodoPanel from '@/components/Todo/TodoPanel';
 import { useCardEvents } from '@/hooks/useCardEvents';
 
+type NonSearchFilters = Omit<CardFilters, 'search'>;
+
+function matchesSearch(card: Card, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    (card.companyName?.toLowerCase().includes(q) ?? false) ||
+    (card.roleTitle?.toLowerCase().includes(q) ?? false) ||
+    (card.notes?.toLowerCase().includes(q) ?? false)
+  );
+}
+
 export default function BoardPage() {
   const [stages, setStages] = useState<Stage[]>([]);
   const [cards, setCards] = useState<Card[]>([]);
   const [loading, setLoading] = useState(true);
-  const [filters, setFilters] = useState<CardFilters>({});
+  const [filters, setFilters] = useState<NonSearchFilters>({});
+  const [searchQuery, setSearchQuery] = useState('');
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [createStageId, setCreateStageId] = useState<string>('');
@@ -26,6 +39,8 @@ export default function BoardPage() {
 
   useCardEvents({ setCards });
 
+  // Search is now client-side — fetchData no longer depends on the search query.
+  // Only stage/priority/workMode filters still hit the server.
   const fetchData = useCallback(async () => {
     try {
       const [stagesData, cardsData] = await Promise.all([
@@ -45,7 +60,16 @@ export default function BoardPage() {
     fetchData();
   }, [fetchData]);
 
-  const handleMoveCard = async (cardId: string, newStageId: string, newPosition: number) => {
+  // deferredSearch lags behind searchQuery during rapid typing.
+  // filteredCards only recomputes when deferredSearch settles, keeping
+  // the input responsive and protecting the Board tree from mid-typing re-renders.
+  const deferredSearch = useDeferredValue(searchQuery);
+  const filteredCards = useMemo(
+    () => cards.filter((card) => matchesSearch(card, deferredSearch)),
+    [cards, deferredSearch],
+  );
+
+  const handleMoveCard = useCallback(async (cardId: string, newStageId: string, newPosition: number) => {
     setCards((prev) =>
       prev.map((c) =>
         c.id === cardId ? { ...c, stageId: newStageId, position: newPosition } : c
@@ -63,7 +87,7 @@ export default function BoardPage() {
     } catch {
       fetchData();
     }
-  };
+  }, [fetchData]);
 
   const handleCardCreated = (card: Card) => {
     setCards((prev) => [...prev, card]);
@@ -79,44 +103,41 @@ export default function BoardPage() {
     setSelectedCardId(null);
   };
 
-  const handleAddCard = (stageId: string) => {
+  const handleAddCard = useCallback((stageId: string) => {
     setCreateStageId(stageId);
     setShowCreateForm(true);
-  };
+  }, []);
 
   // ── Stage handlers ──────────────────────────────────────────────────────────
 
-  const handleAddStage = () => {
+  const handleAddStage = useCallback(() => {
     setEditingStage(undefined);
     setShowStageForm(true);
-  };
+  }, []);
 
-  const handleEditStage = (stage: Stage) => {
+  const handleEditStage = useCallback((stage: Stage) => {
     setEditingStage(stage);
     setShowStageForm(true);
-  };
+  }, []);
 
   const handleStageSaved = (saved: Stage) => {
     if (editingStage) {
-      // Rename: update in place
       setStages((prev) => prev.map((s) => (s.id === saved.id ? saved : s)));
     } else {
-      // New stage: append
       setStages((prev) => [...prev, saved]);
     }
     setShowStageForm(false);
     setEditingStage(undefined);
   };
 
-  const handleDeleteStage = (stage: Stage) => {
+  const handleDeleteStage = useCallback((stage: Stage) => {
     setDeleteConfirmStage(stage);
-  };
+  }, []);
 
   const confirmDeleteStage = async () => {
     if (!deleteConfirmStage) return;
     try {
       await stagesApi.deleteStage(deleteConfirmStage.id);
-      // Refetch everything since cards were moved
       setDeleteConfirmStage(null);
       fetchData();
     } catch (err: any) {
@@ -125,8 +146,7 @@ export default function BoardPage() {
     }
   };
 
-  const handleResizeStage = async (stageId: string, width: number) => {
-    // Optimistic update
+  const handleResizeStage = useCallback(async (stageId: string, width: number) => {
     setStages((prev) => prev.map((s) => (s.id === stageId ? { ...s, width } : s)));
     try {
       const updated = await stagesApi.updateStage(stageId, { width });
@@ -134,10 +154,9 @@ export default function BoardPage() {
     } catch {
       fetchData();
     }
-  };
+  }, [fetchData]);
 
-  const handleReorderStages = async (stageIds: string[]) => {
-    // Optimistic update
+  const handleReorderStages = useCallback(async (stageIds: string[]) => {
     const reordered = stageIds.map((id, i) => {
       const stage = stages.find((s) => s.id === id)!;
       return { ...stage, position: i };
@@ -149,7 +168,7 @@ export default function BoardPage() {
     } catch {
       fetchData();
     }
-  };
+  }, [stages, fetchData]);
 
   const roleTitleSuggestions = useMemo(
     () => Array.from(new Set(cards.map((c) => c.roleTitle))).sort(),
@@ -163,14 +182,20 @@ export default function BoardPage() {
   return (
     <div className="flex flex-col h-full overflow-y-auto">
       <ReminderBanner />
-      <SearchBar filters={filters} onFiltersChange={setFilters} stages={stages} />
+      <SearchBar
+        filters={filters}
+        onFiltersChange={setFilters}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        stages={stages}
+      />
       <div className="px-4 mb-4">
         <TodoPanel onTodoMutated={fetchData} />
       </div>
       <div className="flex-1 px-4 pb-4">
         <Board
           stages={stages}
-          cards={cards}
+          cards={filteredCards}
           loading={loading}
           onMoveCard={handleMoveCard}
           onCardClick={setSelectedCardId}

--- a/frontend/src/pages/BoardPage.tsx
+++ b/frontend/src/pages/BoardPage.tsx
@@ -89,19 +89,19 @@ export default function BoardPage() {
     }
   }, [fetchData]);
 
-  const handleCardCreated = (card: Card) => {
+  const handleCardCreated = useCallback((card: Card) => {
     setCards((prev) => [...prev, card]);
     setShowCreateForm(false);
-  };
+  }, []);
 
-  const handleCardUpdated = (updatedCard: Card) => {
+  const handleCardUpdated = useCallback((updatedCard: Card) => {
     setCards((prev) => prev.map((c) => (c.id === updatedCard.id ? updatedCard : c)));
-  };
+  }, []);
 
-  const handleCardDeleted = (cardId: string) => {
+  const handleCardDeleted = useCallback((cardId: string) => {
     setCards((prev) => prev.filter((c) => c.id !== cardId));
     setSelectedCardId(null);
-  };
+  }, []);
 
   const handleAddCard = useCallback((stageId: string) => {
     setCreateStageId(stageId);
@@ -120,7 +120,7 @@ export default function BoardPage() {
     setShowStageForm(true);
   }, []);
 
-  const handleStageSaved = (saved: Stage) => {
+  const handleStageSaved = useCallback((saved: Stage) => {
     if (editingStage) {
       setStages((prev) => prev.map((s) => (s.id === saved.id ? saved : s)));
     } else {
@@ -128,13 +128,13 @@ export default function BoardPage() {
     }
     setShowStageForm(false);
     setEditingStage(undefined);
-  };
+  }, [editingStage]);
 
   const handleDeleteStage = useCallback((stage: Stage) => {
     setDeleteConfirmStage(stage);
   }, []);
 
-  const confirmDeleteStage = async () => {
+  const confirmDeleteStage = useCallback(async () => {
     if (!deleteConfirmStage) return;
     try {
       await stagesApi.deleteStage(deleteConfirmStage.id);
@@ -144,7 +144,7 @@ export default function BoardPage() {
       console.error('Failed to delete stage:', err);
       alert(err.response?.data?.error?.message || 'Failed to delete stage');
     }
-  };
+  }, [deleteConfirmStage, fetchData]);
 
   const handleResizeStage = useCallback(async (stageId: string, width: number) => {
     setStages((prev) => prev.map((s) => (s.id === stageId ? { ...s, width } : s)));
@@ -195,7 +195,8 @@ export default function BoardPage() {
       <div className="flex-1 px-4 pb-4">
         <Board
           stages={stages}
-          cards={filteredCards}
+          cards={cards}
+          displayCards={filteredCards}
           loading={loading}
           onMoveCard={handleMoveCard}
           onCardClick={setSelectedCardId}


### PR DESCRIPTION
## Summary
- Moves board search filtering from server-side (API call per 300ms debounce) to client-side using React 18's `useDeferredValue` + `useMemo`
- Adds `React.memo` to `Board` and `SortableCard`, with `useCallback` on all handlers passed as props, so typing in the search box no longer triggers any re-renders in the card tree until the deferred value settles
- Fixes inline arrow function anti-pattern on `SortableCard` that was defeating memo

## Changes
- `BoardPage.tsx` — separate `searchQuery` state from server filters; add `useDeferredValue`, `filteredCards` memo, `useCallback` on all Board handlers
- `SearchBar.tsx` — remove debounce effect, become controlled via `searchQuery`/`onSearchChange` props
- `Board.tsx` — `memo(Board)`
- `SortableCard.tsx` — `memo(SortableCard)`, prop renamed from `onClick` to `onCardClick(id)`
- `Column.tsx` — pass `onCardClick` directly instead of inline arrow
- `CLAUDE.md` — new branch-naming rule for all change types

## Test plan
- [ ] Typing in search filters cards client-side with no network requests
- [ ] Stage / priority / work mode filters still trigger server fetch
- [ ] Clicking a card still opens the detail modal
- [ ] Drag and drop still works
- [ ] Clear all resets both search and other filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)