### PR TITLE
feat: applicationReceiptHandler — core receipt processing module

### DIFF
--- a/backend/src/services/applicationReceiptHandler.ts
+++ b/backend/src/services/applicationReceiptHandler.ts
@@ -1,0 +1,118 @@
+import db from '@/config/database';
+import { cardService } from '@/services/cardService';
+import { notificationService } from '@/services/notificationService';
+
+export interface ApplicationReceiptInput {
+  userId: string;
+  gmailMessageId: string;
+  subject: string;
+  sender: string;
+  companyName: string | null;
+  roleTitle: string | null;
+  jobUrl: string | null;
+  confidence: number;
+  emailReceivedAt: Date;
+}
+
+export interface ApplicationReceiptResult {
+  action: 'created' | 'already_tracked' | 'low_confidence';
+}
+
+function normalizeText(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function substringMatch(a: string, b: string): boolean {
+  return a.includes(b) || b.includes(a);
+}
+
+export async function applicationReceiptHandler(
+  input: ApplicationReceiptInput
+): Promise<ApplicationReceiptResult> {
+  const { userId, gmailMessageId, subject, sender, companyName, roleTitle, jobUrl, confidence, emailReceivedAt } = input;
+
+  const baseLog = {
+    user_id: userId,
+    gmail_message_id: gmailMessageId,
+    subject,
+    sender,
+    received_at: emailReceivedAt,
+    confidence,
+    extracted_company: companyName,
+    extracted_role_title: roleTitle,
+    extracted_job_url: jobUrl,
+  };
+
+  if (confidence < 0.9 || companyName === null) {
+    await db('processed_emails').insert({ ...baseLog, action: 'receipt_low_confidence' });
+    await notificationService.create(
+      userId,
+      'Application email detected',
+      'We found a possible application email but could not process it with high enough confidence.',
+      { companyName, roleTitle, confidence }
+    );
+    return { action: 'low_confidence' };
+  }
+
+  const appliedStage = await db('stages')
+    .where({ user_id: userId, is_applied_stage: true })
+    .first();
+
+  let stage = appliedStage;
+  let usingFallbackStage = false;
+
+  if (!stage) {
+    stage = await db('stages').where({ user_id: userId, is_default: true }).first();
+    usingFallbackStage = true;
+  }
+
+  const existingCards: { company_name: string; role_title: string }[] = await db('cards')
+    .where({ user_id: userId })
+    .select('company_name', 'role_title');
+
+  const finalRoleTitle = roleTitle ?? 'Unknown Role';
+  const normalizedNewCompany = normalizeText(companyName);
+  const normalizedNewRole = normalizeText(finalRoleTitle);
+
+  const isDuplicate = existingCards.some((card) => {
+    const existingCompany = normalizeText(card.company_name);
+    const existingRole = normalizeText(card.role_title);
+    return substringMatch(normalizedNewCompany, existingCompany) &&
+           substringMatch(normalizedNewRole, existingRole);
+  });
+
+  if (isDuplicate) {
+    await db('processed_emails').insert({ ...baseLog, action: 'receipt_already_tracked' });
+    await notificationService.create(
+      userId,
+      'Application already tracked',
+      `Your application to ${companyName} is already in your pipeline.`,
+      { companyName, roleTitle }
+    );
+    return { action: 'already_tracked' };
+  }
+
+  const card = await cardService.createCard(userId, {
+    stage_id: stage.id,
+    company_name: companyName,
+    role_title: finalRoleTitle,
+    application_url: jobUrl ?? undefined,
+    source: 'email',
+    date_applied: emailReceivedAt.toISOString().split('T')[0],
+  });
+
+  await db('processed_emails').insert({ ...baseLog, action: 'receipt_created', card_id: card.id });
+
+  const notificationBody = usingFallbackStage
+    ? `Application to ${companyName} added — no "Applied" stage found, placed in default stage.`
+    : `Application to ${companyName} added to your pipeline.`;
+
+  await notificationService.create(
+    userId,
+    'Application added',
+    notificationBody,
+    { companyName, roleTitle: finalRoleTitle, cardId: card.id }
+  );
+
+  return { action: 'created' };
+}

--- a/backend/src/services/applicationReceiptHandler.ts
+++ b/backend/src/services/applicationReceiptHandler.ts
@@ -1,6 +1,14 @@
 import db from '@/config/database';
 import { cardService } from '@/services/cardService';
 import { notificationService } from '@/services/notificationService';
+import { AppError } from '@/middleware/errorHandler';
+
+const MAX_VARCHAR_255 = 255;
+
+function truncate(value: string | null, max = MAX_VARCHAR_255): string | null {
+  if (value === null) return null;
+  return value.length > max ? value.slice(0, max) : value;
+}
 
 export interface ApplicationReceiptInput {
   userId: string;
@@ -35,16 +43,19 @@ export async function applicationReceiptHandler(
     user_id: userId,
     gmail_message_id: gmailMessageId,
     subject,
-    sender,
+    sender: truncate(sender),
     received_at: emailReceivedAt,
     confidence,
-    extracted_company: companyName,
-    extracted_role_title: roleTitle,
+    extracted_company: truncate(companyName),
+    extracted_role_title: truncate(roleTitle),
     extracted_job_url: jobUrl,
   };
 
-  if (confidence < 0.9 || companyName === null) {
-    await db('processed_emails').insert({ ...baseLog, action: 'receipt_low_confidence' });
+  if (!Number.isFinite(confidence) || confidence < 0.9 || companyName === null) {
+    await db('processed_emails')
+      .insert({ ...baseLog, action: 'receipt_low_confidence' })
+      .onConflict(['user_id', 'gmail_message_id'])
+      .ignore();
     await notificationService.create(
       userId,
       'Application email detected',
@@ -66,28 +77,39 @@ export async function applicationReceiptHandler(
     usingFallbackStage = true;
   }
 
-  const existingCards: { company_name: string; role_title: string }[] = await db('cards')
+  if (!stage) {
+    throw new AppError(
+      'No stages configured for user — cannot process application receipt',
+      500,
+      'ERR_NO_STAGES'
+    );
+  }
+
+  const existingCards: { id: string; company_name: string; role_title: string }[] = await db('cards')
     .where({ user_id: userId })
-    .select('company_name', 'role_title');
+    .select('id', 'company_name', 'role_title');
 
   const finalRoleTitle = roleTitle ?? 'Unknown Role';
   const normalizedNewCompany = normalizeText(companyName);
   const normalizedNewRole = normalizeText(finalRoleTitle);
 
-  const isDuplicate = existingCards.some((card) => {
+  const matchedCard = existingCards.find((card) => {
     const existingCompany = normalizeText(card.company_name);
     const existingRole = normalizeText(card.role_title);
     return substringMatch(normalizedNewCompany, existingCompany) &&
            substringMatch(normalizedNewRole, existingRole);
   });
 
-  if (isDuplicate) {
-    await db('processed_emails').insert({ ...baseLog, action: 'receipt_already_tracked' });
+  if (matchedCard) {
+    await db('processed_emails')
+      .insert({ ...baseLog, action: 'receipt_already_tracked', card_id: matchedCard.id })
+      .onConflict(['user_id', 'gmail_message_id'])
+      .ignore();
     await notificationService.create(
       userId,
       'Application already tracked',
-      `Your application to ${companyName} is already in your pipeline.`,
-      { companyName, roleTitle }
+      `Your application to ${truncate(companyName, 120)} is already in your pipeline.`,
+      { companyName, roleTitle, matchedCardId: matchedCard.id }
     );
     return { action: 'already_tracked' };
   }
@@ -101,11 +123,15 @@ export async function applicationReceiptHandler(
     date_applied: emailReceivedAt.toISOString().split('T')[0],
   });
 
-  await db('processed_emails').insert({ ...baseLog, action: 'receipt_created', card_id: card.id });
+  await db('processed_emails')
+    .insert({ ...baseLog, action: 'receipt_created', card_id: card.id })
+    .onConflict(['user_id', 'gmail_message_id'])
+    .ignore();
 
+  const safeCompany = truncate(companyName, 120);
   const notificationBody = usingFallbackStage
-    ? `Application to ${companyName} added — no "Applied" stage found, placed in default stage.`
-    : `Application to ${companyName} added to your pipeline.`;
+    ? `Application to ${safeCompany} added — no "Applied" stage found, placed in default stage.`
+    : `Application to ${safeCompany} added to your pipeline.`;
 
   await notificationService.create(
     userId,

--- a/backend/tests/applicationReceiptHandler.test.ts
+++ b/backend/tests/applicationReceiptHandler.test.ts
@@ -7,6 +7,7 @@ function createQueryChain(resolvedValue: unknown = undefined) {
   const methods = [
     'where', 'andWhere', 'select', 'first', 'insert', 'update', 'del',
     'returning', 'max', 'join', 'orderBy', 'limit',
+    'onConflict', 'ignore', 'merge',
   ];
   for (const method of methods) {
     chain[method] = jest.fn().mockReturnValue(chain);

--- a/backend/tests/applicationReceiptHandler.test.ts
+++ b/backend/tests/applicationReceiptHandler.test.ts
@@ -1,0 +1,202 @@
+// ── Mock the database module before importing anything that uses it ──────────
+
+const mockDb = jest.fn();
+
+function createQueryChain(resolvedValue: unknown = undefined) {
+  const chain: Record<string, jest.Mock> = {};
+  const methods = [
+    'where', 'andWhere', 'select', 'first', 'insert', 'update', 'del',
+    'returning', 'max', 'join', 'orderBy', 'limit',
+  ];
+  for (const method of methods) {
+    chain[method] = jest.fn().mockReturnValue(chain);
+  }
+  chain.first = jest.fn().mockResolvedValue(resolvedValue);
+  chain.del = jest.fn().mockResolvedValue(1);
+  (chain as any).then = (resolve: (v: unknown) => void, reject: (e: unknown) => void) =>
+    Promise.resolve(Array.isArray(resolvedValue) ? resolvedValue : [resolvedValue]).then(resolve, reject);
+  return chain;
+}
+
+jest.mock('../src/config/database', () => {
+  const handler = (tableName: string) => mockDb(tableName);
+  handler.raw = jest.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] });
+  return { __esModule: true, default: handler };
+});
+
+jest.mock('../src/services/cardService', () => ({
+  cardService: {
+    createCard: jest.fn().mockResolvedValue({ id: 'card-123', stage_name: 'Applied' }),
+  },
+}));
+
+jest.mock('../src/services/notificationService', () => ({
+  notificationService: {
+    create: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+import { applicationReceiptHandler, ApplicationReceiptInput } from '../src/services/applicationReceiptHandler';
+import { cardService } from '../src/services/cardService';
+import { notificationService } from '../src/services/notificationService';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const USER_ID = 'user-abc-123';
+const MSG_ID = 'gmail-msg-001';
+const APPLIED_STAGE = { id: 'stage-applied-1', name: 'Applied', is_applied_stage: true, is_default: false };
+const DEFAULT_STAGE = { id: 'stage-default-1', name: 'New', is_applied_stage: false, is_default: true };
+
+const BASE_INPUT: ApplicationReceiptInput = {
+  userId: USER_ID,
+  gmailMessageId: MSG_ID,
+  subject: 'Your application to Acme Corp',
+  sender: 'noreply@acme.com',
+  companyName: 'Acme Corp',
+  roleTitle: 'Software Engineer',
+  jobUrl: 'https://acme.com/jobs/123',
+  confidence: 0.95,
+  emailReceivedAt: new Date('2024-01-15T10:00:00Z'),
+};
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+function setupDb(options: {
+  appliedStage?: typeof APPLIED_STAGE | null;
+  defaultStage?: typeof DEFAULT_STAGE | null;
+  existingCards?: { company_name: string; role_title: string }[];
+}) {
+  const { appliedStage = APPLIED_STAGE, defaultStage = DEFAULT_STAGE, existingCards = [] } = options;
+
+  let stagesCallCount = 0;
+  const processedEmailsChain = createQueryChain(undefined);
+  const cardsChain = createQueryChain(existingCards);
+
+  mockDb.mockImplementation((tableName: string) => {
+    if (tableName === 'stages') {
+      stagesCallCount++;
+      if (stagesCallCount === 1) {
+        return createQueryChain(appliedStage);
+      }
+      return createQueryChain(defaultStage);
+    }
+    if (tableName === 'cards') return cardsChain;
+    if (tableName === 'processed_emails') return processedEmailsChain;
+    return createQueryChain(undefined);
+  });
+
+  return { processedEmailsChain, cardsChain };
+}
+
+// =============================================================================
+// applicationReceiptHandler tests
+// =============================================================================
+
+describe('applicationReceiptHandler', () => {
+  it('full data → Application created in Applied Stage, receipt_created recorded, Notification fired', async () => {
+    const { processedEmailsChain } = setupDb({ appliedStage: APPLIED_STAGE, existingCards: [] });
+
+    const result = await applicationReceiptHandler(BASE_INPUT);
+
+    expect(result).toEqual({ action: 'created' });
+
+    expect(cardService.createCard).toHaveBeenCalledWith(USER_ID, expect.objectContaining({
+      stage_id: APPLIED_STAGE.id,
+      company_name: 'Acme Corp',
+      role_title: 'Software Engineer',
+      source: 'email',
+      application_url: 'https://acme.com/jobs/123',
+    }));
+
+    expect(processedEmailsChain.insert).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'receipt_created',
+      card_id: 'card-123',
+    }));
+
+    expect(notificationService.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('roleTitle null → Application created with "Unknown Role"', async () => {
+    setupDb({ appliedStage: APPLIED_STAGE, existingCards: [] });
+
+    const result = await applicationReceiptHandler({ ...BASE_INPUT, roleTitle: null });
+
+    expect(result).toEqual({ action: 'created' });
+    expect(cardService.createCard).toHaveBeenCalledWith(USER_ID, expect.objectContaining({
+      role_title: 'Unknown Role',
+    }));
+  });
+
+  it('company + role match existing Application → no creation, receipt_already_tracked recorded, Notification fired', async () => {
+    const { processedEmailsChain } = setupDb({
+      appliedStage: APPLIED_STAGE,
+      existingCards: [{ company_name: 'Acme Corp', role_title: 'Software Engineer' }],
+    });
+
+    const result = await applicationReceiptHandler(BASE_INPUT);
+
+    expect(result).toEqual({ action: 'already_tracked' });
+    expect(cardService.createCard).not.toHaveBeenCalled();
+    expect(processedEmailsChain.insert).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'receipt_already_tracked',
+    }));
+    expect(notificationService.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('company matches but role does not → new Application created (not a duplicate)', async () => {
+    setupDb({
+      appliedStage: APPLIED_STAGE,
+      existingCards: [{ company_name: 'Acme Corp', role_title: 'Product Manager' }],
+    });
+
+    const result = await applicationReceiptHandler(BASE_INPUT);
+
+    expect(result).toEqual({ action: 'created' });
+    expect(cardService.createCard).toHaveBeenCalledTimes(1);
+  });
+
+  it('confidence < 0.9 → no creation, receipt_low_confidence recorded, Notification fired', async () => {
+    const { processedEmailsChain } = setupDb({ appliedStage: APPLIED_STAGE });
+
+    const result = await applicationReceiptHandler({ ...BASE_INPUT, confidence: 0.85 });
+
+    expect(result).toEqual({ action: 'low_confidence' });
+    expect(cardService.createCard).not.toHaveBeenCalled();
+    expect(processedEmailsChain.insert).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'receipt_low_confidence',
+    }));
+    expect(notificationService.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('no Applied Stage → Application created in default Stage, Notification includes fallback warning', async () => {
+    const { processedEmailsChain } = setupDb({
+      appliedStage: null,
+      defaultStage: DEFAULT_STAGE,
+      existingCards: [],
+    });
+
+    const result = await applicationReceiptHandler(BASE_INPUT);
+
+    expect(result).toEqual({ action: 'created' });
+    expect(cardService.createCard).toHaveBeenCalledWith(USER_ID, expect.objectContaining({
+      stage_id: DEFAULT_STAGE.id,
+    }));
+
+    const notifCall = (notificationService.create as jest.Mock).mock.calls[0];
+    expect(notifCall[2]).toMatch(/fallback|default stage/i);
+  });
+
+  it('companyName null → no creation, receipt_low_confidence recorded', async () => {
+    const { processedEmailsChain } = setupDb({ appliedStage: APPLIED_STAGE });
+
+    const result = await applicationReceiptHandler({ ...BASE_INPUT, companyName: null });
+
+    expect(result).toEqual({ action: 'low_confidence' });
+    expect(cardService.createCard).not.toHaveBeenCalled();
+    expect(processedEmailsChain.insert).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'receipt_low_confidence',
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `applicationReceiptHandler` — a deep module that encapsulates the entire Application Receipt processing flow
- Accepts extracted email data + `userId` and handles Applied Stage lookup, fuzzy deduplication, Application creation, Notification creation, and `processed_emails` recording
- Returns `{ action: 'created' | 'already_tracked' | 'low_confidence' }`

## Acceptance criteria
- [x] Applied Stage lookup finds the stage with `is_applied_stage = true`; falls back to the default stage if none found
- [x] Deduplication: normalise (lowercase, strip punctuation) + substring match in both directions on both `companyName` AND `roleTitle`
- [x] Auto-created Application fields: `source = "email"`, `date_applied = emailReceivedAt`, `application_url = jobUrl`
- [x] `roleTitle` falls back to `"Unknown Role"` when null
- [x] Confidence threshold: `≥ 0.9` to act; below threshold → `receipt_low_confidence`, Notification, no Application created
- [x] Unit test: full data → Application created in Applied Stage, `receipt_created` recorded, Notification fired
- [x] Unit test: `roleTitle: null` → Application created with `"Unknown Role"`
- [x] Unit test: company + role match existing Application → no creation, `receipt_already_tracked` recorded, Notification fired
- [x] Unit test: company matches but role does not → new Application created (not a duplicate)
- [x] Unit test: `confidence < 0.9` → no creation, `receipt_low_confidence` recorded, Notification fired
- [x] Unit test: no Applied Stage → Application created in default Stage, Notification includes fallback warning
- [x] Unit test: `companyName: null` → no creation, `receipt_low_confidence` recorded

## Related
Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)