### PR TITLE
feat: add Stage management E2E test (#111)

### DIFF
--- a/e2e/stages.spec.ts
+++ b/e2e/stages.spec.ts
@@ -7,17 +7,20 @@ test('user creates a new Stage and it appears as a column on the Board', async (
   // Use a timestamp-suffixed name so repeated runs never collide with existing stages.
   const stageName = `E2E Stage ${Date.now()}`;
 
-  // Open the "Add Stage" modal via the dashed button at the end of the board.
-  await page.click('button:has-text("Add Stage")');
+  // Wait for the Board to finish loading before attempting to open the modal.
+  // This guards against the async fetchData calls that hydrate the board after login.
+  const addStageButton = page.locator('button', { hasText: 'Add Stage' });
+  await expect(addStageButton).toBeVisible();
+  await addStageButton.click();
 
   // The StageForm modal should be visible.
-  await expect(page.locator('h2', { hasText: 'New Stage' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'New Stage' })).toBeVisible();
 
   // Fill in the stage name and submit.
-  await page.fill('#stage-name', stageName);
-  await page.click('button[type="submit"]:has-text("Create")');
+  await page.locator('#stage-name').fill(stageName);
+  await page.locator('button[type="submit"]', { hasText: 'Create' }).click();
 
   // The modal should close and the new Stage column header should be on the Board.
-  await expect(page.locator('h2', { hasText: 'New Stage' })).not.toBeVisible();
+  await expect(page.getByRole('heading', { name: 'New Stage' })).not.toBeVisible();
   await expect(page.locator('h3', { hasText: stageName })).toBeVisible();
 });

--- a/e2e/stages.spec.ts
+++ b/e2e/stages.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { login } from './helpers';
+
+test('user creates a new Stage and it appears as a column on the Board', async ({ page }) => {
+  await login(page);
+
+  // Use a timestamp-suffixed name so repeated runs never collide with existing stages.
+  const stageName = `E2E Stage ${Date.now()}`;
+
+  // Open the "Add Stage" modal via the dashed button at the end of the board.
+  await page.click('button:has-text("Add Stage")');
+
+  // The StageForm modal should be visible.
+  await expect(page.locator('h2', { hasText: 'New Stage' })).toBeVisible();
+
+  // Fill in the stage name and submit.
+  await page.fill('#stage-name', stageName);
+  await page.click('button[type="submit"]:has-text("Create")');
+
+  // The modal should close and the new Stage column header should be on the Board.
+  await expect(page.locator('h2', { hasText: 'New Stage' })).not.toBeVisible();
+  await expect(page.locator('h3', { hasText: stageName })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Adds `e2e/stages.spec.ts` with a Playwright test for Stage creation
- Test logs in, opens the "Add Stage" modal, submits a unique stage name, and asserts the new column header is visible on the Board

## Changes
- New file: `e2e/stages.spec.ts` — single independent test that exercises the full create-Stage flow
- Uses timestamp-suffixed stage name to prevent collisions between runs
- Follows the same patterns as `e2e/auth.spec.ts` (login helper, `h3` column header selector)

## Test plan
- [ ] `npx playwright test e2e/stages.spec.ts` passes against a running dev stack (frontend + backend + seeded test user)

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)