### PR TITLE
feat: wire applicationReceiptHandler into gmailSyncService

### DIFF
--- a/backend/src/services/applicationReceiptHandler.ts
+++ b/backend/src/services/applicationReceiptHandler.ts
@@ -1,7 +1,7 @@
-import db from '@/config/database';
-import { cardService } from '@/services/cardService';
-import { notificationService } from '@/services/notificationService';
-import { AppError } from '@/middleware/errorHandler';
+import db from '../config/database';
+import { cardService } from '../services/cardService';
+import { notificationService } from '../services/notificationService';
+import { AppError } from '../middleware/errorHandler';
 
 const MAX_VARCHAR_255 = 255;
 

--- a/backend/src/services/gmailSyncService.ts
+++ b/backend/src/services/gmailSyncService.ts
@@ -6,6 +6,16 @@ import { cardService } from './cardService';
 import { notificationService } from './notificationService';
 import { applicationReceiptHandler } from './applicationReceiptHandler';
 
+// Max length of the processed_emails.sender column (varchar(255)). Truncate at the
+// call site so an oversized header never causes a silent insert failure — especially
+// in the receipt_handler_error branch, where the catch handler would otherwise
+// swallow the audit row.
+const SENDER_MAX_LEN = 255;
+
+function truncateSender(sender: string): string {
+  return sender.length > SENDER_MAX_LEN ? sender.slice(0, SENDER_MAX_LEN) : sender;
+}
+
 function normalize(str: string): string {
   return str.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
@@ -26,10 +36,11 @@ export interface SyncSummary {
   noMatch: number;
   lowConfidence: number;
   notRejection: number;
+  receipts: number;
 }
 
 export async function syncUserGmail(userId: string): Promise<SyncSummary> {
-  const summary: SyncSummary = { scanned: 0, moved: 0, ambiguous: 0, noMatch: 0, lowConfidence: 0, notRejection: 0 };
+  const summary: SyncSummary = { scanned: 0, moved: 0, ambiguous: 0, noMatch: 0, lowConfidence: 0, notRejection: 0, receipts: 0 };
 
   const gmailToken = await db('gmail_tokens').where({ user_id: userId, is_valid: true }).first();
   if (!gmailToken) return summary;
@@ -87,7 +98,7 @@ export async function syncUserGmail(userId: string): Promise<SyncSummary> {
       user_id: userId,
       gmail_message_id: email.messageId,
       subject: email.subject,
-      sender: email.sender,
+      sender: truncateSender(email.sender),
       received_at: email.receivedAt,
       confidence: classification.confidence,
       extracted_company: classification.companyName,
@@ -108,13 +119,20 @@ export async function syncUserGmail(userId: string): Promise<SyncSummary> {
           confidence: classification.confidence,
           emailReceivedAt: email.receivedAt,
         });
+        summary.receipts++;
       } catch (err) {
         logger.error('applicationReceiptHandler failed', { userId, messageId: email.messageId, error: err });
         await db('processed_emails')
           .insert({ ...baseLog, action: 'receipt_handler_error' })
           .onConflict(['user_id', 'gmail_message_id'])
           .ignore()
-          .catch(() => {});
+          .catch((insertErr) => {
+            logger.error('Failed to record receipt_handler_error in processed_emails', {
+              userId,
+              messageId: email.messageId,
+              error: insertErr,
+            });
+          });
       }
       continue;
     }

--- a/backend/src/services/gmailSyncService.ts
+++ b/backend/src/services/gmailSyncService.ts
@@ -4,6 +4,7 @@ import { gmailService } from './gmailService';
 import { classifyEmail } from './emailClassifier';
 import { cardService } from './cardService';
 import { notificationService } from './notificationService';
+import { applicationReceiptHandler } from './applicationReceiptHandler';
 
 function normalize(str: string): string {
   return str.toLowerCase().replace(/[^a-z0-9]/g, '');
@@ -94,8 +95,35 @@ export async function syncUserGmail(userId: string): Promise<SyncSummary> {
       extracted_job_url: classification.type === 'application_receipt' ? classification.jobUrl : null,
     };
 
-    if (classification.type !== 'rejection') {
-      await db('processed_emails').insert({ ...baseLog, action: 'not_rejection' });
+    if (classification.type === 'application_receipt') {
+      try {
+        await applicationReceiptHandler({
+          userId,
+          gmailMessageId: email.messageId,
+          subject: email.subject,
+          sender: email.sender,
+          companyName: classification.companyName ?? null,
+          roleTitle: classification.roleTitle ?? null,
+          jobUrl: classification.jobUrl ?? null,
+          confidence: classification.confidence,
+          emailReceivedAt: email.receivedAt,
+        });
+      } catch (err) {
+        logger.error('applicationReceiptHandler failed', { userId, messageId: email.messageId, error: err });
+        await db('processed_emails')
+          .insert({ ...baseLog, action: 'receipt_handler_error' })
+          .onConflict(['user_id', 'gmail_message_id'])
+          .ignore()
+          .catch(() => {});
+      }
+      continue;
+    }
+
+    if (classification.type === 'other') {
+      await db('processed_emails')
+        .insert({ ...baseLog, action: 'not_actionable' })
+        .onConflict(['user_id', 'gmail_message_id'])
+        .ignore();
       summary.notRejection++;
       continue;
     }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -237,6 +237,7 @@ export interface SyncSummary {
   noMatch: number;
   lowConfidence: number;
   notRejection: number;
+  receipts: number;
 }
 
 export const gmailApi = {


### PR DESCRIPTION
## Summary
- Added routing in `gmailSyncService` so `application_receipt` emails are dispatched to `applicationReceiptHandler`
- `other` type now records `not_actionable` in `processed_emails` and produces no notification
- `rejection` flow is completely unchanged

## Acceptance criteria
- [x] `rejection` type routes to the existing rejection flow with no change to its behaviour
- [x] `application_receipt` type routes to `applicationReceiptHandler`
- [x] `other` type records `not_actionable` in `processed_emails` and produces no Notification
- [ ] End-to-end: trigger `/api/gmail/sync` with a real Application Receipt in the inbox → Application appears in Applied Stage
- [ ] End-to-end: Notification is created with correct plain-text message
- [ ] End-to-end: email is recorded in `processed_emails` with action `receipt_created`
- [ ] End-to-end: triggering sync again on the same email → no duplicate Application created (idempotent)

## Related
Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)