### PR TITLE
Perf: hoist existingCards lookup in gmailSync receipt path (with in-batch dedup safety)

### DIFF
--- a/backend/src/services/gmailSync.ts
+++ b/backend/src/services/gmailSync.ts
@@ -430,7 +430,10 @@ async function processReceipt(
   });
 
   summary.receiptsCreated++;
-  return { newCard: { id: card.id, company_name: companyName, role_title: finalRoleTitle } };
+  // Use the persisted row values rather than the extracted strings so the
+  // in-memory list stays the row-of-record even if createCard ever normalises
+  // names on write.
+  return { newCard: { id: card.id, company_name: card.company_name, role_title: card.role_title } };
 }
 
 // ── Rejection path ────────────────────────────────────────────────────────────

--- a/backend/src/services/gmailSync.ts
+++ b/backend/src/services/gmailSync.ts
@@ -72,6 +72,8 @@ interface ClassifiedEmail {
   classification: EmailClassification | null;
 }
 
+type TrxResult = { newCard: { id: string; company_name: string; role_title: string } } | null;
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 // Errors from Gaxios/Axios carry a `config` field that includes the request
@@ -196,6 +198,18 @@ export async function syncUserGmailWith(
       .select('cards.*', 'stages.name as stage_name'),
   ]);
 
+  // Mutable list seeded from the hoisted userCards, fed into processReceipt
+  // so it doesn't have to SELECT per email. Appended ONLY after a transaction
+  // commits with a newly-created card — never inside the trx callback, so a
+  // rolled-back trx leaves no stale entry that could cause the next email
+  // to falsely report receipt_already_tracked.
+  const userCardsForReceipt: Array<{ id: string; company_name: string; role_title: string }> =
+    userCards.map((c: { id: string; company_name: string; role_title: string }) => ({
+      id: c.id,
+      company_name: c.company_name,
+      role_title: c.role_title,
+    }));
+
   // ── Process emails — one short transaction per email ─────────────────────
   for (const { email, classification } of classified) {
     try {
@@ -223,7 +237,7 @@ export async function syncUserGmailWith(
         }
       }
 
-      await knex.transaction(async (trx) => {
+      const trxResult = await knex.transaction(async (trx): Promise<TrxResult> => {
         // Serialises all DB writes for this user across concurrent sync calls.
         // Lock is acquired and released per email — shorter hold than per-batch.
         await trx.raw('SELECT pg_advisory_xact_lock(hashtext(?))', [`gmail_sync:${userId}`]);
@@ -233,7 +247,7 @@ export async function syncUserGmailWith(
         const alreadyDone = await trx('processed_emails')
           .where({ user_id: userId, gmail_message_id: email.messageId })
           .first();
-        if (alreadyDone) return;
+        if (alreadyDone) return null;
 
         if (classification === null) {
           await trx('processed_emails').insert({
@@ -244,7 +258,7 @@ export async function syncUserGmailWith(
             received_at: email.receivedAt,
             action: 'classifier_error' as ProcessedAction,
           }).onConflict(['user_id', 'gmail_message_id']).ignore();
-          return;
+          return null;
         }
 
         const baseLog = {
@@ -262,8 +276,7 @@ export async function syncUserGmailWith(
         };
 
         if (classification.type === 'application_receipt') {
-          await processReceipt(trx, userId, email, classification as EmailClassification & { type: 'application_receipt' }, baseLog, summary, preResolvedIconUrl);
-          return;
+          return processReceipt(trx, userId, email, classification as EmailClassification & { type: 'application_receipt' }, baseLog, summary, preResolvedIconUrl, userCardsForReceipt);
         }
 
         if (classification.type === 'other') {
@@ -271,12 +284,19 @@ export async function syncUserGmailWith(
             .insert({ ...baseLog, action: 'not_actionable' as ProcessedAction })
             .onConflict(['user_id', 'gmail_message_id']).ignore();
           summary.notActionable++;
-          return;
+          return null;
         }
 
         // classification.type === 'rejection'
         await processRejection(trx, userId, email, classification as EmailClassification & { type: 'rejection' }, baseLog, rejectionStage, userCards, summary);
+        return null;
       });
+
+      // Append the new card to the in-memory list ONLY after the transaction
+      // commits — guarantees a rolled-back trx leaves no stale entry behind.
+      if (trxResult?.newCard) {
+        userCardsForReceipt.push(trxResult.newCard);
+      }
     } catch (err) {
       logger.error('gmailSync per-email failure', { userId, messageId: email.messageId, error: safeError(err) });
       // Best-effort audit row outside the failed transaction — a failed tx cannot
@@ -315,7 +335,8 @@ async function processReceipt(
   baseLog: Record<string, unknown>,
   summary: SyncSummary,
   preResolvedIconUrl: string | null | undefined,
-): Promise<void> {
+  userCardsForReceipt: ReadonlyArray<{ id: string; company_name: string; role_title: string }>,
+): Promise<TrxResult> {
   const { companyName, roleTitle, jobUrl, confidence } = classification;
 
   if (!Number.isFinite(confidence) || confidence < CONFIDENCE_THRESHOLD || companyName === null) {
@@ -329,7 +350,7 @@ async function processReceipt(
       metadata: { companyName, roleTitle, confidence },
     });
     summary.receiptsLowConfidence++;
-    return;
+    return null;
   }
 
   const appliedStage = await trx('stages').where({ user_id: userId, is_applied_stage: true }).first();
@@ -349,21 +370,13 @@ async function processReceipt(
     );
   }
 
-  // Exclude rejection-stage cards so a previously-rejected application does
-  // not block a fresh receipt for the same company+role from creating a new
-  // card. This mirrors the rejection path's scope and lets users re-apply.
-  // We query inside the trx (not the hoisted userCards) so we see cards
-  // created by earlier emails in the same batch — preventing in-batch
-  // duplicate creation.
-  const existingCards: { id: string; company_name: string; role_title: string }[] = await trx('cards')
-    .join('stages', 'cards.stage_id', 'stages.id')
-    .where({ 'cards.user_id': userId })
-    .where('stages.is_rejection_stage', false)
-    .select('cards.id', 'cards.company_name', 'cards.role_title');
-
   const finalRoleTitle = roleTitle ?? 'Unknown Role';
 
-  const matchedCard = existingCards.find(card =>
+  // Match against the hoisted in-memory list. The caller seeds it once before
+  // the per-email loop and appends only after each trx commits, so this list
+  // sees cards from earlier *committed* emails in the same batch — preserving
+  // in-batch dedup without a per-email SELECT.
+  const matchedCard = userCardsForReceipt.find(card =>
     companyMatch(card.company_name, companyName) &&
     roleMatch(card.role_title, finalRoleTitle),
   );
@@ -379,7 +392,7 @@ async function processReceipt(
       metadata: { companyName, roleTitle, matchedCardId: matchedCard.id },
     });
     summary.receiptsAlreadyTracked++;
-    return;
+    return null;
   }
 
   // Threading `trx` makes the card INSERT atomic with the processed_emails
@@ -417,6 +430,7 @@ async function processReceipt(
   });
 
   summary.receiptsCreated++;
+  return { newCard: { id: card.id, company_name: companyName, role_title: finalRoleTitle } };
 }
 
 // ── Rejection path ────────────────────────────────────────────────────────────

--- a/backend/tests/gmailSync.test.ts
+++ b/backend/tests/gmailSync.test.ts
@@ -222,7 +222,7 @@ function setupDb(options: SetupOptions = {}) {
     (trx as any).raw = jest.fn().mockResolvedValue(undefined);
     (trx as any).fn = { now: jest.fn().mockReturnValue('2026-01-01T00:00:00.000Z') };
 
-    await cb(trx);
+    return await cb(trx);
   });
 
   mockRaw.mockResolvedValue(undefined);
@@ -399,6 +399,62 @@ describe('syncUserGmailWith', () => {
         expect.objectContaining({ role_title: 'Unknown Role' }),
         expect.anything(),
       );
+    });
+
+    it('marks the second receipt as already_tracked when the first created a matching card in the same batch', async () => {
+      // In-batch dedup: with the hoisted userCardsForReceipt list, the second
+      // email must see the card created by the first email's committed trx
+      // and mark itself as already_tracked rather than creating a duplicate.
+      const { insertedProcessedEmails } = setupDb({ existingCards: [] });
+      (cardService.createCard as jest.Mock).mockResolvedValueOnce({ id: 'card-batch-1', stage_name: 'Applied' });
+
+      const email1: RawEmail = { ...BASE_EMAIL, messageId: 'msg-batch-1' };
+      const email2: RawEmail = { ...BASE_EMAIL, messageId: 'msg-batch-2' };
+
+      const summary = await syncUserGmailWith(USER_ID, makeDeps(
+        [email1, email2],
+        {
+          'msg-batch-1': makeReceiptClassification(),
+          'msg-batch-2': makeReceiptClassification(),
+        },
+      ));
+
+      expect(summary.receiptsCreated).toBe(1);
+      expect(summary.receiptsAlreadyTracked).toBe(1);
+      expect(cardService.createCard).toHaveBeenCalledTimes(1);
+      expect(insertedProcessedEmails).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ action: 'receipt_created' }),
+          expect.objectContaining({ action: 'receipt_already_tracked', card_id: 'card-batch-1' }),
+        ]),
+      );
+    });
+
+    it('does not leave a stale entry in userCardsForReceipt when the trx rolls back', async () => {
+      // Rollback safety: if email 1's trx throws after createCard (or anywhere
+      // inside the callback), the in-memory list must NOT be updated. Email 2
+      // for the same company+role must still create a new card, not match a
+      // ghost entry from the rolled-back trx.
+      setupDb({ existingCards: [] });
+      (cardService.createCard as jest.Mock)
+        .mockRejectedValueOnce(new Error('simulated post-createCard failure'))
+        .mockResolvedValueOnce({ id: 'card-second', stage_name: 'Applied' });
+
+      const email1: RawEmail = { ...BASE_EMAIL, messageId: 'msg-rollback-1' };
+      const email2: RawEmail = { ...BASE_EMAIL, messageId: 'msg-rollback-2' };
+
+      const summary = await syncUserGmailWith(USER_ID, makeDeps(
+        [email1, email2],
+        {
+          'msg-rollback-1': makeReceiptClassification(),
+          'msg-rollback-2': makeReceiptClassification(),
+        },
+      ));
+
+      expect(summary.errors).toBe(1);
+      expect(summary.receiptsCreated).toBe(1);
+      expect(summary.receiptsAlreadyTracked).toBe(0);
+      expect(cardService.createCard).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/backend/tests/gmailSync.test.ts
+++ b/backend/tests/gmailSync.test.ts
@@ -406,7 +406,12 @@ describe('syncUserGmailWith', () => {
       // email must see the card created by the first email's committed trx
       // and mark itself as already_tracked rather than creating a duplicate.
       const { insertedProcessedEmails } = setupDb({ existingCards: [] });
-      (cardService.createCard as jest.Mock).mockResolvedValueOnce({ id: 'card-batch-1', stage_name: 'Applied' });
+      (cardService.createCard as jest.Mock).mockResolvedValueOnce({
+        id: 'card-batch-1',
+        company_name: 'Acme Corp',
+        role_title: 'Software Engineer',
+        stage_name: 'Applied',
+      });
 
       const email1: RawEmail = { ...BASE_EMAIL, messageId: 'msg-batch-1' };
       const email2: RawEmail = { ...BASE_EMAIL, messageId: 'msg-batch-2' };
@@ -438,7 +443,12 @@ describe('syncUserGmailWith', () => {
       setupDb({ existingCards: [] });
       (cardService.createCard as jest.Mock)
         .mockRejectedValueOnce(new Error('simulated post-createCard failure'))
-        .mockResolvedValueOnce({ id: 'card-second', stage_name: 'Applied' });
+        .mockResolvedValueOnce({
+          id: 'card-second',
+          company_name: 'Acme Corp',
+          role_title: 'Software Engineer',
+          stage_name: 'Applied',
+        });
 
       const email1: RawEmail = { ...BASE_EMAIL, messageId: 'msg-rollback-1' };
       const email2: RawEmail = { ...BASE_EMAIL, messageId: 'msg-rollback-2' };


### PR DESCRIPTION
## Summary
- Replace the per-email `existingCards` SELECT inside `processReceipt` with a hoisted, in-memory `userCardsForReceipt` list derived from the existing `userCards` hoist (no extra DB query — saves N round-trips per sync where N = high-confidence receipt emails).
- Preserve in-batch dedup by appending to the list **only after a transaction successfully commits**, so a rolled-back trx leaves no stale entry that could cause the next email to falsely match.

## Implementation
- `processReceipt` now takes `userCardsForReceipt` as a `ReadonlyArray` param and matches in memory; it no longer issues a per-trx SELECT.
- The `knex.transaction(...)` callback returns `{ newCard } | null`. After the trx resolves, the caller appends `newCard` to the list — never inside the callback.
- Test mock updated to propagate the trx callback's return value.

## Acceptance criteria
- [x] `existingCards` SELECT inside `processReceipt` is removed.
- [x] A single hoisted query at sync start populates an in-memory `userCardsForReceipt` list (reuses `userCards` — no second query).
- [x] Successful `createCard` appends to the list **only after the transaction commits**.
- [x] In-batch dedup is preserved: new test `marks the second receipt as already_tracked when the first created a matching card in the same batch` covers "two receipt emails for the same company+role in one sync → exactly one card created, second is `receipt_already_tracked`".
- [x] Rolled-back transactions do not leave stale entries: new test `does not leave a stale entry in userCardsForReceipt when the trx rolls back` simulates a `createCard` throw on email 1 and asserts email 2 still creates a fresh card.
- [x] Match semantics still exclude rejection-stage cards (inherited from the existing hoist's filter).

## Test plan
- [x] `npx jest tests/gmailSync.test.ts` — 25/25 passing (2 new tests)
- [x] `npx jest` (full backend suite) — 83/83 passing
- [x] `npx tsc --noEmit` — clean

## Related
Closes #152
Origin: PR #146 (where this was flagged as HIGH and deliberately skipped by the orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)