### PR TITLE
fix: add extracted_role_title and extracted_job_url columns to processed_emails

### DIFF
--- a/backend/migrations/016_add_extracted_fields_to_processed_emails.ts
+++ b/backend/migrations/016_add_extracted_fields_to_processed_emails.ts
@@ -1,0 +1,15 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('processed_emails', (table) => {
+    table.string('extracted_role_title', 255).nullable();
+    table.text('extracted_job_url').nullable();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('processed_emails', (table) => {
+    table.dropColumn('extracted_role_title');
+    table.dropColumn('extracted_job_url');
+  });
+}

--- a/backend/src/services/emailClassifier.ts
+++ b/backend/src/services/emailClassifier.ts
@@ -6,8 +6,8 @@ import { z } from 'zod';
 const classificationSchema = z.object({
   type: z.enum(['rejection', 'application_receipt', 'other']),
   companyName: z.string().max(200).nullable(),
-  roleTitle: z.string().max(200).nullable(),
-  jobUrl: z.string().url().refine(
+  roleTitle: z.string().max(255).nullable(),
+  jobUrl: z.string().url().max(2048).refine(
     url => /^https?:\/\//i.test(url),
     { message: 'jobUrl must use http or https scheme' }
   ).nullable(),

--- a/backend/src/services/gmailSyncService.ts
+++ b/backend/src/services/gmailSyncService.ts
@@ -90,6 +90,8 @@ export async function syncUserGmail(userId: string): Promise<SyncSummary> {
       received_at: email.receivedAt,
       confidence: classification.confidence,
       extracted_company: classification.companyName,
+      extracted_role_title: classification.type === 'application_receipt' ? classification.roleTitle : null,
+      extracted_job_url: classification.type === 'application_receipt' ? classification.jobUrl : null,
     };
 
     if (classification.type !== 'rejection') {


### PR DESCRIPTION
## Summary
- Adds `extracted_role_title` (varchar 255, nullable) and `extracted_job_url` (text, nullable) columns to `processed_emails` via migration 016
- Updates `baseLog` in `gmailSyncService` to populate both fields when `type === 'application_receipt'`, leaving them `null` for rejection and other types

## Acceptance criteria
- [x] Migration adds `extracted_role_title varchar(255) nullable` to `processed_emails`
- [x] Migration adds `extracted_job_url text nullable` to `processed_emails`
- [x] `baseLog` in `gmailSyncService` includes both fields, populated only when `type === 'application_receipt'`
- [x] For `rejection` and `other` email types, both columns remain `null`
- [x] Migration runs cleanly on existing data (all existing rows get `null` for both columns)

## Related
Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)