### PR TITLE
chore: three-agent code review orchestration (orchestrator + React reviewer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,13 +117,13 @@ Return the PR URL to the user so they can see it.
 ### Step 5: Run Code Review
 
 **This step is mandatory and must run after Step 4 (PR creation) — no exceptions.**
-Any code review that happened during implementation does NOT count as this step. Even if a review was already done, this step must still run independently after the PR exists.
+Any code review that happened during implementation (e.g. as part of a plan file's internal agent phases) does NOT count as this step. Even if a review was already done, this step must still run independently after the PR exists.
 
-Launch the `code-review-orchestrator` agent with the PR number. The orchestrator runs the full review automatically — no further prompting needed.
+Tell Claude — in natural language — to run the orchestrator with the PR number:
 
-```
-Use the code-review-orchestrator agent for PR #<number>
-```
+> "Run the code-review-orchestrator for PR #<number>"
+
+The orchestrator runs the full review automatically — no further prompting needed.
 
 **What the orchestrator does (fully automatic):**
 
@@ -172,5 +172,5 @@ Only the human can approve and merge the PR. This is a hard rule.
 | 2 | Claude | Implement the change |
 | 3 | Claude | Commit with clear message |
 | 4 | Claude | Push and create PR to main |
-| 5 | `code-review-orchestrator` | Phase 1: parallel review (security + domain specialists) → Phase 2: parallel fixes → verification → final status |
+| 5 | `code-review-orchestrator` | Phase 1: parallel review (security + domain specialists) → Phase 2: parallel fixes + verification → Phase 3: final status table posted to PR |
 | 6 | Human | Review PR and merge when satisfied |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,176 @@
+# Claude Instructions for JobFlow
+
+## Branch Rule — Applies to ALL Code Changes
+
+**Every code change — feature, bug fix, refactor, experiment, or anything else — must live on a dedicated branch. No exceptions. Never commit directly to `main`.**
+
+If Claude does not know the purpose of the change, it must ask the user before writing any code:
+> "Before I start, what is the goal of this change? (new feature, bug fix, refactor, learning experiment, etc.) — I need this to name the branch correctly."
+
+**Branch naming convention by type:**
+
+| Purpose | Prefix | Example |
+|---------|--------|---------|
+| New feature | `feature/` | `feature/drag-and-drop-cards` |
+| Bug fix | `fix/` | `fix/search-not-clearing-filters` |
+| Refactor / cleanup | `refactor/` | `refactor/client-side-search` |
+| Learning / experiment | `experiment/` | `experiment/use-deferred-value` |
+| Chore / config / deps | `chore/` | `chore/upgrade-react-19` |
+| Docs | `docs/` | `docs/api-reference` |
+
+Branch off the latest `main` unless the user specifies otherwise:
+```bash
+git checkout main
+git pull origin main
+git checkout -b <prefix>/<short-kebab-case-description>
+```
+
+---
+
+## Development Workflow
+
+Every code change must follow this exact workflow — no exceptions.
+
+---
+
+### Step 1: Create a Branch
+
+Before writing any code, determine the purpose and create the appropriate branch (see Branch Rule above). If the purpose is unclear, ask first.
+
+---
+
+### Step 2: Implement the Change
+
+Make all code changes on the branch. Keep changes focused — only modify what is necessary for the stated purpose. Do not refactor unrelated code, add unnecessary comments, or over-engineer.
+
+**External dependencies must be verified before use.** If a plan or task requires calling an external API, loading from a third-party URL, or depending on any service outside the codebase, Claude must confirm it is reachable and working before writing code that depends on it. If research agents report that a dependency is unreachable, broken, or returns errors — stop, surface this to the user, and agree on an alternative before proceeding. Never implement code that relies on a dependency known to be broken.
+
+---
+
+### Step 3: Commit the Changes
+
+Stage and commit with a clear, structured commit message.
+
+**Commit message format:**
+```
+<type>: <concise summary in imperative mood>
+
+<body — what changed and why, not how>
+- bullet points for multiple changes
+- reference any relevant context
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+**Types:** `feat`, `fix`, `refactor`, `style`, `docs`, `test`, `chore`
+
+Example:
+```
+feat: add drag-and-drop reordering for kanban cards
+
+- Cards can now be dragged between columns
+- Order persists to the backend via PATCH /api/cards/:id
+- Drag handle shown on hover to avoid accidental drags
+```
+
+Commands:
+```bash
+git add <specific files>
+git commit -m "$(cat <<'EOF'
+feat: your message here
+
+- detail 1
+- detail 2
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Step 4: Create a Pull Request
+
+Push the branch and open a PR from the branch to `main`.
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<concise PR title>" --body "$(cat <<'EOF'
+## Summary
+- What this PR does (1-3 bullets)
+
+## Changes
+- List of key changes
+
+## Test plan
+- [ ] Manual test steps or scenarios
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL to the user so they can see it.
+
+---
+
+### Step 5: Run Code Review
+
+**This step is mandatory and must run after Step 4 (PR creation) — no exceptions.**
+Any code review that happened during implementation does NOT count as this step. Even if a review was already done, this step must still run independently after the PR exists.
+
+Launch the `code-review-orchestrator` agent with the PR number. The orchestrator runs the full review automatically — no further prompting needed.
+
+```
+Use the code-review-orchestrator agent for PR #<number>
+```
+
+**What the orchestrator does (fully automatic):**
+
+**Phase 1 — Review (parallel):**
+- Detects which files changed: frontend, backend, or both
+- Spawns `react-code-reviewer` if frontend files changed
+- Spawns `backend-code-reviewer` if backend files changed
+- Performs security review itself (OWASP, secrets, auth, CORS, injection)
+- Each agent posts its own findings: a summary comment + inline line-level comments on the PR
+- All agents run in parallel; Phase 2 does not start until all Phase 1 agents finish
+
+**Phase 2 — Fix (parallel, after all reviews):**
+- Each domain agent reads the full PR conversation
+- Each fixes all issues in its domain (all severities)
+- Fixes are skipped if they risk breaking other features; tests are run after each fix; failing tests revert that specific fix and leave it as a PR comment
+- Each agent pushes its own fix commit
+- Orchestrator does a verification pass on all fix commits
+
+**Phase 3 — Final status:**
+- Orchestrator posts a summary table: which agents ran, how many issues found, how many fixed, what was skipped
+- Skipped fixes are listed for human resolution
+
+**The human only needs to act if:**
+- An ambiguous file is found (orchestrator will ask in chat — answer is cached for future PRs)
+- A fix was skipped due to cross-cutting risk (left as a PR comment)
+
+**Never commit fixes before posting review comments.** The GitHub comment trail must show findings first, then fixes.
+
+---
+
+### Step 6: Work is Done — Await Human Review
+
+After the orchestrator finishes, the workflow is complete.
+
+**Claude must never merge the feature branch into main.**
+Only the human can approve and merge the PR. This is a hard rule.
+
+---
+
+## Summary
+
+| Step | Who | Action |
+|------|-----|--------|
+| 0 | Claude | Determine purpose → ask if unclear → name and create branch |
+| 1 | Claude | Create branch (feature/, fix/, refactor/, experiment/, chore/, docs/) |
+| 2 | Claude | Implement the change |
+| 3 | Claude | Commit with clear message |
+| 4 | Claude | Push and create PR to main |
+| 5 | `code-review-orchestrator` | Phase 1: parallel review (security + domain specialists) → Phase 2: parallel fixes → verification → final status |
+| 6 | Human | Review PR and merge when satisfied |

--- a/docs/adr/0001-three-agent-code-review-orchestration.md
+++ b/docs/adr/0001-three-agent-code-review-orchestration.md
@@ -11,15 +11,16 @@ The original code review flow used a single `senior-code-reviewer` agent to revi
 
 Replace the single-agent review with a three-agent orchestration:
 
-1. **`code-review-orchestrator`** — always runs; performs security review itself; detects which files changed using a 3-layer strategy (path heuristics → file content → cached project memory); spawns only the relevant domain specialists; coordinates the two-phase execution; handles failure and runs a verification pass after fixes.
+1. **`code-review-orchestrator`** — always runs; performs security review itself; detects which files changed using a 3-layer strategy (path heuristics → file content → cached project memory); spawns only the relevant domain specialists; coordinates the three-phase execution; handles failure and runs a verification pass after fixes.
 
 2. **`react-code-reviewer`** — spawned when frontend files change; runs ESLint as a guardrail before semantic analysis; reviews React-specific failure modes (hooks correctness, concurrent rendering, performance, a11y, forms, TypeScript type safety); flags testing gaps in the React domain.
 
-3. **`backend-code-reviewer`** — spawned when backend files change; reviews Node/Express patterns, database logic, migrations, TypeScript type safety, and testing gaps in the backend domain.
+3. **`backend-code-reviewer`** — spawned when backend files change; reviews Node/Express patterns, database logic, migrations, TypeScript type safety, and testing gaps in the backend domain. **Status: planned — not yet implemented.** Until implemented, the orchestrator reviews backend files directly.
 
-**Two-phase execution:**
+**Three-phase execution:**
 - **Phase 1 (Review, parallel):** All relevant agents run simultaneously, each posting its own findings as a summary comment plus inline line-level PR comments.
-- **Phase 2 (Fix, parallel, after all reviews):** Each domain agent reads the entire PR conversation, applies fixes for all issues in its domain. Fixes are skipped if they risk breaking other features/functionality; tests are run after each fix; a failing test reverts that fix and leaves the original PR comment for human resolution.
+- **Phase 2 (Fix, parallel, after all reviews):** Each domain agent reads the entire PR conversation, applies fixes for all issues in its domain. Fixes are skipped if they risk breaking other features/functionality; tests are run after each fix; a failing test reverts that fix and leaves the original PR comment for human resolution. After all fix commits are pushed, the orchestrator performs a verification pass: it re-fetches the full diff and confirms all Critical and High findings have been addressed. Any regression introduced by a fix is caught here and flagged.
+- **Phase 3 (Final status):** The orchestrator posts a summary table on the PR listing which agents ran, how many issues were found, how many were fixed, and which fixes were skipped for human resolution.
 
 **Project-agnostic design:** All three agents live at `~/.claude/agents/` (global scope) so the methodology is portable across projects. File routing uses path heuristics and content analysis, falling back to cached project memory once the onboarding scan has run.
 
@@ -40,4 +41,5 @@ Replace the single-agent review with a three-agent orchestration:
 - PRs touching both domains produce a longer PR conversation (multiple agent threads) — intentional and desirable for traceability.
 - Ambiguous files (not routable by any heuristic) pause the orchestrator, which asks the human in the chat; the answer is cached in project memory and the question is never asked again for that file/pattern.
 - Failure in one specialist does not block others; the orchestrator degrades gracefully, continues, and reports the failure on the PR.
+- Every reviewed PR receives a machine-generated final status table from the orchestrator (Phase 3), listing agents run, findings count, fix count, and skipped items. This creates a permanent, auditable record of each review on the PR itself.
 - The workflow requires no human intervention except for: ambiguous file routing (once per file, cached), and cases where a fix was skipped due to break risk (left as a PR comment).

--- a/docs/adr/0001-three-agent-code-review-orchestration.md
+++ b/docs/adr/0001-three-agent-code-review-orchestration.md
@@ -1,0 +1,43 @@
+# ADR 0001: Three-Agent Code Review Orchestration
+
+**Date:** 2026-05-16
+**Status:** Accepted
+
+## Context
+
+The original code review flow used a single `senior-code-reviewer` agent to review the entire PR diff in one pass — security, frontend, backend, and code quality all together. As the review surface grew, this produced unfocused findings and mixed React and backend concerns in a single comment thread with no domain expertise applied to either.
+
+## Decision
+
+Replace the single-agent review with a three-agent orchestration:
+
+1. **`code-review-orchestrator`** — always runs; performs security review itself; detects which files changed using a 3-layer strategy (path heuristics → file content → cached project memory); spawns only the relevant domain specialists; coordinates the two-phase execution; handles failure and runs a verification pass after fixes.
+
+2. **`react-code-reviewer`** — spawned when frontend files change; runs ESLint as a guardrail before semantic analysis; reviews React-specific failure modes (hooks correctness, concurrent rendering, performance, a11y, forms, TypeScript type safety); flags testing gaps in the React domain.
+
+3. **`backend-code-reviewer`** — spawned when backend files change; reviews Node/Express patterns, database logic, migrations, TypeScript type safety, and testing gaps in the backend domain.
+
+**Two-phase execution:**
+- **Phase 1 (Review, parallel):** All relevant agents run simultaneously, each posting its own findings as a summary comment plus inline line-level PR comments.
+- **Phase 2 (Fix, parallel, after all reviews):** Each domain agent reads the entire PR conversation, applies fixes for all issues in its domain. Fixes are skipped if they risk breaking other features/functionality; tests are run after each fix; a failing test reverts that fix and leaves the original PR comment for human resolution.
+
+**Project-agnostic design:** All three agents live at `~/.claude/agents/` (global scope) so the methodology is portable across projects. File routing uses path heuristics and content analysis, falling back to cached project memory once the onboarding scan has run.
+
+**Per-project learning:**
+- **Mechanism 1 — Onboarding scan:** On first run in a project, each agent automatically scans project structure, identifies tech stack and conventions, and writes an initial `MEMORY.md` to its project-scoped memory directory (`.claude/agent-memory/<agent-name>/`).
+- **Mechanism 2 — Per-review updates:** After each review, agents update their memory with newly confirmed patterns, recurring issues, and project-specific conventions.
+
+## Alternatives Considered
+
+- **Single general reviewer:** Simpler, but unfocused. React-specific patterns (stale closures, concurrent rendering gotchas) and backend patterns (N+1 queries, migration safety) require domain expertise that degrades in a single-pass review.
+- **Single fixer agent reading all findings:** Clean separation of review and fix, but the fixer loses context the reviewer already had. Domain-specific fixers reading the full PR conversation was preferred.
+- **Always run all three reviewers:** Simpler routing but wastes time on unaffected domains. A backend-only PR doesn't benefit from a React review pass.
+- **Fix only Critical/High severity:** More conservative but requires human intervention for Medium/Low issues. Rejected in favour of fixing all issues with a safety gate (test run + break-risk check).
+
+## Consequences
+
+- PRs touching only one domain get faster, more focused reviews with less noise.
+- PRs touching both domains produce a longer PR conversation (multiple agent threads) — intentional and desirable for traceability.
+- Ambiguous files (not routable by any heuristic) pause the orchestrator, which asks the human in the chat; the answer is cached in project memory and the question is never asked again for that file/pattern.
+- Failure in one specialist does not block others; the orchestrator degrades gracefully, continues, and reports the failure on the PR.
+- The workflow requires no human intervention except for: ambiguous file routing (once per file, cached), and cases where a fix was skipped due to break risk (left as a PR comment).

--- a/docs/adr/0001-three-agent-code-review-orchestration.md
+++ b/docs/adr/0001-three-agent-code-review-orchestration.md
@@ -5,41 +5,23 @@
 
 ## Context
 
-The original code review flow used a single `senior-code-reviewer` agent to review the entire PR diff in one pass — security, frontend, backend, and code quality all together. As the review surface grew, this produced unfocused findings and mixed React and backend concerns in a single comment thread with no domain expertise applied to either.
+The original code review flow used a single `senior-code-reviewer` agent to review the entire PR diff in one pass. As the codebase grew, this produced unfocused findings — React-specific patterns and backend patterns require different expertise, and mixing them in one comment thread reduced review quality for both domains.
 
 ## Decision
 
-Replace the single-agent review with a three-agent orchestration:
-
-1. **`code-review-orchestrator`** — always runs; performs security review itself; detects which files changed using a 3-layer strategy (path heuristics → file content → cached project memory); spawns only the relevant domain specialists; coordinates the three-phase execution; handles failure and runs a verification pass after fixes.
-
-2. **`react-code-reviewer`** — spawned when frontend files change; runs ESLint as a guardrail before semantic analysis; reviews React-specific failure modes (hooks correctness, concurrent rendering, performance, a11y, forms, TypeScript type safety); flags testing gaps in the React domain.
-
-3. **`backend-code-reviewer`** — spawned when backend files change; reviews Node/Express patterns, database logic, migrations, TypeScript type safety, and testing gaps in the backend domain. **Status: planned — not yet implemented.** Until implemented, the orchestrator reviews backend files directly.
-
-**Three-phase execution:**
-- **Phase 1 (Review, parallel):** All relevant agents run simultaneously, each posting its own findings as a summary comment plus inline line-level PR comments.
-- **Phase 2 (Fix, parallel, after all reviews):** Each domain agent reads the entire PR conversation, applies fixes for all issues in its domain. Fixes are skipped if they risk breaking other features/functionality; tests are run after each fix; a failing test reverts that fix and leaves the original PR comment for human resolution. After all fix commits are pushed, the orchestrator performs a verification pass: it re-fetches the full diff and confirms all Critical and High findings have been addressed. Any regression introduced by a fix is caught here and flagged.
-- **Phase 3 (Final status):** The orchestrator posts a summary table on the PR listing which agents ran, how many issues were found, how many were fixed, and which fixes were skipped for human resolution.
-
-**Project-agnostic design:** All three agents live at `~/.claude/agents/` (global scope) so the methodology is portable across projects. File routing uses path heuristics and content analysis, falling back to cached project memory once the onboarding scan has run.
-
-**Per-project learning:**
-- **Mechanism 1 — Onboarding scan:** On first run in a project, each agent automatically scans project structure, identifies tech stack and conventions, and writes an initial `MEMORY.md` to its project-scoped memory directory (`.claude/agent-memory/<agent-name>/`).
-- **Mechanism 2 — Per-review updates:** After each review, agents update their memory with newly confirmed patterns, recurring issues, and project-specific conventions.
+Replace the single-agent review with a `code-review-orchestrator` that spawns domain specialists (`react-code-reviewer`, `backend-code-reviewer`) only when their domain is touched. The orchestrator owns security review across all files. Agents are global (`~/.claude/agents/`) and project-agnostic, learning per-project conventions via a scoped memory directory.
 
 ## Alternatives Considered
 
-- **Single general reviewer:** Simpler, but unfocused. React-specific patterns (stale closures, concurrent rendering gotchas) and backend patterns (N+1 queries, migration safety) require domain expertise that degrades in a single-pass review.
-- **Single fixer agent reading all findings:** Clean separation of review and fix, but the fixer loses context the reviewer already had. Domain-specific fixers reading the full PR conversation was preferred.
-- **Always run all three reviewers:** Simpler routing but wastes time on unaffected domains. A backend-only PR doesn't benefit from a React review pass.
-- **Fix only Critical/High severity:** More conservative but requires human intervention for Medium/Low issues. Rejected in favour of fixing all issues with a safety gate (test run + break-risk check).
+- **Single general reviewer:** Simpler, but unfocused. React-specific patterns (stale closures, concurrent rendering) and backend patterns (N+1 queries, migration safety) degrade when reviewed by a generalist.
+- **Always run all three reviewers:** Simpler routing but wastes time on unaffected domains.
+- **Project-scoped agents:** Would need to be duplicated per project. Rejected in favour of global agents with per-project memory so the methodology is portable.
+- **Fix only Critical/High severity:** Requires human intervention for Medium/Low. Rejected in favour of fixing all issues with a test-guarded safety gate.
 
 ## Consequences
 
-- PRs touching only one domain get faster, more focused reviews with less noise.
-- PRs touching both domains produce a longer PR conversation (multiple agent threads) — intentional and desirable for traceability.
-- Ambiguous files (not routable by any heuristic) pause the orchestrator, which asks the human in the chat; the answer is cached in project memory and the question is never asked again for that file/pattern.
-- Failure in one specialist does not block others; the orchestrator degrades gracefully, continues, and reports the failure on the PR.
-- Every reviewed PR receives a machine-generated final status table from the orchestrator (Phase 3), listing agents run, findings count, fix count, and skipped items. This creates a permanent, auditable record of each review on the PR itself.
-- The workflow requires no human intervention except for: ambiguous file routing (once per file, cached), and cases where a fix was skipped due to break risk (left as a PR comment).
+- PRs touching one domain get focused, faster reviews with less noise.
+- PRs touching both domains produce multiple agent comment threads — intentional for traceability.
+- Every PR gets a machine-generated final status table (agents run, findings, fixes applied, fixes skipped) as a permanent audit record.
+- Failure in one specialist does not block others; the orchestrator degrades gracefully and reports failures on the PR.
+- Ambiguous files pause the orchestrator, which asks the human once and caches the routing decision in project memory.


### PR DESCRIPTION
## Summary
- Replaces the single `senior-code-reviewer` with a three-agent orchestrated code review system
- This session delivers: `code-review-orchestrator` (global) + `react-code-reviewer` (global) + updated `CLAUDE.md` Step 5
- Backend reviewer coming in next session

## Changes
- `CLAUDE.md` Step 5 updated to call `code-review-orchestrator` instead of `senior-code-reviewer`
- `docs/adr/0001-three-agent-code-review-orchestration.md` — architectural decision record
- `~/.claude/agents/code-review-orchestrator.md` — orchestrates parallel reviews, security review, 3-layer file routing, two-phase execution, graceful failure, per-project memory
- `~/.claude/agents/react-code-reviewer.md` — React specialist: ESLint guardrail, PR classification, hooks/performance/a11y/forms/TS/testing-gaps checks, inline PR comments, domain fix phase

## Architecture
- **Orchestrator** always runs; detects frontend/backend files; spawns specialists; does security review
- **Phase 1 (parallel):** all agents post findings (summary + inline line-level comments) before any fixes
- **Phase 2 (parallel, after all reviews):** each agent reads full PR conversation, fixes domain issues, runs tests, reverts on failure
- **Agents are global and project-agnostic** — auto-detect project structure, cache routing decisions in per-project memory

## Test plan
- [ ] Create a test PR with frontend-only changes — verify only react-code-reviewer is spawned
- [ ] Create a test PR with backend-only changes — verify only backend-code-reviewer is spawned
- [ ] Create a test PR with both — verify both specialists run in parallel
- [ ] Verify orchestrator posts security findings before fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)