### PR TITLE
feat: DB migration — add is_applied_stage flag to stages

### DIFF
--- a/backend/migrations/015_add_is_applied_stage_to_stages.ts
+++ b/backend/migrations/015_add_is_applied_stage_to_stages.ts
@@ -1,0 +1,14 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('stages', (table) => {
+    table.boolean('is_applied_stage').notNullable().defaultTo(false);
+  });
+  await knex.raw(`UPDATE stages SET is_applied_stage = true WHERE LOWER(name) = 'applied'`);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('stages', (table) => {
+    table.dropColumn('is_applied_stage');
+  });
+}

--- a/backend/seeds/001_demo_data.ts
+++ b/backend/seeds/001_demo_data.ts
@@ -44,6 +44,8 @@ export async function seed(knex: Knex): Promise<void> {
       name: stage.name,
       position: stage.position,
       is_default: true,
+      is_rejection_stage: stage.name === 'Rejected',
+      is_applied_stage: stage.name === 'Applied',
     });
   }
 

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -86,6 +86,7 @@ async function createDefaultStages(userId: string): Promise<void> {
     position: index,
     is_default: true,
     is_rejection_stage: name === 'Rejected',
+    is_applied_stage: name === 'Applied',
   }));
 
   await db('stages').insert(stages);


### PR DESCRIPTION
## Summary
- Adds `is_applied_stage boolean default false` column to the `stages` table via migration 015
- Backfills the flag on all existing \"Applied\" stages (case-insensitive match)
- Seeds the flag for new users in account setup and demo data seeder

## Acceptance criteria
- [x] Migration adds `is_applied_stage boolean default false` to `stages` table
- [x] Backfill sets the flag on each existing user's \"Applied\" stage (case-insensitive name match)
- [x] Users with no \"Applied\" stage are left without the flag (no error, graceful skip)
- [x] Account setup seeder seeds `is_applied_stage = true` on the \"Applied\" stage for new users
- [x] `SELECT * FROM stages WHERE is_applied_stage = true` returns the correct row for the existing user after migration

## Related
Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)