### PR TITLE
chore: ban @/ path aliases in backend, enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - name: TypeScript check
         run: npx tsc --noEmit
 
+      - name: No path-alias imports
+        run: |
+          if grep -rn "from '@/" src --include="*.ts"; then
+            echo "ERROR: @/ path aliases found in backend source. Use relative imports instead."
+            exit 1
+          fi
+
       - name: Run tests
         run: npx jest --forceExit --detectOpenHandles
 

--- a/backend/eslint.config.mjs
+++ b/backend/eslint.config.mjs
@@ -33,6 +33,12 @@ export default tseslint.config(
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
+      'no-restricted-imports': ['error', {
+        patterns: [{
+          regex: '^@/',
+          message: "Use relative imports (e.g. '../config/database'). @/ aliases are not rewritten by tsc and will crash at runtime.",
+        }],
+      }],
     },
   },
 );


### PR DESCRIPTION
## Summary
- Adds `no-restricted-imports` ESLint rule to `backend/eslint.config.mjs` — editors flag `@/` imports inline
- Adds a `No path-alias imports` grep step to the backend CI job — build fails if any `@/` import reaches `backend/src/`

## Why
`@/` aliases are configured in `tsconfig.json` for ts-jest and pass type-checking, but `tsc` does not rewrite them in the compiled output. They crash the server at runtime with `Cannot find module '@/config/database'` — which is exactly what caused the E2E failure on PR #138.

The frontend legitimately uses `@/` (Vite rewrites them at bundle time), so enforcement is backend-only.

## Related
Closes the enforcement gap surfaced by #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)