### PR TITLE
docs: Application Receipt domain terms + feature planning process checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,37 @@ git checkout -b <prefix>/<short-kebab-case-description>
 
 ---
 
+## Feature Planning Workflow
+
+Before any code is written, new features follow this planning sequence:
+**grill-with-docs → write-a-prd → prd-to-issues → ship**
+
+Two mandatory checks must happen at specific phases to prevent schema gaps from slipping through to implementation.
+
+---
+
+### Grill phase — "Follow the data" check
+
+When the grill resolves what data the system will extract or compute (from emails, APIs, user input, etc.), ask for every new field:
+
+1. **Where does it live permanently?** (e.g., the `cards` table)
+2. **Where does it live in the audit log?** (e.g., the `processed_emails` table)
+
+If the answer to #2 doesn't match the existing column pattern on that audit table, flag it as a schema gap and resolve it before closing the grill. Do not leave audit log columns to be discovered during code review.
+
+---
+
+### prd-to-issues phase — "Enumerate all table changes" check
+
+Before finalising the slice breakdown, explicitly list every database table the feature touches — not just the primary new tables but all side-effect tables (audit logs, join tables, seeder targets). For each table:
+
+- Are all new columns covered by a migration issue's acceptance criteria?
+- Is any existing table missing a column that the new feature implies?
+
+If a column is used by one issue but its migration is not assigned to any issue, create a dedicated migration slice before the issue that depends on it.
+
+---
+
 ## Development Workflow
 
 Every code change must follow this exact workflow — no exceptions.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,9 +16,17 @@ _Avoid_: Status, Column, State
 A Stage whose `is_rejection_stage` flag is set — the Email Agent routes matching rejection emails to this Stage. The flag is seeded automatically to the Stage named "Rejected" at account setup; there is currently no UI to change it. Only one Rejection Stage per user is expected.
 _Avoid_: Terminal stage, Closed stage
 
+**Applied Stage**:
+A Stage whose `is_applied_stage` flag is set — the Email Agent places auto-created Applications here when it detects an Application Receipt. The flag is seeded automatically to the Stage named "Applied" at account setup; there is currently no UI to change it. Only one Applied Stage per user is expected. Mirrors the Rejection Stage pattern.
+_Avoid_: Submitted stage, In-progress stage
+
 **Email Agent**:
-An automated process that reads the user's inbox and acts on Applications based on detected email patterns. Currently handles rejection emails; designed to handle other hiring-process events in the future.
+An automated process that reads the user's inbox and acts on Applications based on detected email patterns. Currently handles rejection emails and Application Receipts; designed to handle other hiring-process events in the future.
 _Avoid_: Rejection Agent, Email Processor, Inbox Monitor
+
+**Application Receipt**:
+An email sent by a company to acknowledge that they received a job application. When the Email Agent detects one with no matching Application in the system, it auto-creates a new Application. Not to be confused with a rejection — an Application Receipt confirms receipt, not outcome.
+_Avoid_: Application confirmation, Acknowledgement email, Receipt email
 
 **Activity**:
 A row in `card_activities` representing either a system-recorded event (action = `created`, `updated`, or `moved`) or a user-authored Note (action = `note_added`). System Activities are created automatically when an Application is created, a field changes, or the Application moves to a new Stage.
@@ -44,9 +52,11 @@ _Avoid_: Todo (internal/DB term), Checklist item
 
 - A **User** owns a set of **Stages**
 - An **Application** lives in exactly one **Stage** at a time
-- One **Stage** per user is seeded as the **Rejection Stage** (the Email Agent's routing target)
+- One **Stage** per user is seeded as the **Rejection Stage** (the Email Agent's routing target for rejections)
+- One **Stage** per user is seeded as the **Applied Stage** (the Email Agent's placement target for auto-created Applications)
 - An **Application** accumulates **Activities** (system) and **Notes** (user) over its lifetime; both are stored in `card_activities` and displayed together as its **Timeline**
 - The **Email Agent** moves **Applications** into the **Rejection Stage** when a matching email is received
+- The **Email Agent** auto-creates **Applications** in the **Applied Stage** when an Application Receipt is detected and no matching Application exists
 - The **Email Agent** produces **Notifications** to inform the user of every automated action it takes
 - A **Task** may optionally be linked to an **Application**; a **Task** without a link is standalone
 

--- a/docs/adr/0001-applied-stage-flag.md
+++ b/docs/adr/0001-applied-stage-flag.md
@@ -1,0 +1,20 @@
+# ADR 0001: Applied Stage flag mirrors Rejection Stage pattern
+
+## Status
+Proposed
+
+## Context
+The Email Agent needs a target Stage when auto-creating Applications from Application Receipts. Three options were considered:
+
+1. Use the default Stage (`is_default = true`) — always available, but semantically wrong (the default is typically "Wishlist", not "Applied")
+2. Name-based heuristic ("Applied") with fallback to default — works for most users but is brittle against renamed or non-English Stages
+3. Add an `is_applied_stage` flag to the `stages` table, seeded to the "Applied" Stage at account setup — mirrors the existing `is_rejection_stage` pattern exactly
+
+## Decision
+Add `is_applied_stage` boolean flag to `stages`. Seed it to the "Applied" Stage at account creation (same mechanism used for `is_rejection_stage` on "Rejected"). The Email Agent reads this flag to find the placement target, identical to how it reads `is_rejection_stage` for rejections.
+
+## Consequences
+- Requires a migration to add the column and backfill existing users' "Applied" Stage
+- Consistent with the existing Rejection Stage mental model — no new pattern to learn
+- No UI to reassign the flag (same limitation as Rejection Stage — deferred)
+- If a user has no Stage with `is_applied_stage = true` (e.g., deleted it), fall back to the default Stage and include that in the Notification


### PR DESCRIPTION
## Summary
- Adds Application Receipt and Applied Stage to CONTEXT.md (domain glossary terms resolved during grill session)
- Adds Feature Planning Workflow section to CLAUDE.md with two mandatory pre-implementation checks to prevent schema gaps
- Adds ADR 0001 documenting the is_applied_stage flag decision

## Changes
- CONTEXT.md: new terms (Application Receipt, Applied Stage), updated Email Agent definition and Relationships
- CLAUDE.md: new Feature Planning Workflow section with grill-phase and prd-to-issues-phase checklists
- docs/adr/0001-applied-stage-flag.md: new ADR

## Test plan
- [ ] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)