### PR TITLE
feat: add Application lifecycle E2E tests (#108)

### DIFF
--- a/e2e/applications.spec.ts
+++ b/e2e/applications.spec.ts
@@ -54,15 +54,15 @@ test('user edits the role title in an Application and it persists after reload',
   await stageColumn.locator('.board-card', { hasText: companyName }).click();
   await expect(page.locator('h2', { hasText: companyName })).toBeVisible();
 
-  // Edit the Role Title field (label text is "Role Title", no htmlFor — locate via container).
-  const roleTitleInput = page.locator('div:has(> label:has-text("Role Title")) input').first();
-  await roleTitleInput.fill('');
+  // Edit the Role Title field (label text is "Role Title", no htmlFor — traverse to parent, then input).
+  const roleTitleInput = page.locator('label', { hasText: 'Role Title' }).locator('..').locator('input');
   const updatedTitle = 'Senior Engineer E2E';
   await roleTitleInput.fill(updatedTitle);
 
-  // Save and wait for the modal to confirm the save (button re-enables).
+  // Save and wait for the full async round-trip: button enters "Saving..." state, then returns to "Save".
   await page.getByRole('button', { name: 'Save' }).click();
-  await expect(page.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Saving...' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Save' })).toBeVisible();
 
   // Close modal.
   await page.getByRole('button', { name: 'Cancel' }).click();

--- a/e2e/applications.spec.ts
+++ b/e2e/applications.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from '@playwright/test';
+import { login, createApplication, DEFAULT_STAGES } from './helpers';
+
+// ---------------------------------------------------------------------------
+// Test 1 — Create Application
+// ---------------------------------------------------------------------------
+test('user creates a new Application and it appears in the correct Stage', async ({ page }) => {
+  await login(page);
+
+  const stageName = DEFAULT_STAGES[0]; // 'Wishlist'
+  const companyName = await createApplication(page, stageName);
+
+  // The card must be visible inside the Wishlist Stage column.
+  const stageColumn = page.locator('.board-column', {
+    has: page.locator('h3', { hasText: stageName }),
+  });
+  await expect(stageColumn.locator('.board-card', { hasText: companyName })).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Test 2 — View Application details
+// ---------------------------------------------------------------------------
+test('user opens an Application and sees company name and role title', async ({ page }) => {
+  await login(page);
+
+  const stageName = DEFAULT_STAGES[1]; // 'Applied'
+  const companyName = await createApplication(page, stageName);
+
+  // Click the card to open the detail modal.
+  const stageColumn = page.locator('.board-column', {
+    has: page.locator('h3', { hasText: stageName }),
+  });
+  await stageColumn.locator('.board-card', { hasText: companyName }).click();
+
+  // The CardDetail header shows "<companyName> - Software Engineer".
+  const detailHeader = page.locator('h2', { hasText: companyName });
+  await expect(detailHeader).toBeVisible();
+  await expect(detailHeader).toContainText('Software Engineer');
+});
+
+// ---------------------------------------------------------------------------
+// Test 3 — Edit field and persist after reload
+// ---------------------------------------------------------------------------
+test('user edits the role title in an Application and it persists after reload', async ({ page }) => {
+  await login(page);
+
+  const stageName = DEFAULT_STAGES[2]; // 'Recruiter Call'
+  const companyName = await createApplication(page, stageName);
+
+  // Open the Application detail modal.
+  const stageColumn = page.locator('.board-column', {
+    has: page.locator('h3', { hasText: stageName }),
+  });
+  await stageColumn.locator('.board-card', { hasText: companyName }).click();
+  await expect(page.locator('h2', { hasText: companyName })).toBeVisible();
+
+  // Edit the Role Title field (label text is "Role Title", no htmlFor — locate via container).
+  const roleTitleInput = page.locator('div:has(> label:has-text("Role Title")) input').first();
+  await roleTitleInput.fill('');
+  const updatedTitle = 'Senior Engineer E2E';
+  await roleTitleInput.fill(updatedTitle);
+
+  // Save and wait for the modal to confirm the save (button re-enables).
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+
+  // Close modal.
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  await expect(page.locator('h2', { hasText: companyName })).not.toBeVisible();
+
+  // Reload to confirm persistence.
+  await page.reload();
+  await page.waitForURL('/');
+
+  // The card should now display the updated role title in CardPreview.
+  await expect(
+    page.locator('.board-card', { hasText: companyName }),
+  ).toContainText(updatedTitle);
+});
+
+// ---------------------------------------------------------------------------
+// Test 4 — Move Application to a different Stage via drag-and-drop, persist after reload
+// ---------------------------------------------------------------------------
+test('user moves an Application to a different Stage and it persists after reload', async ({ page }) => {
+  await login(page);
+
+  const sourceStage = DEFAULT_STAGES[0]; // 'Wishlist'
+  const targetStage = DEFAULT_STAGES[1]; // 'Applied'
+  const companyName = await createApplication(page, sourceStage);
+
+  const sourceColumn = page.locator('.board-column', {
+    has: page.locator('h3', { hasText: sourceStage }),
+  });
+  const targetColumn = page.locator('.board-column', {
+    has: page.locator('h3', { hasText: targetStage }),
+  });
+
+  const card = sourceColumn.locator('.board-card', { hasText: companyName });
+  await expect(card).toBeVisible();
+
+  // Drag the card from the source column to the target column using low-level
+  // mouse events, which work reliably with @dnd-kit's pointer-event listeners.
+  const cardBox = await card.boundingBox();
+  const targetBox = await targetColumn.boundingBox();
+  if (!cardBox || !targetBox) throw new Error('Could not get bounding boxes for DnD');
+
+  const startX = cardBox.x + cardBox.width / 2;
+  const startY = cardBox.y + cardBox.height / 2;
+  const endX = targetBox.x + targetBox.width / 2;
+  const endY = targetBox.y + targetBox.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Move in small increments so @dnd-kit's distance threshold (5px) is satisfied.
+  await page.mouse.move(startX + 5, startY, { steps: 3 });
+  await page.mouse.move(endX, endY, { steps: 20 });
+  await page.mouse.up();
+
+  // Wait for the card to appear in the target column.
+  await expect(targetColumn.locator('.board-card', { hasText: companyName })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Reload to confirm persistence.
+  await page.reload();
+  await page.waitForURL('/');
+
+  const targetColumnAfterReload = page.locator('.board-column', {
+    has: page.locator('h3', { hasText: targetStage }),
+  });
+  await expect(
+    targetColumnAfterReload.locator('.board-card', { hasText: companyName }),
+  ).toBeVisible();
+
+  // The card must NOT appear in the source column after the move.
+  const sourceColumnAfterReload = page.locator('.board-column', {
+    has: page.locator('h3', { hasText: sourceStage }),
+  });
+  await expect(
+    sourceColumnAfterReload.locator('.board-card', { hasText: companyName }),
+  ).not.toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// Test 5 — Delete Application and confirm it is gone after reload
+// ---------------------------------------------------------------------------
+test('user deletes an Application and it is gone after reload', async ({ page }) => {
+  await login(page);
+
+  const stageName = DEFAULT_STAGES[3]; // 'Technical Screen'
+  const companyName = await createApplication(page, stageName);
+
+  // Open the Application detail modal.
+  const stageColumn = page.locator('.board-column', {
+    has: page.locator('h3', { hasText: stageName }),
+  });
+  await stageColumn.locator('.board-card', { hasText: companyName }).click();
+  await expect(page.locator('h2', { hasText: companyName })).toBeVisible();
+
+  // Click "Delete" to show the confirmation prompt.
+  await page.locator('button', { hasText: 'Delete' }).first().click();
+
+  // A second "Delete" button appears in the confirmation row — click it to confirm.
+  await page.locator('button', { hasText: 'Delete' }).last().click();
+
+  // The modal should close and the card should no longer be on the Board.
+  await expect(page.locator('h2', { hasText: companyName })).not.toBeVisible();
+  await expect(page.locator('.board-card', { hasText: companyName })).not.toBeVisible();
+
+  // Reload to confirm the deletion persisted.
+  await page.reload();
+  await page.waitForURL('/');
+
+  await expect(page.locator('.board-card', { hasText: companyName })).not.toBeVisible();
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -14,3 +14,39 @@ export async function login(page: Page): Promise<void> {
   await expect(page).not.toHaveURL('/login');
   await page.waitForURL('/');
 }
+
+/**
+ * Creates a new Application through the UI and waits for it to appear on the Board.
+ *
+ * Returns the unique company name used, so callers can locate the card afterwards.
+ *
+ * @param page      - Playwright Page (must already be logged in and on the Board).
+ * @param stageName - The Stage column to create the Application in (must be one of DEFAULT_STAGES).
+ */
+export async function createApplication(page: Page, stageName: string): Promise<string> {
+  const companyName = `E2E Co ${Date.now()}`;
+  const roleTitle = 'Software Engineer';
+
+  // Click the "Add card" (+) button in the matching Stage column header.
+  const stageColumn = page.locator('.board-column', { has: page.locator('h3', { hasText: stageName }) });
+  await stageColumn.locator('[title="Add card"]').click();
+
+  // The CardForm modal ("New Application") should appear.
+  await expect(page.locator('h2', { hasText: 'New Application' })).toBeVisible();
+
+  // The Stage select is pre-filled with the clicked column's stage; no change needed.
+  // Fill the required fields using placeholder selectors (labels have no htmlFor in this UI).
+  await page.getByPlaceholder('Acme Inc.').fill(companyName);
+  await page.getByPlaceholder('Senior Frontend Engineer').fill(roleTitle);
+
+  // Submit the form.
+  await page.getByRole('button', { name: 'Add' }).click();
+
+  // Modal closes and the new card must be visible in the correct Stage column.
+  await expect(page.locator('h2', { hasText: 'New Application' })).not.toBeVisible();
+  await expect(
+    stageColumn.locator('.board-card', { hasText: companyName }),
+  ).toBeVisible();
+
+  return companyName;
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -40,7 +40,9 @@ export async function createApplication(page: Page, stageName: string): Promise<
   await page.getByPlaceholder('Senior Frontend Engineer').fill(roleTitle);
 
   // Submit the form.
-  await page.getByRole('button', { name: 'Add' }).click();
+  const submitBtn = page.getByRole('button', { name: 'Add', exact: true });
+  await expect(submitBtn).toBeEnabled();
+  await submitBtn.click();
 
   // Modal closes and the new card must be visible in the correct Stage column.
   await expect(page.locator('h2', { hasText: 'New Application' })).not.toBeVisible();

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -40,7 +40,7 @@ export async function createApplication(page: Page, stageName: string): Promise<
   await page.getByPlaceholder('Senior Frontend Engineer').fill(roleTitle);
 
   // Submit the form.
-  const submitBtn = page.getByRole('button', { name: 'Add', exact: true });
+  const submitBtn = page.locator('form').getByRole('button', { name: 'Add', exact: true });
   await expect(submitBtn).toBeEnabled();
   await submitBtn.click();
 


### PR DESCRIPTION
## Summary
- Adds `createApplication(page, stageName)` helper to `e2e/helpers.ts` — creates an Application via UI using a timestamp-based company name for test isolation, returns the company name for assertions
- Adds `e2e/applications.spec.ts` with 5 fully-independent Application lifecycle tests covering create, view, edit, move-stage (DnD), and delete

## Changes
- `e2e/helpers.ts` — new `createApplication(page, stageName)` export; clicks the column's add-card button, fills Company Name + Role Title, submits, waits for card visibility
- `e2e/applications.spec.ts` — 5 tests, each calls `login()` first and creates its own Application:
  1. **Create** — card appears in the correct Stage column after creation
  2. **View details** — company name and role title visible in detail modal header
  3. **Edit field** — role title update saved and visible after `page.reload()`
  4. **Move stage** — DnD via `page.mouse` (compatible with `@dnd-kit` pointer events); card found in target Stage after reload, absent from source
  5. **Delete** — two-step delete confirmation; card absent from Board after reload

## Test plan
- [ ] All 5 tests in `applications.spec.ts` pass against the full stack (`npm run test:e2e`)
- [ ] `createApplication` helper is re-used in all 5 tests (no shared state between tests)
- [ ] Reload assertions confirm server-side persistence for write operations (edit, move, delete)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)