### PR TITLE
chore: add --ui and --headed flags to test:e2e script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "scripts": {
     "seed:test": "npm --prefix backend run seed:test",
-    "test:e2e": "bash scripts/test-e2e.sh"
+    "test:e2e": "bash scripts/test-e2e.sh",
+    "test:e2e:ui": "bash scripts/test-e2e.sh --ui",
+    "test:e2e:headed": "bash scripts/test-e2e.sh --headed"
   },
   "devDependencies": {
     "@playwright/test": "^1.52.0",

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+UI_MODE=false
+HEADED=false
+for arg in "$@"; do
+  case $arg in
+    --ui) UI_MODE=true ;;
+    --headed) HEADED=true ;;
+  esac
+done
+
 # Load .env.test from repo root if it exists
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 if [ -f "$ROOT/.env.test" ]; then
@@ -59,4 +68,10 @@ echo "--- Waiting for services ---"
   --timeout 60000
 
 echo "--- Running Playwright ---"
-"$ROOT/node_modules/.bin/playwright" test --config "$ROOT/playwright.config.ts"
+if [ "$UI_MODE" = true ]; then
+  "$ROOT/node_modules/.bin/playwright" test --ui --config "$ROOT/playwright.config.ts"
+elif [ "$HEADED" = true ]; then
+  "$ROOT/node_modules/.bin/playwright" test --headed --config "$ROOT/playwright.config.ts"
+else
+  "$ROOT/node_modules/.bin/playwright" test --config "$ROOT/playwright.config.ts"
+fi


### PR DESCRIPTION
## Summary
- Adds `--ui` flag to `test-e2e.sh` — starts servers then opens Playwright's interactive UI; servers tear down automatically when the UI is closed
- Adds `--headed` flag to `test-e2e.sh` — runs all tests in a visible browser window without the full interactive UI
- Without either flag, behaviour is unchanged (headless, tear down after run)

## Changes
- `scripts/test-e2e.sh`: flag-parsing block at the top; final `playwright test` call replaced with a three-way conditional
- `package.json`: two new convenience scripts (`test:e2e:ui`, `test:e2e:headed`) alongside the existing `test:e2e`

## Test plan
- [ ] `npm run test:e2e` — runs headless as before, servers tear down on exit
- [ ] `npm run test:e2e:headed` — browser window opens, tests run visibly, servers tear down on exit
- [ ] `npm run test:e2e:ui` — Playwright UI opens, servers stay alive while UI is open, tear down when UI is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)