### PR TITLE
refactor: bound same-column moveCard shifts to the range between positions

### DIFF
--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -406,8 +406,24 @@ export const cardService = {
     const oldPosition = card.position;
 
     const performMove = async (t: Knex.Transaction) => {
-      await shiftDown({ trx: t, table: 'cards', scope: { user_id: userId, stage_id: oldStageId }, fromPos: oldPosition });
-      await shiftUp({ trx: t, table: 'cards', scope: { user_id: userId, stage_id: stageId }, fromPos: position });
+      if (oldStageId === stageId && oldPosition !== position) {
+        // Same column: only the cards strictly between old and new position need to
+        // shift — not every card below the departure point or above the destination.
+        const scope = { user_id: userId, stage_id: stageId };
+        if (oldPosition < position) {
+          // Moving down: cards in (oldPosition, position] shift down by 1
+          await shiftDown({ trx: t, table: 'cards', scope, fromPos: oldPosition, toPos: position });
+        } else {
+          // Moving up: cards in [position, oldPosition) shift up by 1
+          await shiftUp({ trx: t, table: 'cards', scope, fromPos: position, toPos: oldPosition - 1 });
+        }
+      } else if (oldStageId !== stageId) {
+        // Cross-column: full tail shift in each column — unavoidable
+        await shiftDown({ trx: t, table: 'cards', scope: { user_id: userId, stage_id: oldStageId }, fromPos: oldPosition });
+        await shiftUp({ trx: t, table: 'cards', scope: { user_id: userId, stage_id: stageId }, fromPos: position });
+      }
+      // oldPosition === position and same stage: no shift needed at all
+
       await t('cards')
         .where({ id: cardId })
         .update({

--- a/backend/tests/cards.test.ts
+++ b/backend/tests/cards.test.ts
@@ -442,6 +442,59 @@ describe('CardService - moveCard', () => {
     expect(mockTransaction).toHaveBeenCalledTimes(1);
   });
 
+  it('should move card within the same stage (no activity logged)', async () => {
+    // Card moves from position 0 to position 3 within STAGE_ID — same column.
+    const cardAtPos0 = { ...MOCK_CARD, position: 0 };
+    const movedCard = { ...MOCK_CARD, position: 3, stage_name: MOCK_STAGE.name };
+    let cardsCallCount = 0;
+
+    // Use the proxy transaction so shiftDown/shiftUp run against mockDb.
+    // The beforeEach proxy is already in place; no override needed here.
+
+    mockDb.mockImplementation((tableName: string) => {
+      if (tableName === 'cards') {
+        cardsCallCount++;
+        if (cardsCallCount === 1) {
+          const chain = createQueryChain(undefined);
+          chain.where = jest.fn().mockReturnValue({
+            first: jest.fn().mockResolvedValue(cardAtPos0),
+          });
+          return chain;
+        }
+        // subsequent trx calls + final select
+        const chain = createQueryChain(undefined);
+        chain.where = jest.fn().mockReturnValue(chain);
+        chain.andWhere = jest.fn().mockReturnValue(chain);
+        chain.decrement = jest.fn().mockResolvedValue(1);
+        chain.increment = jest.fn().mockResolvedValue(1);
+        chain.update = jest.fn().mockResolvedValue(1);
+        chain.join = jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            select: jest.fn().mockResolvedValue([movedCard]),
+          }),
+        });
+        return chain;
+      }
+      if (tableName === 'stages') {
+        const chain = createQueryChain(undefined);
+        chain.where = jest.fn().mockReturnValue({
+          first: jest.fn().mockResolvedValue(MOCK_STAGE),
+        });
+        return chain;
+      }
+      return createQueryChain(undefined);
+    });
+
+    const result = await cardService.moveCard(CARD_ID, USER_ID, STAGE_ID, 3);
+
+    expect(result).toMatchObject({ position: 3 });
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    // No activity logged — same stage, no stage_id change
+    const activityCalls = (mockDb as jest.Mock).mock.calls
+      .filter((args: string[]) => args[0] === 'card_activities');
+    expect(activityCalls).toHaveLength(0);
+  });
+
   it('should throw 404 when moving a non-existent card', async () => {
     const cardsChain = createQueryChain(undefined);
     cardsChain.where = jest.fn().mockReturnValue({


### PR DESCRIPTION
## Summary
- Same-column card drags now shift only the cards between old and new position instead of every card from each position to the end of the list
- No change to cross-column moves (tail-shift in both columns remains unavoidable)

## The problem
For a 100-card column, dragging card 50 → 75 previously did:
- `shiftDown(fromPos=50)` → 49 writes (positions 51–99)
- `shiftUp(fromPos=75)` → 24 writes (positions 75–98 after step 1)
- 1 card UPDATE = **74 total writes**, only 26 of which were needed.

## The fix
```
move-down (old < new): shiftDown(fromPos=old, toPos=new)   → new-old writes
move-up   (old > new): shiftUp(fromPos=new, toPos=old-1)   → old-new writes
no-op     (old == new): zero shifts
```
Same 50→75 example: **26 writes** (25 range shifts + 1 card update).

## Acceptance criteria
- [x] Same-column drag issues exactly `(|new - old|)` row writes + 1 UPDATE
- [x] Cross-column behavior unchanged
- [x] Existing integration tests for same-stage moves pass
- [x] New unit test: same-stage move produces correct result and logs no activity

## Related
Stacks on top of #167 (position-shift helpers). Base branch set to PR #167's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)