### PR TITLE
fix(gmailSync): preserve Hebrew/Unicode characters in normalize() to fix companyMatch false negatives

### DIFF
--- a/backend/src/services/gmailSync.ts
+++ b/backend/src/services/gmailSync.ts
@@ -105,8 +105,13 @@ function truncate(value: string | null | undefined, max = MAX_VARCHAR_255): stri
 
 // Strips non-letter/non-digit characters (Unicode-aware) and lowercases.
 // The `u` flag enables \p{L} (any letter) and \p{N} (any digit) Unicode property escapes.
+// NFC normalization is applied first so that the same visually identical name in
+// composed (NFC) and decomposed (NFD) form produces the same output — combining
+// marks (\p{M}) are not letters and would otherwise be stripped, e.g. NFD
+// `"Société"` would lose its acute accents while NFC `"Société"`
+// would keep them, causing companyMatch to falsely diverge.
 export function normalize(str: string): string {
-  return str.toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
+  return str.normalize('NFC').toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
 }
 
 // Canonical company match — used for both receipt and rejection paths.

--- a/backend/src/services/gmailSync.ts
+++ b/backend/src/services/gmailSync.ts
@@ -103,16 +103,16 @@ function truncate(value: string | null | undefined, max = MAX_VARCHAR_255): stri
   return value.length > max ? value.slice(0, max) : value;
 }
 
-// Strips all non-ASCII-alphanumeric chars and lowercases. Returns empty string
-// for names that consist entirely of non-ASCII characters (e.g. Hebrew-only).
-function normalize(str: string): string {
-  return str.toLowerCase().replace(/[^a-z0-9]/g, '');
+// Strips non-letter/non-digit characters (Unicode-aware) and lowercases.
+// The `u` flag enables \p{L} (any letter) and \p{N} (any digit) Unicode property escapes.
+export function normalize(str: string): string {
+  return str.toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
 }
 
 // Canonical company match — used for both receipt and rejection paths.
-// Rejects if the card company has no ASCII alphanumeric content, or the
-// extracted name is too short (≤3 chars) to be meaningful.
-function companyMatch(cardCompany: string, extractedCompany: string): boolean {
+// Rejects if either normalized name is empty, or the extracted name is too
+// short (≤3 chars) to avoid noise matches.
+export function companyMatch(cardCompany: string, extractedCompany: string): boolean {
   const a = normalize(cardCompany);
   const b = normalize(extractedCompany);
   if (a.length === 0 || b.length <= 3) return false;

--- a/backend/tests/gmailSync.test.ts
+++ b/backend/tests/gmailSync.test.ts
@@ -302,6 +302,12 @@ describe('companyMatch', () => {
   it('matches accented-Latin company names', () => {
     expect(companyMatch('Société Générale', 'Société Générale')).toBe(true);
   });
+
+  it('matches the same name in NFC vs NFD form', () => {
+    const nfc = 'Société Générale';            // 'é' = U+00E9 (precomposed)
+    const nfd = 'Société Générale';        // 'e' + U+0301 (combining acute)
+    expect(companyMatch(nfc, nfd)).toBe(true);
+  });
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/backend/tests/gmailSync.test.ts
+++ b/backend/tests/gmailSync.test.ts
@@ -41,7 +41,7 @@ jest.mock('../src/services/cardService', () => ({
   resolveCompanyIconUrl: jest.fn().mockResolvedValue(null),
 }));
 
-import { syncUserGmailWith, GmailPort, ClassifierPort, SyncDeps, RawEmail, GmailClient } from '../src/services/gmailSync';
+import { syncUserGmailWith, normalize, companyMatch, GmailPort, ClassifierPort, SyncDeps, RawEmail, GmailClient } from '../src/services/gmailSync';
 import { cardService } from '../src/services/cardService';
 import { EmailClassification } from '../src/services/emailClassifier';
 
@@ -248,6 +248,60 @@ function makeDeps(emails: RawEmail[], classMap: Record<string, EmailClassificati
 
 afterEach(() => {
   jest.clearAllMocks();
+});
+
+// ── Unit tests for normalize / companyMatch helpers ───────────────────────────
+
+describe('normalize', () => {
+  it('strips spaces and punctuation from ASCII names', () => {
+    expect(normalize('Acme, Inc.')).toBe('acmeinc');
+  });
+
+  it('preserves Hebrew letters', () => {
+    expect(normalize('בנק הפועלים')).toBe('בנקהפועלים');
+  });
+
+  it('preserves mixed Hebrew and Latin letters', () => {
+    expect(normalize('Apple בנק')).toBe('appleבנק');
+  });
+
+  it('preserves accented Latin letters', () => {
+    expect(normalize('Société Générale')).toBe('sociétégénérale');
+  });
+
+  it('strips emoji, preserving surrounding letters', () => {
+    expect(normalize('Company 🚀')).toBe('company');
+  });
+
+  it('returns empty string for a space-only input', () => {
+    expect(normalize('   ')).toBe('');
+  });
+});
+
+describe('companyMatch', () => {
+  it('matches identical Hebrew company names', () => {
+    expect(companyMatch('בנק הפועלים', 'בנק הפועלים')).toBe(true);
+  });
+
+  it('does not cross-match Hebrew and Latin names for the same company', () => {
+    expect(companyMatch('Bank Hapoalim', 'בנק הפועלים')).toBe(false);
+  });
+
+  it('matches when extracted name is a substring of card name (ASCII)', () => {
+    expect(companyMatch('Acme Corporation', 'Acme Corp')).toBe(true);
+  });
+
+  it('rejects when both names normalize to empty', () => {
+    expect(companyMatch('   ', '   ')).toBe(false);
+  });
+
+  it('rejects when extracted name normalizes to ≤3 chars', () => {
+    expect(companyMatch('IBM', 'IBM')).toBe(false);
+  });
+
+  it('matches accented-Latin company names', () => {
+    expect(companyMatch('Société Générale', 'Société Générale')).toBe(true);
+  });
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -609,20 +663,21 @@ describe('syncUserGmailWith', () => {
   });
 
   describe('normalizer parity', () => {
-    it('matches Hebrew-only company name as no-match (not a false positive)', async () => {
+    it('moves card to rejection stage when company name is Hebrew-only', async () => {
       const { insertedProcessedEmails } = setupDb({
         existingCards: [{ id: 'card-1', company_name: 'חברה ישראלית', role_title: 'Engineer' }],
       });
+      (cardService.moveCard as jest.Mock).mockResolvedValue({});
 
       const summary = await syncUserGmailWith(USER_ID, makeDeps(
         [REJECTION_EMAIL],
         { 'msg-002': makeRejectionClassification({ companyName: 'חברה ישראלית' }) },
       ));
 
-      // Both normalize to '' — companyMatch returns false (extracted is too short after normalize)
-      expect(summary.noMatch).toBe(1);
+      // Hebrew letters are preserved — both normalize to 'חברהישראלית', companyMatch returns true
+      expect(summary.rejectionsMoved).toBe(1);
       expect(insertedProcessedEmails).toEqual(
-        expect.arrayContaining([expect.objectContaining({ action: 'no_match' })]),
+        expect.arrayContaining([expect.objectContaining({ action: 'moved_to_rejected' })]),
       );
     });
 


### PR DESCRIPTION
## Summary
- Replace the ASCII-only `[^a-z0-9]` regex in `normalize()` with Unicode-safe `[^\p{L}\p{N}]` and the `u` flag
- Hebrew (and any non-ASCII Unicode) company names no longer collapse to an empty string, fixing silent false negatives for the entire non-English user base
- Export `normalize` and `companyMatch` as named exports to enable direct unit testing

## Acceptance criteria
- [x] `normalize()` no longer strips Hebrew characters; `normalize("בנק הפועלים")` returns a non-empty string
- [x] `companyMatch("בנק הפועלים", "בנק הפועלים")` returns `true`
- [x] `companyMatch("Bank Hapoalim", "בנק הפועלים")` returns `false` (no cross-script false positives)
- [x] Unit tests added covering: Hebrew-only, mixed Hebrew + Latin, accented Latin (`"Société Générale"`), and emoji-in-name edge cases
- [x] Existing ASCII test cases for `companyMatch` / `roleMatch` continue to pass unchanged
- [ ] Manual regression: trigger a sync with a Hebrew-language receipt against an existing Hebrew-named card → no duplicate card created, and a `receipt_already_tracked` row is written to `processed_emails`

## Related
Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)