### PR TITLE
[Cassandra pipeline PR1.1] Schema: companies lifecycle + backfill state tables

### DIFF
--- a/data-pipeline/schema/005_alter_companies_initialized.cql
+++ b/data-pipeline/schema/005_alter_companies_initialized.cql
@@ -1,0 +1,2 @@
+ALTER TABLE jobflow.companies ADD initialized boolean;
+ALTER TABLE jobflow.companies ADD initialized_at timestamp;

--- a/data-pipeline/schema/006_backfill_runs.cql
+++ b/data-pipeline/schema/006_backfill_runs.cql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS jobflow.backfill_runs (
+    bucket          text,
+    run_id          timeuuid,
+    started_at      timestamp,
+    completed_at    timestamp,
+    status          text,
+    target_rows     set<frozen<tuple<text, text>>>,
+    PRIMARY KEY ((bucket), run_id)
+) WITH CLUSTERING ORDER BY (run_id DESC);

--- a/data-pipeline/schema/007_backfill_progress.cql
+++ b/data-pipeline/schema/007_backfill_progress.cql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS jobflow.backfill_progress (
+    run_id          timeuuid,
+    date            date,
+    status          text,
+    started_at      timestamp,
+    completed_at    timestamp,
+    events_written  bigint,
+    PRIMARY KEY ((run_id), date)
+) WITH CLUSTERING ORDER BY (date ASC);


### PR DESCRIPTION
## Summary
- Adds `initialized boolean` and `initialized_at timestamp` columns to the existing `companies` table via `ALTER`
- Creates `backfill_runs` table with singleton-bucket partition pattern (`bucket = 'singleton'`) and `run_id DESC` clustering for efficient latest-run lookup
- Creates `backfill_progress` table keyed by `run_id` with `date ASC` clustering for crash-resume via max completed date

## Acceptance criteria
- [x] `005_alter_companies_initialized.cql` adds `initialized boolean` and `initialized_at timestamp` columns to the existing `companies` table
- [x] `006_backfill_runs.cql` creates a table with primary key `((bucket), run_id)`, `WITH CLUSTERING ORDER BY (run_id DESC)`, and a `target_rows` column of type `set<frozen<tuple<text, text>>>`
- [x] `007_backfill_progress.cql` creates a table with primary key `((run_id), date)`, `WITH CLUSTERING ORDER BY (date ASC)`
- [ ] All three files apply cleanly via `cqlsh` against a fresh `cassandra:4.1` container started from `data-pipeline/docker-compose.yml` *(requires manual verification — Docker not accessible in CI shell)*
- [ ] `cqlsh -e "DESCRIBE KEYSPACE jobflow"` shows the two new columns on `companies` and the two new tables *(requires manual verification)*
- [x] Files committed in the `data-pipeline/schema/` directory; existing 001–004 files unchanged

## Related
Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)