### PR TITLE
refactor: embed user claims in JWT and clean up gmail /sync auth

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,9 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import db from '../config/database';
 import logger from '../config/logger';
 
-// Extend Express Request to include authenticated user
 declare global {
   namespace Express {
     interface Request {
@@ -12,6 +10,7 @@ declare global {
         email: string;
         name: string;
       };
+      isCronRequest?: boolean;
     }
   }
 }
@@ -19,18 +18,11 @@ declare global {
 export interface JwtPayload {
   userId: string;
   email: string;
+  name: string;
   iat: number;
   exp: number;
 }
 
-/**
- * Express middleware that verifies the JWT access token from the
- * Authorization: Bearer <token> header, looks up the user in the database,
- * and attaches { id, email, name } to req.user.
- *
- * Returns 401 if the token is missing, malformed, expired, or belongs to a
- * user that no longer exists.
- */
 export async function authenticate(
   req: Request,
   res: Response,
@@ -91,26 +83,10 @@ export async function authenticate(
       return;
     }
 
-    // Look up user in database to ensure they still exist
-    const user = await db('users')
-      .select('id', 'email', 'name')
-      .where({ id: decoded.userId })
-      .first();
-
-    if (!user) {
-      res.status(401).json({
-        error: {
-          message: 'User not found',
-          code: 'ERR_USER_NOT_FOUND',
-        },
-      });
-      return;
-    }
-
     req.user = {
-      id: user.id,
-      email: user.email,
-      name: user.name,
+      id: decoded.userId,
+      email: decoded.email,
+      name: decoded.name,
     };
 
     next();

--- a/backend/src/routes/gmail.ts
+++ b/backend/src/routes/gmail.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { timingSafeEqual, createHash } from 'crypto';
 import db from '../config/database';
 import { authenticate } from '../middleware/auth';
+import logger from '../config/logger';
 import { gmailService } from '../services/gmailService';
 import { syncUserGmail } from '../services/gmailSync';
 
@@ -57,7 +58,11 @@ function syncAuth(req: Request, res: Response, next: NextFunction): void {
     return;
   }
 
-  authenticate(req, res, next);
+  if (cronKey) {
+    logger.warn('syncAuth: Authorization header did not match CRON_API_KEY — falling through to JWT auth');
+  }
+
+  authenticate(req, res, next).catch(next);
 }
 
 router.post('/sync', syncAuth, async (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/routes/gmail.ts
+++ b/backend/src/routes/gmail.ts
@@ -47,13 +47,22 @@ router.delete('/disconnect', authenticate, async (req: Request, res: Response, n
   } catch (err) { next(err); }
 });
 
-router.post('/sync', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const cronKey = process.env.CRON_API_KEY;
-    const authHeader = req.headers.authorization ?? '';
-    const isCron = !!cronKey && safeCompare(authHeader, `Bearer ${cronKey}`);
+function syncAuth(req: Request, res: Response, next: NextFunction): void {
+  const cronKey = process.env.CRON_API_KEY;
+  const authHeader = req.headers.authorization ?? '';
 
-    if (isCron) {
+  if (cronKey && safeCompare(authHeader, `Bearer ${cronKey}`)) {
+    req.isCronRequest = true;
+    next();
+    return;
+  }
+
+  authenticate(req, res, next);
+}
+
+router.post('/sync', syncAuth, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    if (req.isCronRequest) {
       const tokens = await db('gmail_tokens').where({ is_valid: true }).select('user_id');
       const results: Record<string, unknown> = {};
       for (const { user_id } of tokens) {
@@ -62,11 +71,7 @@ router.post('/sync', async (req: Request, res: Response, next: NextFunction) => 
       return res.json({ results });
     }
 
-    await new Promise<void>((resolve, reject) => {
-      authenticate(req as Request, res as Response, (err?: unknown) => (err ? reject(err) : resolve()));
-    });
-
-    const summary = await syncUserGmail((req as Request).user!.id);
+    const summary = await syncUserGmail(req.user!.id);
     res.json({ data: summary });
   } catch (err) { next(err); }
 });

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -52,11 +52,11 @@ function hashToken(token: string): string {
  * Generate an access token and a refresh token for the given user.
  * The refresh token is a random UUID whose SHA-256 hash is stored in the DB.
  */
-async function generateTokens(userId: string, email: string): Promise<TokenPair> {
+async function generateTokens(userId: string, email: string, name: string): Promise<TokenPair> {
   const secret = getJwtSecret();
 
   const accessToken = jwt.sign(
-    { userId, email },
+    { userId, email, name },
     secret,
     { expiresIn: ACCESS_TOKEN_EXPIRY }
   );
@@ -118,7 +118,7 @@ async function signup(
 
   await createDefaultStages(user.id);
 
-  const tokens = await generateTokens(user.id, user.email);
+  const tokens = await generateTokens(user.id, user.email, user.name);
 
   logger.info('User signed up', { userId: user.id, email: user.email });
 
@@ -149,7 +149,7 @@ async function login(
     throw new AppError('Invalid email or password', 401, 'ERR_INVALID_CREDENTIALS');
   }
 
-  const tokens = await generateTokens(user.id, user.email);
+  const tokens = await generateTokens(user.id, user.email, user.name);
 
   logger.info('User logged in', { userId: user.id });
 
@@ -189,7 +189,7 @@ async function refreshTokens(
   // Rotate: delete old token then issue new pair
   await db('refresh_tokens').where({ id: storedToken.id }).del();
 
-  const tokens = await generateTokens(user.id, user.email);
+  const tokens = await generateTokens(user.id, user.email, user.name);
 
   logger.info('Tokens refreshed', { userId: user.id });
 

--- a/backend/tests/auth.test.ts
+++ b/backend/tests/auth.test.ts
@@ -63,8 +63,8 @@ afterEach(() => {
 });
 
 // ── Helper: generate a valid access token ────────────────────────────────────
-function generateValidToken(userId: string, email: string): string {
-  return jwt.sign({ userId, email }, JWT_SECRET, { expiresIn: '15m' });
+function generateValidToken(userId: string, email: string, name: string = 'Test User'): string {
+  return jwt.sign({ userId, email, name }, JWT_SECRET, { expiresIn: '15m' });
 }
 
 // ── Helper: configure mockDb for a specific test scenario ────────────────────
@@ -284,20 +284,7 @@ describe('Auth - POST /api/auth/login', () => {
 
 describe('Auth - GET /api/auth/me', () => {
   it('should return user data with valid auth token', async () => {
-    const token = generateValidToken(MOCK_USER.id, MOCK_USER.email);
-
-    const usersChain = createQueryChain(undefined);
-    usersChain.select = jest.fn().mockReturnValue({
-      where: jest.fn().mockReturnValue({
-        first: jest.fn().mockResolvedValue({
-          id: MOCK_USER.id,
-          email: MOCK_USER.email,
-          name: MOCK_USER.name,
-        }),
-      }),
-    });
-
-    setupDbMock({ users: usersChain });
+    const token = generateValidToken(MOCK_USER.id, MOCK_USER.email, MOCK_USER.name);
 
     const res = await request(app)
       .get('/api/auth/me')

--- a/backend/tests/gmail.test.ts
+++ b/backend/tests/gmail.test.ts
@@ -1,0 +1,150 @@
+// ── Mock the database module before any imports that use it ───────────────────
+
+const mockDb = jest.fn();
+
+function createQueryChain(resolvedValue: unknown = undefined) {
+  const chain: Record<string, jest.Mock> = {};
+  const methods = [
+    'where', 'andWhere', 'select', 'first', 'insert', 'update', 'del',
+    'returning', 'join', 'orderBy',
+  ];
+  for (const method of methods) {
+    chain[method] = jest.fn().mockReturnValue(chain);
+  }
+  chain.first = jest.fn().mockResolvedValue(resolvedValue);
+  chain.select = jest.fn().mockResolvedValue(
+    Array.isArray(resolvedValue) ? resolvedValue : [resolvedValue],
+  );
+  chain.del = jest.fn().mockResolvedValue(1);
+  return chain;
+}
+
+jest.mock('../src/config/database', () => {
+  const handler = (tableName: string) => mockDb(tableName);
+  handler.raw = jest.fn();
+  handler.fn = { now: jest.fn() };
+  handler.transaction = jest.fn();
+  return { __esModule: true, default: handler };
+});
+
+jest.mock('../src/services/gmailSync', () => ({
+  syncUserGmail: jest.fn(),
+}));
+
+jest.mock('../src/services/gmailService', () => ({
+  gmailService: {
+    getAuthUrl: jest.fn(),
+    handleCallback: jest.fn(),
+    getStatus: jest.fn(),
+    disconnect: jest.fn(),
+  },
+}));
+
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import app from '../src/app';
+import { syncUserGmail } from '../src/services/gmailSync';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+const JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
+const CRON_API_KEY = 'test-cron-key-secret';
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000';
+const USER_EMAIL = 'test@example.com';
+const USER_NAME = 'Test User';
+
+function generateValidToken(userId: string, email: string, name: string): string {
+  return jwt.sign({ userId, email, name }, JWT_SECRET, { expiresIn: '15m' });
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+  delete process.env.CRON_API_KEY;
+});
+
+// =============================================================================
+// POST /api/gmail/sync
+// =============================================================================
+
+describe('POST /api/gmail/sync — cron path', () => {
+  it('should sync all users when called with a valid CRON_API_KEY', async () => {
+    process.env.CRON_API_KEY = CRON_API_KEY;
+
+    const gmailTokensChain = createQueryChain([{ user_id: USER_ID }]);
+    mockDb.mockImplementation((tableName: string) => {
+      if (tableName === 'gmail_tokens') return gmailTokensChain;
+      return createQueryChain(undefined);
+    });
+
+    (syncUserGmail as jest.Mock).mockResolvedValue({ scanned: 5, receiptsCreated: 1 });
+
+    const res = await request(app)
+      .post('/api/gmail/sync')
+      .set('Authorization', `Bearer ${CRON_API_KEY}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[USER_ID]).toMatchObject({ scanned: 5, receiptsCreated: 1 });
+    expect(syncUserGmail).toHaveBeenCalledWith(USER_ID);
+    expect(syncUserGmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return 401 when CRON_API_KEY is wrong', async () => {
+    process.env.CRON_API_KEY = CRON_API_KEY;
+
+    const res = await request(app)
+      .post('/api/gmail/sync')
+      .set('Authorization', 'Bearer wrong-key');
+
+    // Wrong cron key is passed to authenticate as a JWT — rejected as invalid token
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('ERR_INVALID_TOKEN');
+  });
+});
+
+describe('POST /api/gmail/sync — user path', () => {
+  it('should sync for the authenticated user when called with a valid JWT', async () => {
+    const token = generateValidToken(USER_ID, USER_EMAIL, USER_NAME);
+    (syncUserGmail as jest.Mock).mockResolvedValue({ scanned: 3, receiptsCreated: 0 });
+
+    const res = await request(app)
+      .post('/api/gmail/sync')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({ scanned: 3, receiptsCreated: 0 });
+    expect(syncUserGmail).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it('should return 401 when no token is provided', async () => {
+    const res = await request(app)
+      .post('/api/gmail/sync');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('ERR_NO_TOKEN');
+  });
+
+  it('should return 401 when JWT is invalid', async () => {
+    const res = await request(app)
+      .post('/api/gmail/sync')
+      .set('Authorization', 'Bearer invalid.jwt.token');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('ERR_INVALID_TOKEN');
+  });
+
+  it('should return 401 when JWT is expired', async () => {
+    const expiredToken = jwt.sign(
+      { userId: USER_ID, email: USER_EMAIL, name: USER_NAME },
+      JWT_SECRET,
+      { expiresIn: '0s' },
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const res = await request(app)
+      .post('/api/gmail/sync')
+      .set('Authorization', `Bearer ${expiredToken}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.message).toBe('Token has expired');
+  });
+});

--- a/backend/tests/gmail.test.ts
+++ b/backend/tests/gmail.test.ts
@@ -87,6 +87,48 @@ describe('POST /api/gmail/sync — cron path', () => {
     expect(syncUserGmail).toHaveBeenCalledTimes(1);
   });
 
+  it('should return empty results when no valid gmail tokens exist', async () => {
+    process.env.CRON_API_KEY = CRON_API_KEY;
+
+    const gmailTokensChain = createQueryChain([]);
+    mockDb.mockImplementation((tableName: string) => {
+      if (tableName === 'gmail_tokens') return gmailTokensChain;
+      return createQueryChain(undefined);
+    });
+
+    const res = await request(app)
+      .post('/api/gmail/sync')
+      .set('Authorization', `Bearer ${CRON_API_KEY}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toEqual({});
+    expect(syncUserGmail).not.toHaveBeenCalled();
+  });
+
+  it('should sync each user independently when multiple tokens exist', async () => {
+    process.env.CRON_API_KEY = CRON_API_KEY;
+    const USER_ID_2 = '660f9511-f3ac-52e5-b827-557766551111';
+
+    const gmailTokensChain = createQueryChain([{ user_id: USER_ID }, { user_id: USER_ID_2 }]);
+    mockDb.mockImplementation((tableName: string) => {
+      if (tableName === 'gmail_tokens') return gmailTokensChain;
+      return createQueryChain(undefined);
+    });
+
+    (syncUserGmail as jest.Mock)
+      .mockResolvedValueOnce({ scanned: 3, receiptsCreated: 1 })
+      .mockResolvedValueOnce({ scanned: 7, receiptsCreated: 2 });
+
+    const res = await request(app)
+      .post('/api/gmail/sync')
+      .set('Authorization', `Bearer ${CRON_API_KEY}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[USER_ID]).toMatchObject({ scanned: 3, receiptsCreated: 1 });
+    expect(res.body.results[USER_ID_2]).toMatchObject({ scanned: 7, receiptsCreated: 2 });
+    expect(syncUserGmail).toHaveBeenCalledTimes(2);
+  });
+
   it('should return 401 when CRON_API_KEY is wrong', async () => {
     process.env.CRON_API_KEY = CRON_API_KEY;
 
@@ -95,6 +137,17 @@ describe('POST /api/gmail/sync — cron path', () => {
       .set('Authorization', 'Bearer wrong-key');
 
     // Wrong cron key is passed to authenticate as a JWT — rejected as invalid token
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('ERR_INVALID_TOKEN');
+  });
+
+  it('should fall through to JWT auth when CRON_API_KEY is not configured', async () => {
+    // CRON_API_KEY unset — afterEach already handles cleanup, nothing to set here
+    const res = await request(app)
+      .post('/api/gmail/sync')
+      .set('Authorization', 'Bearer some-cron-looking-value');
+
+    // syncAuth has no cronKey to compare against, falls to authenticate which rejects it as bad JWT
     expect(res.status).toBe(401);
     expect(res.body.error.code).toBe('ERR_INVALID_TOKEN');
   });


### PR DESCRIPTION
## Summary
- Embed `name` alongside `userId` and `email` in JWT access tokens, so `authenticate` can populate `req.user` without a DB round-trip on every request
- Remove the `db('users')` lookup from `authenticate` middleware — token verification is now the only check
- Introduce `syncAuth` middleware for `POST /api/gmail/sync` that handles the dual-caller pattern (cron vs. user JWT) using proper Express middleware chaining instead of a fragile `Promise`-wrapped manual call

## Acceptance criteria
- [x] `generateTokens` accepts `name` alongside `userId` and `email`; JWT payload shape is `{ userId, email, name }`
- [x] `JwtPayload` interface updated to include `name: string`
- [x] `authenticate` populates `req.user` from decoded token payload — no DB query
- [x] `ERR_USER_NOT_FOUND` branch removed; a valid unexpired token is sufficient proof of identity
- [x] `syncAuth` middleware in `routes/gmail.ts` checks CRON_API_KEY first, sets `req.isCronRequest = true` and calls `next()` on match; delegates to `authenticate` as a standard middleware call otherwise
- [x] `POST /api/gmail/sync` handler reads `req.isCronRequest` flag to select cron vs user path
- [x] Auth tests updated: `generateValidToken` includes `name`; `GET /api/auth/me` test needs no DB mock
- [x] New `gmail.test.ts` covers cron path (valid key → 200), user path (valid JWT → 200), no token → 401, invalid JWT → 401, expired JWT → 401
- [x] All 104 tests pass

## Related
Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)