### PR TITLE
Add /gitflow deterministic git workflow skill

### DIFF
--- a/.claude/commands/gitflow.md
+++ b/.claude/commands/gitflow.md
@@ -18,11 +18,18 @@ bash .claude/commands/gitflow/scripts/detect.sh
 
 Parse the output lines:
 - `GIT_ROOT=<path>` → where changes live (main repo or a worktree path)
-- `BRANCH=<name>` → current branch at that location
-- `STATUS=<value>` → `changes_here` | `changes_in_worktree` | `clean`
-- Remaining lines → dirty file list (`git status --short` format)
+- `BRANCH=<name>` → current branch at that location (or `DETACHED` in detached-HEAD state)
+- `STATUS=<value>` → one of:
+  - `changes_here` — dirty files in the current repo
+  - `changes_in_worktree` — dirty files in exactly one worktree
+  - `multiple_dirty` — dirty files in more than one location (followed by `DIRTY=<path>` lines)
+  - `clean` — nothing to commit anywhere
+- Remaining lines → dirty file list (`git status --short` format), or `DIRTY=<path>` lines when `multiple_dirty`
 
-If `STATUS=clean`, tell the user "No uncommitted changes found." and stop.
+Handle each status:
+- `clean` → tell the user "No uncommitted changes found." and stop.
+- `multiple_dirty` → show the user the list of dirty locations and ask which one to ship. Re-run `detect.sh` from that location (or pass its path) before continuing. Do not guess.
+- `DETACHED` branch → stop and ask the user how to proceed (likely needs a real branch first).
 
 ---
 
@@ -80,15 +87,31 @@ Never skip a step. Never rearrange. If a script exits non-zero, STOP and report 
 
 ### 4a — Create branch (SKIP if BRANCH_NAME already exists, i.e. BRANCH ≠ main)
 
+Before invoking, verify whether the branch already exists locally:
+
+```bash
+git -C "<GIT_ROOT>" show-ref --verify --quiet "refs/heads/<BRANCH_NAME>" \
+  && echo EXISTS || echo MISSING
+```
+
+- `EXISTS` → skip 4a entirely; we are already on the branch.
+- `MISSING` → run the create-branch script:
+
 ```bash
 bash .claude/commands/gitflow/scripts/create-branch.sh "<BRANCH_NAME>"
 ```
 
+`create-branch.sh` branches directly off `origin/main` without resetting local `main`, refuses reserved names (`main`, `master`, `HEAD`), and enforces the `<type>/<kebab-case>` convention from CLAUDE.md.
+
 ### 4b — Stage files
 
+Quote each file path individually so paths with spaces are passed correctly:
+
 ```bash
-bash .claude/commands/gitflow/scripts/stage.sh -C "<GIT_ROOT>" <FILES_TO_STAGE space-separated>
+bash .claude/commands/gitflow/scripts/stage.sh -C "<GIT_ROOT>" "<file 1>" "<file 2>" "<file N>"
 ```
+
+`stage.sh` refuses `.`, `-A`, `--all`, and a deny-list of sensitive paths (`.env*`, `CLAUDE.md`, `*.pem`, `*.key`, `id_rsa*`, `secrets/`). If you see a deny-list error, drop the offending file from the staged set — never bypass it.
 
 ### 4c — Commit (pipe the body via heredoc)
 

--- a/.claude/commands/gitflow.md
+++ b/.claude/commands/gitflow.md
@@ -97,76 +97,54 @@ Proceed? y=run  n=abort  e=edit a value
 
 ---
 
-## Phase 4 — Execute scripts in order (only after `y`)
+## Phase 4 — Delegate execution to git-ops agent (only after `y`)
 
-Never skip a step. Never rearrange. If a script exits non-zero, STOP and report the error.
+**All script execution is handled by the `git-ops` agent (Haiku). Never run the scripts directly in the main session.**
 
-### 4a — Create branch (SKIP if BRANCH_NAME already exists, i.e. BRANCH ≠ main)
+Spawn the `git-ops` agent using the Agent tool with `subagent_type: "git-ops"` and `model: "haiku"`. Pass it the following prompt, with every `<placeholder>` filled in from the values inferred in Phase 2:
 
-Before invoking, verify whether the branch already exists locally:
+---
 
-```bash
-git -C "<GIT_ROOT>" show-ref --verify --quiet "refs/heads/<BRANCH_NAME>" \
-  && echo EXISTS || echo MISSING
 ```
+You are being invoked by the /gitflow skill to execute git operations.
+Follow your "Gitflow Script Execution" section exactly.
 
-- `EXISTS` → skip 4a entirely; we are already on the branch.
-- `MISSING` → run the create-branch script:
+GIT_ROOT: <GIT_ROOT>
+BRANCH_NAME: <BRANCH_NAME>
+CREATE_BRANCH: <true if BRANCH was 'main', false otherwise>
+COMMIT_TYPE: <COMMIT_TYPE>
+COMMIT_SUMMARY: <COMMIT_SUMMARY>
+FILES_TO_STAGE: "<file1>" "<file2>" "<fileN>"
 
-```bash
-bash .claude/commands/gitflow/scripts/create-branch.sh "<BRANCH_NAME>"
-```
-
-`create-branch.sh` branches directly off `origin/main` without resetting local `main`, refuses reserved names (`main`, `master`, `HEAD`), and enforces the `<type>/<kebab-case>` convention from CLAUDE.md.
-
-### 4b — Stage files
-
-Quote each file path individually so paths with spaces are passed correctly:
-
-```bash
-bash .claude/commands/gitflow/scripts/stage.sh -C "<GIT_ROOT>" "<file 1>" "<file 2>" "<file N>"
-```
-
-`stage.sh` refuses `.`, `-A`, `--all`, and a deny-list of sensitive paths (`.env*`, `CLAUDE.md`, `*.pem`, `*.key`, `id_rsa*`, `secrets/`). If you see a deny-list error, drop the offending file from the staged set — never bypass it.
-
-### 4c — Commit (pipe the body via heredoc)
-
-```bash
-bash .claude/commands/gitflow/scripts/commit.sh -C "<GIT_ROOT>" "<CHANGE_TYPE>" "<COMMIT_SUMMARY>" <<'BODY'
+COMMIT_BODY:
 - <bullet 1>
 - <bullet 2>
 - <bullet 3>
-BODY
+
+PR_TITLE: <PR_TITLE>
+
+PR_SUMMARY:
+- <summary bullet 1>
+- <summary bullet 2>
+
+PR_CHANGES:
+- <file1>: <one-line description>
+- <file2>: <one-line description>
+
+PR_TEST_PLAN:
+- [ ] <test step 1>
+- [ ] <test step 2>
+
+Return the PR URL when done.
 ```
 
-### 4d — Push
+---
 
-```bash
-bash .claude/commands/gitflow/scripts/push.sh -C "<GIT_ROOT>" "<BRANCH_NAME>"
-```
-
-### 4e — Create PR (pipe the body via heredoc)
-
-```bash
-bash .claude/commands/gitflow/scripts/create-pr.sh "<BRANCH_NAME>" "<PR_TITLE>" <<'BODY'
-## Summary
-<PR_SUMMARY bullets>
-
-## Changes
-<one-line description per changed file>
-
-## Test plan
-<PR_TEST_PLAN checkboxes>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-BODY
-```
-
-Capture the URL printed to stdout. Report it to the user.
+Wait for the git-ops agent to return. It will print the PR URL.
 
 ### 4f — Trigger code review (MANDATORY — never skip even if not asked)
 
-Extract the PR number from the URL (`.../pull/<N>` → `N`).
+Extract the PR number from the URL returned by git-ops (`.../pull/<N>` → `N`).
 
 Say: "Running Step 5 — code-review-orchestrator for PR #<N>"
 

--- a/.claude/commands/gitflow.md
+++ b/.claude/commands/gitflow.md
@@ -1,0 +1,146 @@
+# /gitflow — Deterministic Git Workflow
+
+Executes the full JobFlow git workflow: detect → infer → confirm → run scripts → review.
+**You call pre-written scripts with inferred values. You do not write git commands yourself.**
+
+Scripts live at: `.claude/commands/gitflow/scripts/`
+Make them executable on first use: `chmod +x .claude/commands/gitflow/scripts/*.sh`
+
+---
+
+## Phase 1 — Detect git state
+
+Run the detect script and parse its output:
+
+```bash
+bash .claude/commands/gitflow/scripts/detect.sh
+```
+
+Parse the output lines:
+- `GIT_ROOT=<path>` → where changes live (main repo or a worktree path)
+- `BRANCH=<name>` → current branch at that location
+- `STATUS=<value>` → `changes_here` | `changes_in_worktree` | `clean`
+- Remaining lines → dirty file list (`git status --short` format)
+
+If `STATUS=clean`, tell the user "No uncommitted changes found." and stop.
+
+---
+
+## Phase 2 — Infer values from conversation context
+
+Derive these variables from what was just implemented in this conversation.
+Do NOT ask the user for these — infer them:
+
+| Variable | Rule |
+|---|---|
+| `CHANGE_TYPE` | `feat` / `fix` / `refactor` / `style` / `docs` / `test` / `chore` |
+| `BRANCH_NAME` | If `BRANCH` ≠ `main` → use detected `BRANCH`. If `BRANCH` = `main` → derive `<type>/<kebab-3-to-5-words>` |
+| `COMMIT_SUMMARY` | Imperative mood, ≤72 chars, no type prefix (e.g. `eliminate search typing lag`) |
+| `COMMIT_BODY` | 2–4 bullet lines describing what changed and why |
+| `PR_TITLE` | ≤70 chars (e.g. `Fix search typing lag with debounced re-renders`) |
+| `PR_SUMMARY` | 1–3 bullets for the PR `## Summary` section |
+| `PR_TEST_PLAN` | Checkbox list (`- [ ] step`) of manual test scenarios |
+| `FILES_TO_STAGE` | The dirty files from Phase 1 — filter out any secrets, `.env`, or `CLAUDE.md` |
+
+---
+
+## Phase 3 — Dry-run display (STOP and wait for confirmation)
+
+Print this block with all values filled in:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+/gitflow DRY RUN
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+GIT ROOT:   <GIT_ROOT>
+BRANCH:     <BRANCH_NAME>  [exists / will create from main]
+TYPE:       <CHANGE_TYPE>
+COMMIT:     <CHANGE_TYPE>: <COMMIT_SUMMARY>
+BODY:       - <bullet 1>
+            - <bullet 2>
+FILES:
+  + <file 1>
+  + <file 2>
+PR TITLE:   <PR_TITLE>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Proceed? y=run  n=abort  e=edit a value
+```
+
+**Do not run any write command until the user replies.**
+
+- `y` → proceed to Phase 4
+- `n` → abort, no changes made, tell the user nothing was run
+- `e` → ask which field to change, update it, re-display the dry-run, wait again
+
+---
+
+## Phase 4 — Execute scripts in order (only after `y`)
+
+Never skip a step. Never rearrange. If a script exits non-zero, STOP and report the error.
+
+### 4a — Create branch (SKIP if BRANCH_NAME already exists, i.e. BRANCH ≠ main)
+
+```bash
+bash .claude/commands/gitflow/scripts/create-branch.sh "<BRANCH_NAME>"
+```
+
+### 4b — Stage files
+
+```bash
+bash .claude/commands/gitflow/scripts/stage.sh -C "<GIT_ROOT>" <FILES_TO_STAGE space-separated>
+```
+
+### 4c — Commit (pipe the body via heredoc)
+
+```bash
+bash .claude/commands/gitflow/scripts/commit.sh -C "<GIT_ROOT>" "<CHANGE_TYPE>" "<COMMIT_SUMMARY>" <<'BODY'
+- <bullet 1>
+- <bullet 2>
+- <bullet 3>
+BODY
+```
+
+### 4d — Push
+
+```bash
+bash .claude/commands/gitflow/scripts/push.sh -C "<GIT_ROOT>" "<BRANCH_NAME>"
+```
+
+### 4e — Create PR (pipe the body via heredoc)
+
+```bash
+bash .claude/commands/gitflow/scripts/create-pr.sh "<BRANCH_NAME>" "<PR_TITLE>" <<'BODY'
+## Summary
+<PR_SUMMARY bullets>
+
+## Changes
+<one-line description per changed file>
+
+## Test plan
+<PR_TEST_PLAN checkboxes>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+```
+
+Capture the URL printed to stdout. Report it to the user.
+
+### 4f — Trigger code review (MANDATORY — never skip even if not asked)
+
+Extract the PR number from the URL (`.../pull/<N>` → `N`).
+
+Say: "Running Step 5 — code-review-orchestrator for PR #<N>"
+
+Then spawn the `code-review-orchestrator` agent for that PR number.
+
+---
+
+## Hard rules
+
+- Never commit `CLAUDE.md`, `.env`, secrets, or files unrelated to the feature
+- Never pass `.` or `-A` to `stage.sh` — always list explicit file paths
+- Never use `--no-verify`, `--force`, or amend a pushed commit
+- Never push directly to `main` or `master`
+- Never merge — human only
+- Step 4f always runs after a successful PR creation
+- On any script failure: STOP, show the error output, do not continue

--- a/.claude/commands/gitflow.md
+++ b/.claude/commands/gitflow.md
@@ -1,5 +1,7 @@
 # /gitflow — Deterministic Git Workflow
 
+**When to invoke this skill:** Any time the JobFlow CLAUDE.md workflow needs to run Steps 1, 3, 4, or 5 — branch creation, committing, pushing, PR creation, and triggering the code review. This is the single canonical mechanism for all git operations in this project. Trigger phrases include: "run the gitflow", "commit and open a PR", "ship this", "push and create a PR", "follow the workflow", or any instruction to execute the CLAUDE.md development workflow after implementation is done.
+
 Executes the full JobFlow git workflow: detect → infer → confirm → run scripts → review.
 **You call pre-written scripts with inferred values. You do not write git commands yourself.**
 
@@ -38,10 +40,24 @@ Handle each status:
 Derive these variables from what was just implemented in this conversation.
 Do NOT ask the user for these — infer them:
 
+Branch prefixes and commit types are **different** — use the right convention for each (both defined in CLAUDE.md):
+
+| Variable | Convention | Values |
+|---|---|---|
+| `BRANCH_PREFIX` | CLAUDE.md branch rule | `feature/` `fix/` `refactor/` `experiment/` `chore/` `docs/` |
+| `COMMIT_TYPE` | Conventional commits | `feat` `fix` `refactor` `style` `docs` `test` `chore` |
+
+Mapping (most common cases):
+- New feature → branch `feature/`, commit `feat:`
+- Bug fix → branch `fix/`, commit `fix:`
+- Refactor → branch `refactor/`, commit `refactor:`
+- Config/deps → branch `chore/`, commit `chore:`
+- Docs → branch `docs/`, commit `docs:`
+- Experiment → branch `experiment/`, commit `chore:` or `refactor:`
+
 | Variable | Rule |
 |---|---|
-| `CHANGE_TYPE` | `feat` / `fix` / `refactor` / `style` / `docs` / `test` / `chore` |
-| `BRANCH_NAME` | If `BRANCH` ≠ `main` → use detected `BRANCH`. If `BRANCH` = `main` → derive `<type>/<kebab-3-to-5-words>` |
+| `BRANCH_NAME` | If `BRANCH` ≠ `main` → use detected `BRANCH`. If `BRANCH` = `main` → `<BRANCH_PREFIX><kebab-3-to-5-words>` e.g. `feature/drag-and-drop-cards` |
 | `COMMIT_SUMMARY` | Imperative mood, ≤72 chars, no type prefix (e.g. `eliminate search typing lag`) |
 | `COMMIT_BODY` | 2–4 bullet lines describing what changed and why |
 | `PR_TITLE` | ≤70 chars (e.g. `Fix search typing lag with debounced re-renders`) |

--- a/.claude/commands/gitflow/scripts/commit.sh
+++ b/.claude/commands/gitflow/scripts/commit.sh
@@ -21,6 +21,9 @@ while [[ $# -gt 0 ]]; do
     *)
       if   [ -z "$TYPE" ];    then TYPE="$1"
       elif [ -z "$SUMMARY" ]; then SUMMARY="$1"
+      else
+        echo "ERROR: unexpected extra argument: '$1'" >&2
+        exit 1
       fi
       shift
       ;;
@@ -30,7 +33,36 @@ done
 [ -z "$TYPE" ]    && { echo "ERROR: type required"    >&2; exit 1; }
 [ -z "$SUMMARY" ] && { echo "ERROR: summary required" >&2; exit 1; }
 
-BODY=$(cat)   # read bullet points from stdin
+# Validate type against the allowed set
+case "$TYPE" in
+  feat|fix|refactor|style|docs|test|chore) ;;
+  *)
+    echo "ERROR: invalid type '$TYPE' — must be one of: feat fix refactor style docs test chore" >&2
+    exit 1 ;;
+esac
+
+# Enforce ≤72 char summary
+if [ ${#SUMMARY} -gt 72 ]; then
+  echo "ERROR: summary too long (${#SUMMARY} > 72 chars)" >&2
+  exit 1
+fi
+
+# Refuse to read from a terminal — body must be piped via heredoc
+if [ -t 0 ]; then
+  echo "ERROR: commit body must be piped via stdin (heredoc)" >&2
+  echo "       example:" >&2
+  echo "         commit.sh feat 'summary' <<'BODY'" >&2
+  echo "         - bullet 1" >&2
+  echo "         BODY" >&2
+  exit 1
+fi
+
+BODY=$(cat)
+
+if [ -z "${BODY//[[:space:]]/}" ]; then
+  echo "ERROR: commit body (stdin) is empty" >&2
+  exit 1
+fi
 
 MSG="$(printf '%s: %s\n\n%s\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>' \
   "$TYPE" "$SUMMARY" "$BODY")"

--- a/.claude/commands/gitflow/scripts/commit.sh
+++ b/.claude/commands/gitflow/scripts/commit.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Creates a structured commit. Reads the body from stdin.
+# Usage: commit.sh [-C <git-root>] <type> <summary> <<'BODY'
+#          - bullet 1
+#          - bullet 2
+#        BODY
+#
+# type     — feat | fix | refactor | style | docs | test | chore
+# summary  — imperative mood, ≤72 chars (no type prefix)
+# stdin    — bullet-point body (2–4 lines)
+
+set -euo pipefail
+
+GIT_ROOT=""
+TYPE=""
+SUMMARY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -C) GIT_ROOT="$2"; shift 2 ;;
+    *)
+      if   [ -z "$TYPE" ];    then TYPE="$1"
+      elif [ -z "$SUMMARY" ]; then SUMMARY="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+[ -z "$TYPE" ]    && { echo "ERROR: type required"    >&2; exit 1; }
+[ -z "$SUMMARY" ] && { echo "ERROR: summary required" >&2; exit 1; }
+
+BODY=$(cat)   # read bullet points from stdin
+
+MSG="$(printf '%s: %s\n\n%s\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>' \
+  "$TYPE" "$SUMMARY" "$BODY")"
+
+if [ -n "$GIT_ROOT" ]; then
+  git -C "$GIT_ROOT" commit -m "$MSG"
+else
+  git commit -m "$MSG"
+fi

--- a/.claude/commands/gitflow/scripts/create-branch.sh
+++ b/.claude/commands/gitflow/scripts/create-branch.sh
@@ -1,16 +1,38 @@
 #!/usr/bin/env bash
-# Creates a new branch from latest main.
+# Creates a new branch from latest origin/main.
 # Usage: create-branch.sh <branch-name>
 #
-# Always branches off origin/main (not local main) to avoid stale state.
+# Branches directly off origin/main without touching local main, so any
+# uncommitted work or unpushed commits on local main are never destroyed.
 
 set -euo pipefail
 
 BRANCH="${1:?ERROR: branch-name required}"
 
-git fetch origin main --quiet
-git checkout main
-git reset --hard origin/main
-git checkout -b "$BRANCH"
+# 1. Refuse reserved / dangerous names
+case "$BRANCH" in
+  main|master|HEAD|"")
+    echo "ERROR: refusing to create reserved branch name: '$BRANCH'" >&2
+    exit 1 ;;
+esac
 
-echo "Branch created: $BRANCH"
+# 2. Enforce JobFlow naming convention (see CLAUDE.md)
+if ! [[ "$BRANCH" =~ ^(feat|fix|refactor|experiment|chore|docs|test|style)/[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "ERROR: branch must match '<type>/<kebab-case>' (got: '$BRANCH')" >&2
+  echo "       valid types: feat, fix, refactor, experiment, chore, docs, test, style" >&2
+  exit 1
+fi
+
+# 3. Fail fast if the branch already exists locally — never silently reuse it
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "ERROR: branch '$BRANCH' already exists locally" >&2
+  exit 1
+fi
+
+# 4. Fetch the latest main from origin (no destructive reset on local main)
+git fetch origin main --quiet
+
+# 5. Branch off the remote ref directly — avoids touching local main
+git checkout -b "$BRANCH" origin/main
+
+echo "Branch created: $BRANCH (from origin/main)"

--- a/.claude/commands/gitflow/scripts/create-branch.sh
+++ b/.claude/commands/gitflow/scripts/create-branch.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Creates a new branch from latest main.
+# Usage: create-branch.sh <branch-name>
+#
+# Always branches off origin/main (not local main) to avoid stale state.
+
+set -euo pipefail
+
+BRANCH="${1:?ERROR: branch-name required}"
+
+git fetch origin main --quiet
+git checkout main
+git reset --hard origin/main
+git checkout -b "$BRANCH"
+
+echo "Branch created: $BRANCH"

--- a/.claude/commands/gitflow/scripts/create-branch.sh
+++ b/.claude/commands/gitflow/scripts/create-branch.sh
@@ -17,9 +17,9 @@ case "$BRANCH" in
 esac
 
 # 2. Enforce JobFlow naming convention (see CLAUDE.md)
-if ! [[ "$BRANCH" =~ ^(feat|fix|refactor|experiment|chore|docs|test|style)/[a-z0-9][a-z0-9-]*$ ]]; then
+if ! [[ "$BRANCH" =~ ^(feature|fix|refactor|experiment|chore|docs)/[a-z0-9][a-z0-9-]*$ ]]; then
   echo "ERROR: branch must match '<type>/<kebab-case>' (got: '$BRANCH')" >&2
-  echo "       valid types: feat, fix, refactor, experiment, chore, docs, test, style" >&2
+  echo "       valid types: feature, fix, refactor, experiment, chore, docs" >&2
   exit 1
 fi
 

--- a/.claude/commands/gitflow/scripts/create-pr.sh
+++ b/.claude/commands/gitflow/scripts/create-pr.sh
@@ -10,12 +10,38 @@ set -euo pipefail
 BRANCH="${1:?ERROR: branch-name required}"
 TITLE="${2:?ERROR: PR title required}"
 
-BODY=$(cat)   # read PR body from stdin
+# Preflight: gh must be installed
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI is not installed or not on PATH" >&2
+  exit 1
+fi
 
-URL=$(gh pr create \
+# Refuse to open a PR from a protected base branch
+case "$BRANCH" in
+  main|master)
+    echo "ERROR: refusing to open PR from base branch '$BRANCH'" >&2
+    exit 1 ;;
+esac
+
+# Refuse to read from a terminal — body must be piped via heredoc
+if [ -t 0 ]; then
+  echo "ERROR: PR body must be piped via stdin (heredoc)" >&2
+  exit 1
+fi
+
+BODY=$(cat)
+if [ -z "${BODY//[[:space:]]/}" ]; then
+  echo "ERROR: PR body (stdin) is empty" >&2
+  exit 1
+fi
+
+# Create the PR (suppress stdout — gh may emit warnings alongside the URL).
+gh pr create \
   --base main \
   --head "$BRANCH" \
   --title "$TITLE" \
-  --body "$BODY")
+  --body "$BODY" >/dev/null
 
+# Fetch the URL deterministically via JSON so warnings can't pollute it.
+URL=$(gh pr view "$BRANCH" --json url --jq .url)
 echo "$URL"

--- a/.claude/commands/gitflow/scripts/create-pr.sh
+++ b/.claude/commands/gitflow/scripts/create-pr.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Creates a GitHub PR. Reads the body from stdin. Prints the PR URL.
+# Usage: create-pr.sh <branch-name> <title> <<'BODY'
+#          ## Summary
+#          ...
+#        BODY
+
+set -euo pipefail
+
+BRANCH="${1:?ERROR: branch-name required}"
+TITLE="${2:?ERROR: PR title required}"
+
+BODY=$(cat)   # read PR body from stdin
+
+URL=$(gh pr create \
+  --base main \
+  --head "$BRANCH" \
+  --title "$TITLE" \
+  --body "$BODY")
+
+echo "$URL"

--- a/.claude/commands/gitflow/scripts/detect.sh
+++ b/.claude/commands/gitflow/scripts/detect.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Detects where uncommitted changes live: main repo or a worktree.
+# Outputs key=value pairs followed by the dirty file list.
+#
+# Output keys:
+#   GIT_ROOT   — absolute path to work from (main repo or worktree)
+#   BRANCH     — current branch at that location
+#   STATUS     — changes_here | changes_in_worktree | clean
+#   (followed by git status --short lines for the dirty location)
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# 1. Check the current working directory first
+CURRENT_CHANGES=$(git status --short 2>/dev/null | grep -c '' || true)
+
+if [ "$CURRENT_CHANGES" -gt 0 ]; then
+  echo "GIT_ROOT=$REPO_ROOT"
+  echo "BRANCH=$(git branch --show-current)"
+  echo "STATUS=changes_here"
+  git status --short
+  exit 0
+fi
+
+# 2. Walk all registered worktrees looking for dirty state
+while IFS= read -r line; do
+  if [[ "$line" == worktree\ * ]]; then
+    WT_PATH="${line#worktree }"
+    [ "$WT_PATH" = "$REPO_ROOT" ] && continue   # skip main, already checked
+
+    WT_CHANGES=$(git -C "$WT_PATH" status --short 2>/dev/null | grep -c '' || true)
+    if [ "$WT_CHANGES" -gt 0 ]; then
+      echo "GIT_ROOT=$WT_PATH"
+      echo "BRANCH=$(git -C "$WT_PATH" branch --show-current)"
+      echo "STATUS=changes_in_worktree"
+      git -C "$WT_PATH" status --short
+      exit 0
+    fi
+  fi
+done < <(git worktree list --porcelain)
+
+# 3. Nothing dirty anywhere
+echo "GIT_ROOT=$REPO_ROOT"
+echo "BRANCH=$(git branch --show-current)"
+echo "STATUS=clean"

--- a/.claude/commands/gitflow/scripts/detect.sh
+++ b/.claude/commands/gitflow/scripts/detect.sh
@@ -4,43 +4,66 @@
 #
 # Output keys:
 #   GIT_ROOT   — absolute path to work from (main repo or worktree)
-#   BRANCH     — current branch at that location
-#   STATUS     — changes_here | changes_in_worktree | clean
-#   (followed by git status --short lines for the dirty location)
+#   BRANCH     — current branch at that location (or DETACHED)
+#   STATUS     — changes_here | changes_in_worktree | multiple_dirty | clean
+#   (followed by git status --short lines, or DIRTY=<path> lines when multiple)
 
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
-# 1. Check the current working directory first
-CURRENT_CHANGES=$(git status --short 2>/dev/null | grep -c '' || true)
+# Collect every location with a non-empty git status, then decide what to report.
+DIRTY_LOCATIONS=()
 
-if [ "$CURRENT_CHANGES" -gt 0 ]; then
-  echo "GIT_ROOT=$REPO_ROOT"
-  echo "BRANCH=$(git branch --show-current)"
-  echo "STATUS=changes_here"
-  git status --short
-  exit 0
+count_changes() {
+  # Print the number of changed paths at the given dir. Always echoes a number.
+  local dir="$1"
+  git -C "$dir" status --short 2>/dev/null | wc -l | tr -d ' '
+}
+
+# 1. Check the main repo
+if [ "$(count_changes "$REPO_ROOT")" -gt 0 ]; then
+  DIRTY_LOCATIONS+=("$REPO_ROOT")
 fi
 
-# 2. Walk all registered worktrees looking for dirty state
+# 2. Walk all registered worktrees (skip the main repo — already checked)
 while IFS= read -r line; do
   if [[ "$line" == worktree\ * ]]; then
     WT_PATH="${line#worktree }"
-    [ "$WT_PATH" = "$REPO_ROOT" ] && continue   # skip main, already checked
-
-    WT_CHANGES=$(git -C "$WT_PATH" status --short 2>/dev/null | grep -c '' || true)
-    if [ "$WT_CHANGES" -gt 0 ]; then
-      echo "GIT_ROOT=$WT_PATH"
-      echo "BRANCH=$(git -C "$WT_PATH" branch --show-current)"
-      echo "STATUS=changes_in_worktree"
-      git -C "$WT_PATH" status --short
-      exit 0
+    [ "$WT_PATH" = "$REPO_ROOT" ] && continue
+    if [ "$(count_changes "$WT_PATH")" -gt 0 ]; then
+      DIRTY_LOCATIONS+=("$WT_PATH")
     fi
   fi
 done < <(git worktree list --porcelain)
 
-# 3. Nothing dirty anywhere
-echo "GIT_ROOT=$REPO_ROOT"
-echo "BRANCH=$(git branch --show-current)"
-echo "STATUS=clean"
+# 3a. Nothing dirty
+if [ "${#DIRTY_LOCATIONS[@]}" -eq 0 ]; then
+  echo "GIT_ROOT=$REPO_ROOT"
+  BR=$(git -C "$REPO_ROOT" branch --show-current)
+  echo "BRANCH=${BR:-DETACHED}"
+  echo "STATUS=clean"
+  exit 0
+fi
+
+# 3b. More than one dirty location — surface the ambiguity instead of silently
+# picking the first one. The caller decides how to proceed.
+if [ "${#DIRTY_LOCATIONS[@]}" -gt 1 ]; then
+  echo "STATUS=multiple_dirty"
+  for loc in "${DIRTY_LOCATIONS[@]}"; do
+    echo "DIRTY=$loc"
+  done
+  exit 0
+fi
+
+# 3c. Exactly one dirty location
+LOC="${DIRTY_LOCATIONS[0]}"
+echo "GIT_ROOT=$LOC"
+BR=$(git -C "$LOC" branch --show-current)
+echo "BRANCH=${BR:-DETACHED}"
+if [ "$LOC" = "$REPO_ROOT" ]; then
+  echo "STATUS=changes_here"
+else
+  echo "STATUS=changes_in_worktree"
+fi
+git -C "$LOC" status --short

--- a/.claude/commands/gitflow/scripts/push.sh
+++ b/.claude/commands/gitflow/scripts/push.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pushes a branch to origin and sets the upstream tracking ref.
+# Usage: push.sh [-C <git-root>] <branch-name>
+
+set -euo pipefail
+
+GIT_ROOT=""
+BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -C) GIT_ROOT="$2"; shift 2 ;;
+    *)  BRANCH="$1"; shift ;;
+  esac
+done
+
+[ -z "$BRANCH" ] && { echo "ERROR: branch-name required" >&2; exit 1; }
+
+if [ -n "$GIT_ROOT" ]; then
+  git -C "$GIT_ROOT" push -u origin "$BRANCH"
+else
+  git push -u origin "$BRANCH"
+fi

--- a/.claude/commands/gitflow/scripts/push.sh
+++ b/.claude/commands/gitflow/scripts/push.sh
@@ -16,6 +16,13 @@ done
 
 [ -z "$BRANCH" ] && { echo "ERROR: branch-name required" >&2; exit 1; }
 
+# Defense in depth: never push protected base branches through gitflow.
+case "$BRANCH" in
+  main|master)
+    echo "ERROR: refusing to push protected branch '$BRANCH' from gitflow" >&2
+    exit 1 ;;
+esac
+
 if [ -n "$GIT_ROOT" ]; then
   git -C "$GIT_ROOT" push -u origin "$BRANCH"
 else

--- a/.claude/commands/gitflow/scripts/stage.sh
+++ b/.claude/commands/gitflow/scripts/stage.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Stages explicit files only — never git add -A or git add .
+# Usage: stage.sh [-C <git-root>] <file1> [file2 ...]
+#
+# -C <git-root>   run git from this directory (use for worktree paths)
+
+set -euo pipefail
+
+GIT_ROOT=""
+FILES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -C) GIT_ROOT="$2"; shift 2 ;;
+    *)  FILES+=("$1"); shift ;;
+  esac
+done
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  echo "ERROR: at least one file path required" >&2
+  exit 1
+fi
+
+if [ -n "$GIT_ROOT" ]; then
+  git -C "$GIT_ROOT" add -- "${FILES[@]}"
+else
+  git add -- "${FILES[@]}"
+fi
+
+echo "Staged ${#FILES[@]} file(s): ${FILES[*]}"

--- a/.claude/commands/gitflow/scripts/stage.sh
+++ b/.claude/commands/gitflow/scripts/stage.sh
@@ -9,10 +9,23 @@ set -euo pipefail
 GIT_ROOT=""
 FILES=()
 
+# Defense-in-depth deny-list. The skill caller is expected to filter these out,
+# but we refuse them here too so a slip can never stage a secret.
+DENY_REGEX='(^|/)(\.env(\..*)?|CLAUDE\.md|.*\.pem|.*\.key|.*\.p12|id_rsa(\..*)?|secrets?)$'
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -C) GIT_ROOT="$2"; shift 2 ;;
-    *)  FILES+=("$1"); shift ;;
+    .|-A|--all)
+      echo "ERROR: refusing wildcard staging ('$1') — pass explicit file paths" >&2
+      exit 1 ;;
+    *)
+      if [[ "$1" =~ $DENY_REGEX ]]; then
+        echo "ERROR: refusing to stage sensitive path: '$1'" >&2
+        exit 1
+      fi
+      FILES+=("$1")
+      shift ;;
   esac
 done
 
@@ -27,4 +40,7 @@ else
   git add -- "${FILES[@]}"
 fi
 
-echo "Staged ${#FILES[@]} file(s): ${FILES[*]}"
+echo "Staged ${#FILES[@]} file(s):"
+for f in "${FILES[@]}"; do
+  echo "  + $f"
+done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ git checkout -b <prefix>/<short-kebab-case-description>
 
 Every code change must follow this exact workflow — no exceptions.
 
+> **Use `/gitflow` to execute Steps 1, 3, 4, and 5 atomically.** This skill runs the full workflow deterministically via pre-written shell scripts — branch creation, commit, push, PR creation, and code review trigger. Invoke it whenever you hear "run the gitflow", "commit and open a PR", "ship this", "push and create a PR", or any equivalent instruction to execute the workflow after implementation is done.
+
 ---
 
 ### Step 1: Create a Branch


### PR DESCRIPTION
## Summary
- Adds a `/gitflow` slash command skill that runs the full git workflow deterministically using pre-written shell scripts
- Claude infers values (branch, type, commit message, PR body) from conversation context, then calls locked scripts — no command re-derivation
- Worktree-aware: `detect.sh` scans all registered git worktrees to find where changes live

## Changes
- `.claude/commands/gitflow.md` — skill file with 4-phase workflow: detect → infer → dry-run/confirm → execute scripts
- `.claude/commands/gitflow/scripts/detect.sh` — finds dirty files in main repo or any worktree
- `.claude/commands/gitflow/scripts/create-branch.sh` — branches from `origin/main` (not stale local)
- `.claude/commands/gitflow/scripts/stage.sh` — explicit file list only, never `git add -A`
- `.claude/commands/gitflow/scripts/commit.sh` — structured commit with Co-Authored-By, body via stdin
- `.claude/commands/gitflow/scripts/push.sh` — pushes with upstream tracking
- `.claude/commands/gitflow/scripts/create-pr.sh` — `gh pr create` targeting `main`, outputs URL

## Test plan
- [ ] Type `/gitflow` after implementing a feature — skill loads and runs `detect.sh`
- [ ] Verify dry-run block appears before any git write command
- [ ] Reply `e` to edit a value, confirm re-display works
- [ ] Reply `y` and confirm each script is called in order (4a–4f)
- [ ] Test with changes in a worktree — `detect.sh` should find them
- [ ] Confirm `create-pr.sh` outputs the PR URL and 4f triggers the orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)