### PR TITLE
chore: add .env.test to gitignore for E2E test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .env
 .env.local
 .env.*.local
+.env.test
 !.env.example
 
 # IDE / Editor


### PR DESCRIPTION
## Summary
- Adds `.env.test` to `.gitignore` so local E2E test credentials are never committed

## Changes
- Added `.env.test` entry to the Environment variables section of `.gitignore`

## Context
Part of provisioning the Neon `jobflow_testing` database for the E2E test suite (issue #106):
- Neon project `jobflow_testing` (ID: `flat-resonance-82360756`) was located via API
- All 9 backend migrations were applied against the test database (0 pending)
- `TEST_DATABASE_URL` was added as a GitHub Actions secret
- `.env.test` was created locally with the pooled connection string

## Test plan
- [x] `git check-ignore .env.test` returns a match (line 13 in .gitignore)
- [x] `.env.test` does not appear in `git status` after creation

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)