### PR TITLE
feat: structured sync result panel — surface receipts, rejections, and review items separately

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,6 +5,43 @@ import { useLocation } from 'react-router-dom';
 import { gmailApi } from '@/services/api';
 import type { GmailStatusData, SyncSummary } from '@/services/api';
 
+function SyncResultPanel({ result }: { result: SyncSummary }) {
+  const pl = (n: number, singular: string, plural: string) => `${n} ${n === 1 ? singular : plural}`;
+  const hasActions = result.receipts > 0 || result.moved > 0 || result.ambiguous > 0 || result.lowConfidence > 0;
+
+  return (
+    <div className="text-sm space-y-1">
+      <p className="font-medium text-gray-800">
+        ✦ Sync complete —{' '}
+        {result.scanned === 0
+          ? 'no new emails'
+          : `${result.scanned} email${result.scanned !== 1 ? 's' : ''} scanned`}
+      </p>
+      {result.scanned > 0 && !hasActions && (
+        <p className="pl-4 text-gray-500">All clear, nothing to action</p>
+      )}
+      {result.receipts > 0 && (
+        <p className="pl-4 text-emerald-700">
+          ✚ {pl(result.receipts, 'new application created', 'new applications created')}
+        </p>
+      )}
+      {result.moved > 0 && (
+        <p className="pl-4 text-gray-500">✕ {result.moved} moved to Rejected</p>
+      )}
+      {result.ambiguous > 0 && (
+        <p className="pl-4 text-amber-700">
+          ⚠ {pl(result.ambiguous, 'email needs your review', 'emails need your review')}
+        </p>
+      )}
+      {result.lowConfidence > 0 && (
+        <p className="pl-4 text-amber-700">
+          ⚠ {pl(result.lowConfidence, 'low confidence match', 'low confidence matches')}
+        </p>
+      )}
+    </div>
+  );
+}
+
 export default function SettingsPage() {
   const [gmailStatus, setGmailStatus] = useState<GmailStatusData>({ connected: false });
   const [loading, setLoading] = useState(true);
@@ -121,11 +158,7 @@ export default function SettingsPage() {
                     ? formatDistanceToNow(parseISO(gmailStatus.lastSyncAt), { addSuffix: true })
                     : 'Never synced yet'}
                 </div>
-                {syncResult && (
-                  <p className="text-sm text-gray-600">
-                    {syncResult.scanned} emails scanned · {syncResult.moved} card{syncResult.moved !== 1 ? 's' : ''} moved to Rejected
-                  </p>
-                )}
+                {syncResult && <SyncResultPanel result={syncResult} />}
                 {syncError && (
                   <p className="text-sm text-red-600">{syncError}</p>
                 )}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,12 +5,19 @@ import { useLocation } from 'react-router-dom';
 import { gmailApi } from '@/services/api';
 import type { GmailStatusData, SyncSummary } from '@/services/api';
 
+const pl = (n: number, singular: string, plural: string) => `${n} ${n === 1 ? singular : plural}`;
+
 function SyncResultPanel({ result }: { result: SyncSummary }) {
-  const pl = (n: number, singular: string, plural: string) => `${n} ${n === 1 ? singular : plural}`;
-  const hasActions = result.receipts > 0 || result.moved > 0 || result.ambiguous > 0 || result.lowConfidence > 0;
+  const hasActions =
+    result.receipts > 0 ||
+    result.moved > 0 ||
+    result.ambiguous > 0 ||
+    result.lowConfidence > 0 ||
+    result.noMatch > 0 ||
+    result.notRejection > 0;
 
   return (
-    <div className="text-sm space-y-1">
+    <div className="text-sm space-y-1" role="status" aria-live="polite">
       <p className="font-medium text-gray-800">
         ✦ Sync complete —{' '}
         {result.scanned === 0


### PR DESCRIPTION
## Summary
- Replaces the single-line sync result text in `SettingsPage` with a structured `SyncResultPanel` component
- Each action type (new applications, rejections, ambiguous, low-confidence) gets its own line with appropriate visual treatment
- Zero-count lines are never rendered; handles "all clear" and "no new emails" edge cases

## Acceptance criteria
- [x] Single-line `<p>` in `SettingsPage` replaced with structured result panel component
- [x] `receipts > 0` renders "X new application(s) created" in green/positive style
- [x] `moved > 0` renders "X moved to Rejected" in neutral style
- [x] `ambiguous > 0` renders "X email(s) need your review" with warning style
- [x] `lowConfidence > 0` renders "X low confidence match(es)" with warning style — separate line from ambiguous
- [x] Lines with count = 0 are not rendered
- [x] When scanned > 0 but all action counts are 0: shows "All clear, nothing to action"
- [x] When scanned = 0: shows "no new emails"
- [x] Correct pluralisation for all lines (1 application vs 2 applications, etc.)
- [x] Visual treatment is consistent with the existing SettingsPage design system

## Related
Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)