### PR TITLE
RFC: Extract position-shift helpers + fix deleteStage transaction bug

### DIFF
--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -1,6 +1,7 @@
 import { Knex } from 'knex';
 import db from '../config/database';
 import { AppError } from '../middleware/errorHandler';
+import { shiftUp, shiftDown, withTransaction } from '../util/positions';
 
 export interface CardFilters {
   stage?: string;
@@ -405,20 +406,8 @@ export const cardService = {
     const oldPosition = card.position;
 
     const performMove = async (t: Knex.Transaction) => {
-      // Remove from old position: shift cards in old stage down to fill gap
-      await t('cards')
-        .where({ user_id: userId, stage_id: oldStageId })
-        .andWhere('position', '>', oldPosition)
-        .decrement('position', 1);
-
-      // Make room in new position: shift cards in target stage up
-      await t('cards')
-        .where({ user_id: userId, stage_id: stageId })
-        .andWhere('position', '>=', position)
-        .andWhere('id', '!=', cardId)
-        .increment('position', 1);
-
-      // Move the card
+      await shiftDown({ trx: t, table: 'cards', scope: { user_id: userId, stage_id: oldStageId }, fromPos: oldPosition });
+      await shiftUp({ trx: t, table: 'cards', scope: { user_id: userId, stage_id: stageId }, fromPos: position });
       await t('cards')
         .where({ id: cardId })
         .update({
@@ -470,14 +459,10 @@ export const cardService = {
       throw new AppError('Card not found', 404, 'ERR_NOT_FOUND');
     }
 
-    // Delete card (cascade deletes activities)
-    await db('cards').where({ id: cardId, user_id: userId }).del();
-
-    // Shift remaining cards in the stage down to fill gap
-    await db('cards')
-      .where({ user_id: userId, stage_id: card.stage_id })
-      .andWhere('position', '>', card.position)
-      .decrement('position', 1);
+    await withTransaction(db, undefined, async (trx) => {
+      await trx('cards').where({ id: cardId, user_id: userId }).del();
+      await shiftDown({ trx, table: 'cards', scope: { user_id: userId, stage_id: card.stage_id }, fromPos: card.position });
+    });
   },
 
   async addNote(cardId: string, userId: string, note: string) {

--- a/backend/src/services/stageService.ts
+++ b/backend/src/services/stageService.ts
@@ -1,5 +1,6 @@
 import db from '../config/database';
 import { AppError } from '../middleware/errorHandler';
+import { shiftUp, shiftDown, renumber, withTransaction } from '../util/positions';
 
 export interface StageData {
   name: string;
@@ -17,21 +18,13 @@ export const stageService = {
   },
 
   async createStage(userId: string, data: StageData) {
-    // Shift existing stages at or after this position up by 1
-    await db('stages')
-      .where({ user_id: userId })
-      .andWhere('position', '>=', data.position)
-      .increment('position', 1);
-
-    const [stage] = await db('stages')
-      .insert({
-        user_id: userId,
-        name: data.name,
-        position: data.position,
-      })
-      .returning('*');
-
-    return stage;
+    return withTransaction(db, undefined, async (trx) => {
+      await shiftUp({ trx, table: 'stages', scope: { user_id: userId }, fromPos: data.position });
+      const [stage] = await trx('stages')
+        .insert({ user_id: userId, name: data.name, position: data.position })
+        .returning('*');
+      return stage;
+    });
   },
 
   async updateStage(stageId: string, userId: string, data: Partial<StageData>) {
@@ -43,100 +36,78 @@ export const stageService = {
       throw new AppError('Stage not found', 404, 'ERR_NOT_FOUND');
     }
 
-    if (data.position !== undefined && data.position !== existing.position) {
-      const oldPos = existing.position;
-      const newPos = data.position;
+    return withTransaction(db, undefined, async (trx) => {
+      if (data.position !== undefined && data.position !== existing.position) {
+        const oldPos = existing.position;
+        const newPos = data.position;
 
-      if (newPos > oldPos) {
-        // Moving down: shift stages between old+1 and new down by 1
-        await db('stages')
-          .where({ user_id: userId })
-          .andWhere('position', '>', oldPos)
-          .andWhere('position', '<=', newPos)
-          .decrement('position', 1);
-      } else {
-        // Moving up: shift stages between new and old-1 up by 1
-        await db('stages')
-          .where({ user_id: userId })
-          .andWhere('position', '>=', newPos)
-          .andWhere('position', '<', oldPos)
-          .increment('position', 1);
+        if (newPos > oldPos) {
+          await shiftDown({ trx, table: 'stages', scope: { user_id: userId }, fromPos: oldPos, toPos: newPos });
+        } else {
+          await shiftUp({ trx, table: 'stages', scope: { user_id: userId }, fromPos: newPos, toPos: oldPos - 1 });
+        }
       }
-    }
 
-    const updateData: Record<string, unknown> = {};
-    if (data.name !== undefined) updateData.name = data.name;
-    if (data.position !== undefined) updateData.position = data.position;
-    if (data.width !== undefined) updateData.width = data.width;
+      const updateData: Record<string, unknown> = {};
+      if (data.name !== undefined) updateData.name = data.name;
+      if (data.position !== undefined) updateData.position = data.position;
+      if (data.width !== undefined) updateData.width = data.width;
 
-    const [updated] = await db('stages')
-      .where({ id: stageId, user_id: userId })
-      .update(updateData)
-      .returning('*');
+      const [updated] = await trx('stages')
+        .where({ id: stageId, user_id: userId })
+        .update(updateData)
+        .returning('*');
 
-    return updated;
+      return updated;
+    });
   },
 
   async deleteStage(stageId: string, userId: string) {
-    const stage = await db('stages')
-      .where({ id: stageId, user_id: userId })
-      .first();
+    return withTransaction(db, undefined, async (trx) => {
+      const stage = await trx('stages').where({ id: stageId, user_id: userId }).first();
 
-    if (!stage) {
-      throw new AppError('Stage not found', 404, 'ERR_NOT_FOUND');
-    }
+      if (!stage) {
+        throw new AppError('Stage not found', 404, 'ERR_NOT_FOUND');
+      }
 
-    // Prevent deleting the last remaining stage
-    const stageCount = await db('stages')
-      .where({ user_id: userId })
-      .count('id as count')
-      .first();
-
-    if (Number(stageCount?.count) <= 1) {
-      throw new AppError('Cannot delete the last stage', 400, 'ERR_LAST_STAGE');
-    }
-
-    // Find the first stage (lowest position) that isn't the one being deleted
-    const fallbackStage = await db('stages')
-      .where({ user_id: userId })
-      .whereNot({ id: stageId })
-      .orderBy('position', 'asc')
-      .first();
-
-    // Move all cards from the deleted stage to the fallback stage
-    const movedCount = await db('cards')
-      .where({ stage_id: stageId, user_id: userId })
-      .update({ stage_id: fallbackStage.id });
-
-    // If cards were moved, append them after existing cards in fallback stage
-    if (movedCount > 0) {
-      const maxPos = await db('cards')
-        .where({ stage_id: fallbackStage.id, user_id: userId })
-        .max('position as max')
+      const stageCount = await trx('stages')
+        .where({ user_id: userId })
+        .count('id as count')
         .first();
 
-      // Re-number all cards in fallback stage by position
-      const fallbackCards = await db('cards')
-        .where({ stage_id: fallbackStage.id, user_id: userId })
-        .orderBy('position', 'asc');
-
-      for (let i = 0; i < fallbackCards.length; i++) {
-        await db('cards')
-          .where({ id: fallbackCards[i].id })
-          .update({ position: i });
+      if (Number(stageCount?.count) <= 1) {
+        throw new AppError('Cannot delete the last stage', 400, 'ERR_LAST_STAGE');
       }
-    }
 
-    // Delete the stage
-    await db('stages').where({ id: stageId }).del();
+      const fallbackStage = await trx('stages')
+        .where({ user_id: userId })
+        .whereNot({ id: stageId })
+        .orderBy('position', 'asc')
+        .first();
 
-    // Shift remaining stage positions to fill the gap
-    await db('stages')
-      .where({ user_id: userId })
-      .andWhere('position', '>', stage.position)
-      .decrement('position', 1);
+      const movedCount = await trx('cards')
+        .where({ stage_id: stageId, user_id: userId })
+        .update({ stage_id: fallbackStage.id });
 
-    return { deletedStage: stage, movedCardsTo: fallbackStage, movedCardCount: movedCount };
+      if (movedCount > 0) {
+        const fallbackCards = await trx('cards')
+          .where({ stage_id: fallbackStage.id, user_id: userId })
+          .orderBy('position', 'asc');
+
+        await renumber({
+          trx,
+          table: 'cards',
+          scope: { user_id: userId, stage_id: fallbackStage.id },
+          orderedIds: fallbackCards.map((c: { id: string }) => c.id),
+        });
+      }
+
+      await trx('stages').where({ id: stageId }).del();
+
+      await shiftDown({ trx, table: 'stages', scope: { user_id: userId }, fromPos: stage.position });
+
+      return { deletedStage: stage, movedCardsTo: fallbackStage, movedCardCount: movedCount };
+    });
   },
 
   async reorderStages(userId: string, stageIds: string[]) {
@@ -157,12 +128,8 @@ export const stageService = {
       throw new AppError('All stages must be included in reorder', 400, 'ERR_INCOMPLETE_REORDER');
     }
 
-    await db.transaction(async (trx) => {
-      for (let i = 0; i < stageIds.length; i++) {
-        await trx('stages')
-          .where({ id: stageIds[i], user_id: userId })
-          .update({ position: i });
-      }
+    await withTransaction(db, undefined, async (trx) => {
+      await renumber({ trx, table: 'stages', scope: { user_id: userId }, orderedIds: stageIds });
     });
 
     return db('stages')

--- a/backend/src/services/todoService.ts
+++ b/backend/src/services/todoService.ts
@@ -1,5 +1,6 @@
 import db from '../config/database';
 import { AppError } from '../middleware/errorHandler';
+import { shiftDown, withTransaction } from '../util/positions';
 
 export interface Todo {
   id: string;
@@ -75,13 +76,12 @@ export const todoService = {
     if (!existing) {
       throw new AppError('Todo not found', 404, 'ERR_NOT_FOUND');
     }
-    await db('todo_items').where({ id, user_id: userId }).del();
-    if (existing.position !== null) {
-      await db('todo_items')
-        .where({ user_id: userId })
-        .andWhere('position', '>', existing.position)
-        .decrement('position', 1);
-    }
+    await withTransaction(db, undefined, async (trx) => {
+      await trx('todo_items').where({ id, user_id: userId }).del();
+      if (existing.position !== null) {
+        await shiftDown({ trx, table: 'todo_items', scope: { user_id: userId }, fromPos: existing.position });
+      }
+    });
   },
 
   async reorderTodos(userId: string, orderedIds: string[]): Promise<Todo[]> {
@@ -100,7 +100,7 @@ export const todoService = {
     // the already-computed priority of the item directly above it.
     const inferredPriority = new Map<string, Todo['priority']>();
 
-    await db.transaction(async (trx) => {
+    await withTransaction(db, undefined, async (trx) => {
       for (let i = 0; i < orderedIds.length; i++) {
         const id = orderedIds[i];
         let priority: Todo['priority'];

--- a/backend/src/util/positions.ts
+++ b/backend/src/util/positions.ts
@@ -1,0 +1,60 @@
+import { Knex } from 'knex';
+
+export type Scope = Record<string, string | number>;
+
+export interface ShiftArgs {
+  trx: Knex.Transaction;
+  table: 'stages' | 'cards' | 'todo_items';
+  scope: Scope;
+  fromPos: number;
+  toPos?: number;
+}
+
+export interface RenumberArgs {
+  trx: Knex.Transaction;
+  table: 'stages' | 'cards' | 'todo_items';
+  scope: Scope;
+  orderedIds: string[];
+  idColumn?: string;
+}
+
+export async function shiftUp(args: ShiftArgs): Promise<number> {
+  const { trx, table, scope, fromPos, toPos } = args;
+  let q = trx(table).where(scope).andWhere('position', '>=', fromPos);
+  if (toPos !== undefined) q = q.andWhere('position', '<=', toPos);
+  return q.increment('position', 1);
+}
+
+export async function shiftDown(args: ShiftArgs): Promise<number> {
+  const { trx, table, scope, fromPos, toPos } = args;
+  let q = trx(table).where(scope).andWhere('position', '>', fromPos);
+  if (toPos !== undefined) q = q.andWhere('position', '<=', toPos);
+  return q.decrement('position', 1);
+}
+
+// Two-phase to avoid UNIQUE(scope, position) constraint violations within a transaction.
+// Phase 1 moves rows to unique negative sentinels; phase 2 assigns final 0..N-1 positions.
+export async function renumber(args: RenumberArgs): Promise<void> {
+  const { trx, table, scope, orderedIds, idColumn = 'id' } = args;
+  const N = orderedIds.length;
+  for (let i = 0; i < N; i++) {
+    await trx(table)
+      .where({ ...scope, [idColumn]: orderedIds[i] })
+      .update({ position: -(N + i + 1) });
+  }
+  for (let i = 0; i < N; i++) {
+    await trx(table)
+      .where({ ...scope, [idColumn]: orderedIds[i] })
+      .update({ position: i });
+  }
+}
+
+// Joins caller's trx when present, otherwise opens its own.
+export async function withTransaction<T>(
+  knex: Knex,
+  trx: Knex.Transaction | undefined,
+  fn: (t: Knex.Transaction) => Promise<T>,
+): Promise<T> {
+  if (trx) return fn(trx);
+  return knex.transaction(fn);
+}

--- a/backend/src/util/positions.ts
+++ b/backend/src/util/positions.ts
@@ -1,5 +1,11 @@
 import { Knex } from 'knex';
 
+// CONTRACT: tables passed to renumber/shiftUp/shiftDown must NOT have a
+// non-deferrable UNIQUE (scope, position) index. The helpers transiently
+// duplicate positions inside a transaction. If you add such an index, ensure
+// it is DEFERRABLE INITIALLY DEFERRED (see migration 010 for the stages
+// table — cards and todo_items currently have no such constraint).
+
 export type Scope = Record<string, string | number>;
 
 export interface ShiftArgs {
@@ -18,22 +24,24 @@ export interface RenumberArgs {
   idColumn?: string;
 }
 
-export async function shiftUp(args: ShiftArgs): Promise<number> {
+export async function shiftUp(args: ShiftArgs): Promise<void> {
   const { trx, table, scope, fromPos, toPos } = args;
   let q = trx(table).where(scope).andWhere('position', '>=', fromPos);
   if (toPos !== undefined) q = q.andWhere('position', '<=', toPos);
-  return q.increment('position', 1);
+  await q.increment('position', 1);
 }
 
-export async function shiftDown(args: ShiftArgs): Promise<number> {
+export async function shiftDown(args: ShiftArgs): Promise<void> {
   const { trx, table, scope, fromPos, toPos } = args;
   let q = trx(table).where(scope).andWhere('position', '>', fromPos);
   if (toPos !== undefined) q = q.andWhere('position', '<=', toPos);
-  return q.decrement('position', 1);
+  await q.decrement('position', 1);
 }
 
 // Two-phase to avoid UNIQUE(scope, position) constraint violations within a transaction.
 // Phase 1 moves rows to unique negative sentinels; phase 2 assigns final 0..N-1 positions.
+// TODO(scale): collapse each phase to a single UPDATE ... FROM (VALUES (id, pos), ...)
+// once collections grow beyond ~100 items — current 2N round-trips are fine for ≤100.
 export async function renumber(args: RenumberArgs): Promise<void> {
   const { trx, table, scope, orderedIds, idColumn = 'id' } = args;
   const N = orderedIds.length;

--- a/backend/tests/cards.test.ts
+++ b/backend/tests/cards.test.ts
@@ -83,6 +83,15 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+// Make mockTransaction execute its callback so withTransaction() works in all tests.
+beforeEach(() => {
+  mockTransaction.mockImplementation(async (callback: (trx: any) => Promise<unknown>) => {
+    const trx: any = (tableName: string) => mockDb(tableName);
+    trx.fn = { now: jest.fn().mockReturnValue('2026-01-01T00:00:00.000Z') };
+    return callback(trx);
+  });
+});
+
 // Helper to set up mockDb per table
 function setupDbMock(tableResponses: Record<string, ReturnType<typeof createQueryChain>>) {
   mockDb.mockImplementation((tableName: string) => {

--- a/backend/tests/integration/positions.integration.test.ts
+++ b/backend/tests/integration/positions.integration.test.ts
@@ -114,68 +114,76 @@ describe('shiftUp', () => {
   });
 
   it('respects toPos upper bound', async () => {
+    // Use todo_items (no UNIQUE position constraint) — shiftUp with toPos leaves
+    // duplicate positions in the committed state, which stages would reject.
     const db = getDb();
-    await insertStage(0);
-    await insertStage(1);
-    await insertStage(2);
-    await insertStage(3);
+    await insertTodo(0);
+    await insertTodo(1);
+    await insertTodo(2);
+    await insertTodo(3);
 
     await db.transaction(async (trx) => {
-      await shiftUp({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 1, toPos: 2 });
+      await shiftUp({ trx, table: 'todo_items', scope: { user_id: userId }, fromPos: 1, toPos: 2 });
     });
 
     // positions 1 and 2 shift up; 0 and 3 stay
-    expect(await stagePositions()).toEqual([0, 2, 3, 3]);
+    expect(await todoPositions()).toEqual([0, 2, 3, 3]);
   });
 });
 
 // ── shiftDown ─────────────────────────────────────────────────────────────────
 
 describe('shiftDown', () => {
+  // All shiftDown boundary tests use todo_items (no UNIQUE position constraint).
+  // shiftDown produces duplicate positions in the committed state (e.g. [0,1,1])
+  // because it is designed to be paired with a preceding row deletion; in isolation
+  // the "gap" that deletion would create doesn't exist yet. stages would reject such
+  // states at COMMIT via UNIQUE(user_id, position) DEFERRABLE INITIALLY DEFERRED.
+
   it('uses strict > so the row at fromPos is not shifted', async () => {
     const db = getDb();
-    await insertStage(0);
-    await insertStage(1);
-    await insertStage(2);
+    await insertTodo(0);
+    const todoAtFromPos = await insertTodo(1);
+    await insertTodo(2);
 
     await db.transaction(async (trx) => {
-      await shiftDown({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 1 });
+      await shiftDown({ trx, table: 'todo_items', scope: { user_id: userId }, fromPos: 1 });
     });
 
-    expect(await stagePositions()).toEqual([0, 1, 1]);
-    // row originally at position 1 is NOT shifted (strict >)
-    const rows = await db('stages').where({ user_id: userId }).orderBy('position');
-    expect(rows[1].position).toBe(1); // still 1
+    expect(await todoPositions()).toEqual([0, 1, 1]);
+    // the todo at fromPos=1 is NOT shifted (strict >)
+    const unchanged = await db('todo_items').where({ id: todoAtFromPos }).first();
+    expect(unchanged.position).toBe(1);
   });
 
   it('leaves rows in other scopes untouched', async () => {
     const db = getDb();
-    await insertStage(0);
-    await insertStage(1);
-    await insertStage(0, otherUserId);
-    await insertStage(1, otherUserId);
+    await insertTodo(0);
+    await insertTodo(1);
+    await insertTodo(0, otherUserId);
+    await insertTodo(1, otherUserId);
 
     await db.transaction(async (trx) => {
-      await shiftDown({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 0 });
+      await shiftDown({ trx, table: 'todo_items', scope: { user_id: userId }, fromPos: 0 });
     });
 
-    expect(await stagePositions()).toEqual([0, 0]);
-    expect(await stagePositions(otherUserId)).toEqual([0, 1]); // untouched
+    expect(await todoPositions()).toEqual([0, 0]);
+    expect(await todoPositions(otherUserId)).toEqual([0, 1]); // untouched
   });
 
   it('respects toPos upper bound', async () => {
     const db = getDb();
-    await insertStage(0);
-    await insertStage(1);
-    await insertStage(2);
-    await insertStage(3);
+    await insertTodo(0);
+    await insertTodo(1);
+    await insertTodo(2);
+    await insertTodo(3);
 
     await db.transaction(async (trx) => {
-      await shiftDown({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 0, toPos: 2 });
+      await shiftDown({ trx, table: 'todo_items', scope: { user_id: userId }, fromPos: 0, toPos: 2 });
     });
 
     // positions 1 and 2 shift down (0 is not >0, 3 is above toPos)
-    expect(await stagePositions()).toEqual([0, 0, 1, 3]);
+    expect(await todoPositions()).toEqual([0, 0, 1, 3]);
   });
 });
 

--- a/backend/tests/integration/positions.integration.test.ts
+++ b/backend/tests/integration/positions.integration.test.ts
@@ -1,5 +1,6 @@
 import { destroyDb, getDb, truncateAll } from './db';
 import { shiftUp, shiftDown, renumber, withTransaction } from '../../src/util/positions';
+import { cardService } from '../../src/services/cardService';
 
 const EMAIL = 'positions-test@integration.test';
 const OTHER_EMAIL = 'positions-other@integration.test';
@@ -311,6 +312,46 @@ describe('card scope isolation', () => {
 
     expect(await cardPositions(stage1)).toEqual([0, 0, 1]);
     expect(await cardPositions(stage2)).toEqual([0, 1]); // untouched
+  });
+});
+
+// ── moveCard within the same stage (drag-within-column) ─────────────────────
+
+describe('cardService.moveCard — same stage', () => {
+  it('produces correct final positions when moving down within a column', async () => {
+    const s = await insertStage(0);
+    const c0 = await insertCard(s, 0);
+    const c1 = await insertCard(s, 1);
+    const c2 = await insertCard(s, 2);
+    const c3 = await insertCard(s, 3);
+    const c4 = await insertCard(s, 4);
+
+    // Drag the bottom card (position 4) to the top (position 0)
+    await cardService.moveCard(c4, userId, s, 0);
+
+    const rows = await getDb()('cards')
+      .where({ user_id: userId, stage_id: s })
+      .orderBy('position');
+    expect(rows.map((r: { id: string }) => r.id)).toEqual([c4, c0, c1, c2, c3]);
+    expect(rows.map((r: { position: number }) => r.position)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('produces correct final positions when moving up within a column', async () => {
+    const s = await insertStage(0);
+    const c0 = await insertCard(s, 0);
+    const c1 = await insertCard(s, 1);
+    const c2 = await insertCard(s, 2);
+    const c3 = await insertCard(s, 3);
+    const c4 = await insertCard(s, 4);
+
+    // Drag position 0 down to position 3
+    await cardService.moveCard(c0, userId, s, 3);
+
+    const rows = await getDb()('cards')
+      .where({ user_id: userId, stage_id: s })
+      .orderBy('position');
+    expect(rows.map((r: { id: string }) => r.id)).toEqual([c1, c2, c3, c0, c4]);
+    expect(rows.map((r: { position: number }) => r.position)).toEqual([0, 1, 2, 3, 4]);
   });
 });
 

--- a/backend/tests/integration/positions.integration.test.ts
+++ b/backend/tests/integration/positions.integration.test.ts
@@ -1,0 +1,333 @@
+import { destroyDb, getDb, truncateAll } from './db';
+import { shiftUp, shiftDown, renumber, withTransaction } from '../../src/util/positions';
+
+const EMAIL = 'positions-test@integration.test';
+const OTHER_EMAIL = 'positions-other@integration.test';
+
+let userId: string;
+let otherUserId: string;
+
+beforeAll(async () => {
+  const db = getDb();
+  const [u1] = await db('users')
+    .insert({ email: EMAIL, password_hash: 'x', name: 'Test' })
+    .returning('id');
+  const [u2] = await db('users')
+    .insert({ email: OTHER_EMAIL, password_hash: 'x', name: 'Other' })
+    .returning('id');
+  userId = u1.id;
+  otherUserId = u2.id;
+});
+
+beforeEach(async () => {
+  const db = getDb();
+  // Truncate only the ordered tables, preserve the users created in beforeAll
+  await db.raw('TRUNCATE TABLE todo_items, cards, stages RESTART IDENTITY CASCADE');
+});
+
+afterAll(async () => {
+  await truncateAll();
+  await destroyDb();
+});
+
+async function insertStage(pos: number, uid = userId): Promise<string> {
+  const db = getDb();
+  const [row] = await db('stages')
+    .insert({ user_id: uid, name: `Stage ${pos}`, position: pos })
+    .returning('id');
+  return row.id;
+}
+
+async function insertCard(stageId: string, pos: number, uid = userId): Promise<string> {
+  const db = getDb();
+  const [row] = await db('cards')
+    .insert({
+      user_id: uid,
+      stage_id: stageId,
+      company_name: `Co ${pos}`,
+      role_title: `Role ${pos}`,
+      position: pos,
+    })
+    .returning('id');
+  return row.id;
+}
+
+async function insertTodo(pos: number | null, uid = userId): Promise<string> {
+  const db = getDb();
+  const [row] = await db('todo_items')
+    .insert({ user_id: uid, description: `Todo ${pos}`, priority: 'medium', status: 'active', position: pos })
+    .returning('id');
+  return row.id;
+}
+
+async function stagePositions(uid = userId): Promise<number[]> {
+  const db = getDb();
+  const rows = await db('stages').where({ user_id: uid }).orderBy('position');
+  return rows.map((r: { position: number }) => r.position);
+}
+
+async function cardPositions(stageId: string, uid = userId): Promise<number[]> {
+  const db = getDb();
+  const rows = await db('cards').where({ user_id: uid, stage_id: stageId }).orderBy('position');
+  return rows.map((r: { position: number }) => r.position);
+}
+
+async function todoPositions(uid = userId): Promise<(number | null)[]> {
+  const db = getDb();
+  const rows = await db('todo_items').where({ user_id: uid }).orderByRaw('position ASC NULLS LAST');
+  return rows.map((r: { position: number | null }) => r.position);
+}
+
+// ── shiftUp ───────────────────────────────────────────────────────────────────
+
+describe('shiftUp', () => {
+  it('shifts only rows at-or-after fromPos within scope', async () => {
+    const db = getDb();
+    const s0 = await insertStage(0);
+    const s1 = await insertStage(1);
+    const s2 = await insertStage(2);
+    void s0; void s2;
+
+    await db.transaction(async (trx) => {
+      await shiftUp({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 1 });
+    });
+
+    expect(await stagePositions()).toEqual([0, 2, 3]);
+    // row at 0 was not shifted
+    const unchanged = await db('stages').where({ id: s0 }).first();
+    expect(unchanged.position).toBe(0);
+  });
+
+  it('leaves rows in other scopes untouched', async () => {
+    const db = getDb();
+    await insertStage(0);
+    await insertStage(1);
+    await insertStage(0, otherUserId);
+
+    await db.transaction(async (trx) => {
+      await shiftUp({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 0 });
+    });
+
+    expect(await stagePositions()).toEqual([1, 2]);
+    expect(await stagePositions(otherUserId)).toEqual([0]); // untouched
+  });
+
+  it('respects toPos upper bound', async () => {
+    const db = getDb();
+    await insertStage(0);
+    await insertStage(1);
+    await insertStage(2);
+    await insertStage(3);
+
+    await db.transaction(async (trx) => {
+      await shiftUp({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 1, toPos: 2 });
+    });
+
+    // positions 1 and 2 shift up; 0 and 3 stay
+    expect(await stagePositions()).toEqual([0, 2, 3, 3]);
+  });
+});
+
+// ── shiftDown ─────────────────────────────────────────────────────────────────
+
+describe('shiftDown', () => {
+  it('uses strict > so the row at fromPos is not shifted', async () => {
+    const db = getDb();
+    await insertStage(0);
+    await insertStage(1);
+    await insertStage(2);
+
+    await db.transaction(async (trx) => {
+      await shiftDown({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 1 });
+    });
+
+    expect(await stagePositions()).toEqual([0, 1, 1]);
+    // row originally at position 1 is NOT shifted (strict >)
+    const rows = await db('stages').where({ user_id: userId }).orderBy('position');
+    expect(rows[1].position).toBe(1); // still 1
+  });
+
+  it('leaves rows in other scopes untouched', async () => {
+    const db = getDb();
+    await insertStage(0);
+    await insertStage(1);
+    await insertStage(0, otherUserId);
+    await insertStage(1, otherUserId);
+
+    await db.transaction(async (trx) => {
+      await shiftDown({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 0 });
+    });
+
+    expect(await stagePositions()).toEqual([0, 0]);
+    expect(await stagePositions(otherUserId)).toEqual([0, 1]); // untouched
+  });
+
+  it('respects toPos upper bound', async () => {
+    const db = getDb();
+    await insertStage(0);
+    await insertStage(1);
+    await insertStage(2);
+    await insertStage(3);
+
+    await db.transaction(async (trx) => {
+      await shiftDown({ trx, table: 'stages', scope: { user_id: userId }, fromPos: 0, toPos: 2 });
+    });
+
+    // positions 1 and 2 shift down (0 is not >0, 3 is above toPos)
+    expect(await stagePositions()).toEqual([0, 0, 1, 3]);
+  });
+});
+
+// ── renumber ──────────────────────────────────────────────────────────────────
+
+describe('renumber', () => {
+  it('assigns 0..N-1 positions matching the supplied order', async () => {
+    const db = getDb();
+    const id0 = await insertStage(0);
+    const id1 = await insertStage(1);
+    const id2 = await insertStage(2);
+
+    await db.transaction(async (trx) => {
+      await renumber({
+        trx,
+        table: 'stages',
+        scope: { user_id: userId },
+        orderedIds: [id2, id0, id1],
+      });
+    });
+
+    const rows = await db('stages').where({ user_id: userId }).orderBy('position');
+    expect(rows[0].id).toBe(id2);
+    expect(rows[1].id).toBe(id0);
+    expect(rows[2].id).toBe(id1);
+    expect(rows.map((r: { position: number }) => r.position)).toEqual([0, 1, 2]);
+  });
+
+  it('survives the UNIQUE(user_id, position) constraint on stages', async () => {
+    const db = getDb();
+    const id0 = await insertStage(0);
+    const id1 = await insertStage(1);
+    const id2 = await insertStage(2);
+
+    // Reverse order — would conflict without the two-phase approach
+    await expect(
+      db.transaction(async (trx) => {
+        await renumber({
+          trx,
+          table: 'stages',
+          scope: { user_id: userId },
+          orderedIds: [id2, id1, id0],
+        });
+      }),
+    ).resolves.not.toThrow();
+
+    expect(await stagePositions()).toEqual([0, 1, 2]);
+  });
+
+  it('only renumbers rows in the given scope', async () => {
+    const db = getDb();
+    const id0 = await insertStage(0);
+    const id1 = await insertStage(1);
+    await insertStage(0, otherUserId);
+
+    await db.transaction(async (trx) => {
+      await renumber({
+        trx,
+        table: 'stages',
+        scope: { user_id: userId },
+        orderedIds: [id1, id0],
+      });
+    });
+
+    expect(await stagePositions()).toEqual([0, 1]);
+    expect(await stagePositions(otherUserId)).toEqual([0]); // untouched
+  });
+});
+
+// ── withTransaction ───────────────────────────────────────────────────────────
+
+describe('withTransaction', () => {
+  it('opens its own transaction when trx is undefined', async () => {
+    const db = getDb();
+    const id = await insertStage(0);
+
+    await withTransaction(db, undefined, async (trx) => {
+      await trx('stages').where({ id }).update({ name: 'Updated' });
+    });
+
+    const row = await db('stages').where({ id }).first();
+    expect(row.name).toBe('Updated');
+  });
+
+  it('joins an existing transaction instead of opening a new one', async () => {
+    const db = getDb();
+    const id = await insertStage(0);
+
+    await db.transaction(async (outer) => {
+      await withTransaction(db, outer, async (t) => {
+        // t should be the same transaction object
+        expect(t).toBe(outer);
+        await t('stages').where({ id }).update({ name: 'Inner' });
+      });
+    });
+
+    const row = await db('stages').where({ id }).first();
+    expect(row.name).toBe('Inner');
+  });
+
+  it('rolls back all writes if the inner function throws', async () => {
+    const db = getDb();
+    const id = await insertStage(0);
+
+    await expect(
+      withTransaction(db, undefined, async (trx) => {
+        await trx('stages').where({ id }).update({ name: 'ShouldRollBack' });
+        throw new Error('deliberate failure');
+      }),
+    ).rejects.toThrow('deliberate failure');
+
+    const row = await db('stages').where({ id }).first();
+    expect(row.name).toBe('Stage 0'); // original name preserved
+  });
+});
+
+// ── card scope isolation ──────────────────────────────────────────────────────
+
+describe('card scope isolation', () => {
+  it('shiftDown on cards only affects the target stage', async () => {
+    const db = getDb();
+    const stage1 = await insertStage(0);
+    const stage2 = await insertStage(1);
+
+    await insertCard(stage1, 0);
+    await insertCard(stage1, 1);
+    await insertCard(stage1, 2);
+    await insertCard(stage2, 0);
+    await insertCard(stage2, 1);
+
+    await db.transaction(async (trx) => {
+      await shiftDown({ trx, table: 'cards', scope: { user_id: userId, stage_id: stage1 }, fromPos: 0 });
+    });
+
+    expect(await cardPositions(stage1)).toEqual([0, 0, 1]);
+    expect(await cardPositions(stage2)).toEqual([0, 1]); // untouched
+  });
+});
+
+// ── todo null positions ───────────────────────────────────────────────────────
+
+describe('todo null positions', () => {
+  it('shiftDown does not affect todos with null positions', async () => {
+    const db = getDb();
+    await insertTodo(0);
+    await insertTodo(1);
+    await insertTodo(2);
+    await insertTodo(null);
+
+    await db.transaction(async (trx) => {
+      await shiftDown({ trx, table: 'todo_items', scope: { user_id: userId }, fromPos: 0 });
+    });
+
+    expect(await todoPositions()).toEqual([0, 0, 1, null]);
+  });
+});

--- a/backend/tests/stages.test.ts
+++ b/backend/tests/stages.test.ts
@@ -50,6 +50,16 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+// Make mockTransaction execute its callback so withTransaction() works in all tests.
+// Tests that need custom transaction behaviour override this in the test body.
+beforeEach(() => {
+  mockTransaction.mockImplementation(async (callback: (trx: any) => Promise<unknown>) => {
+    const trx: any = (tableName: string) => mockDb(tableName);
+    trx.fn = { now: jest.fn().mockReturnValue('2026-01-01T00:00:00.000Z') };
+    return callback(trx);
+  });
+});
+
 // =============================================================================
 // CREATE STAGE
 // =============================================================================
@@ -169,27 +179,17 @@ describe('StageService - deleteStage', () => {
       if (tableName === 'cards') {
         cardsCallCount++;
         if (cardsCallCount === 1) {
-          // move cards - update stage_id
+          // move cards to fallback stage
           const chain = createQueryChain(undefined);
           chain.where = jest.fn().mockReturnValue({
             update: jest.fn().mockResolvedValue(2), // 2 cards moved
           });
           return chain;
         } else if (cardsCallCount === 2) {
-          // max position in fallback
-          const chain = createQueryChain(undefined);
-          chain.where = jest.fn().mockReturnValue({
-            max: jest.fn().mockReturnValue({
-              first: jest.fn().mockResolvedValue({ max: 3 }),
-            }),
-          });
-          return chain;
-        } else {
-          // re-number cards
+          // list fallback cards for renumber
           const chain = createQueryChain(undefined);
           chain.where = jest.fn().mockReturnValue(chain);
           chain.orderBy = jest.fn().mockReturnValue(chain);
-          // return cards array for re-numbering
           (chain as any).then = (resolve: (v: unknown) => void) =>
             Promise.resolve([
               { id: 'card-1', position: 0 },
@@ -197,6 +197,11 @@ describe('StageService - deleteStage', () => {
               { id: 'card-3', position: 2 },
               { id: 'card-4', position: 3 },
             ]).then(resolve);
+          return chain;
+        } else {
+          // renumber phase 1 and phase 2 updates
+          const chain = createQueryChain(undefined);
+          chain.where = jest.fn().mockReturnValue(chain);
           chain.update = jest.fn().mockResolvedValue(1);
           return chain;
         }

--- a/backend/tests/todos.test.ts
+++ b/backend/tests/todos.test.ts
@@ -54,6 +54,15 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+// Make mockTransaction execute its callback so withTransaction() works in all tests.
+beforeEach(() => {
+  mockTransaction.mockImplementation(async (callback: (trx: any) => Promise<unknown>) => {
+    const trx: any = (tableName: string) => mockDb(tableName);
+    trx.fn = { now: jest.fn().mockReturnValue('2026-01-01T00:00:00.000Z') };
+    return callback(trx);
+  });
+});
+
 // =============================================================================
 // GET ALL TODOS
 // =============================================================================


### PR DESCRIPTION
## Summary
- Introduces `backend/src/util/positions.ts` with four exported helpers: `shiftUp`, `shiftDown`, `renumber`, and `withTransaction`
- Fixes the latent transaction bug in `deleteStage` — all 5 cascade steps are now wrapped in a single atomic transaction (previously unguarded)
- Converts all 7 hand-written position-shift sites across `stageService`, `cardService`, and `todoService` to use the helpers

## Acceptance criteria
- [x] `backend/src/util/positions.ts` exports `shiftUp`, `shiftDown`, `renumber`, and `withTransaction`
- [x] `stageService.deleteStage` wraps its entire cascade in a single transaction (transaction bug fixed)
- [x] All 7 duplication sites converted to use helpers; no service hand-writes `.where('position', op, x).increment/decrement(...)` directly
- [x] `backend/tests/integration/positions.integration.test.ts` covers boundary semantics, scope isolation, UNIQUE constraint survival, and `withTransaction` join/rollback
- [x] All existing unit tests pass (`npm test` — 83/83)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)

## Changes
- **New**: `backend/src/util/positions.ts` — `shiftUp` (`>=` fromPos), `shiftDown` (`>` fromPos), `renumber` (two-phase to avoid UNIQUE conflicts), `withTransaction` (joins existing trx or opens its own)
- **Fixed**: `stageService.deleteStage` — 5 dependent writes now in one transaction; also removed dead `maxPos` query
- **Fixed**: `cardService.deleteCard` — delete + position shift are now atomic
- **Converted**: `stageService.{createStage,updateStage,reorderStages}`, `cardService.{moveCard,deleteCard}`, `todoService.{deleteTodo,reorderTodos}`
- **Tests**: added proxy `mockTransaction.mockImplementation` in unit test `beforeEach` hooks so `withTransaction` callbacks execute under mock

## Related
Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)