### PR TITLE
[Cassandra pipeline PR1.2] Fetcher base: --hour and --range modes

### DIFF
--- a/data-pipeline/fetcher/.env.example
+++ b/data-pipeline/fetcher/.env.example
@@ -1,0 +1,2 @@
+GHARCHIVE_DIR=./data/gharchive
+LOG_LEVEL=info

--- a/data-pipeline/fetcher/.gitignore
+++ b/data-pipeline/fetcher/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+data/
+.env

--- a/data-pipeline/fetcher/fetcher.js
+++ b/data-pipeline/fetcher/fetcher.js
@@ -1,0 +1,58 @@
+import pino from 'pino';
+import pLimit from 'p-limit';
+import { parseCLI } from './lib/cli.js';
+import { cleanPartials, enumerateRange } from './lib/disk-layout.js';
+import { downloadHour } from './lib/download.js';
+
+const ROOT = process.env.GHARCHIVE_DIR ?? './data/gharchive';
+const LOG_LEVEL = process.env.LOG_LEVEL ?? 'info';
+const IS_PROD = process.env.NODE_ENV === 'production';
+
+const loggerOpts = { level: LOG_LEVEL };
+if (!IS_PROD) {
+  loggerOpts.transport = { target: 'pino-pretty' };
+}
+const logger = pino(loggerOpts);
+
+async function main() {
+  const cmd = parseCLI(process.argv);
+
+  logger.info({ root: ROOT }, 'cleaning partial files');
+  cleanPartials(ROOT);
+
+  const hours =
+    cmd.mode === 'hour'
+      ? [cmd.hourId]
+      : enumerateRange(cmd.start, cmd.end);
+
+  logger.info({ count: hours.length }, 'starting downloads');
+
+  const limit = pLimit(3);
+
+  const results = await Promise.all(
+    hours.map((hourId) =>
+      limit(async () => {
+        const result = await downloadHour(ROOT, hourId);
+        if (result.status === 'written') {
+          logger.info({ hourId }, 'written');
+        } else if (result.status === 'not-found') {
+          logger.warn({ hourId }, 'not found on GH Archive');
+        } else if (result.status === 'failed-after-retries') {
+          logger.error({ hourId, error: result.error }, 'failed after retries');
+        }
+        return result;
+      })
+    )
+  );
+
+  const tally = results.reduce(
+    (acc, r) => { acc[r.status] = (acc[r.status] ?? 0) + 1; return acc; },
+    {}
+  );
+  logger.info(tally, 'done');
+}
+
+main().catch((err) => {
+  logger.error(err, 'fatal error');
+  process.exit(1);
+});

--- a/data-pipeline/fetcher/fetcher.js
+++ b/data-pipeline/fetcher/fetcher.js
@@ -29,7 +29,7 @@ async function main() {
 
   const limit = pLimit(3);
 
-  const results = await Promise.all(
+  const settled = await Promise.allSettled(
     hours.map((hourId) =>
       limit(async () => {
         const result = await downloadHour(ROOT, hourId);
@@ -43,6 +43,12 @@ async function main() {
         return result;
       })
     )
+  );
+
+  const results = settled.map((s) =>
+    s.status === 'fulfilled'
+      ? s.value
+      : { status: 'failed-after-retries', error: s.reason?.message }
   );
 
   const tally = results.reduce(

--- a/data-pipeline/fetcher/lib/cli.js
+++ b/data-pipeline/fetcher/lib/cli.js
@@ -1,0 +1,34 @@
+const HOUR_RE = /^\d{4}-\d{2}-\d{2}-\d{1,2}$/;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+// Parses process.argv and returns a command descriptor. Exits 1 on invalid input.
+export function parseCLI(argv) {
+  const args = argv.slice(2);
+
+  if (args[0] === '--hour') {
+    const hourId = args[1];
+    if (!hourId || !HOUR_RE.test(hourId)) {
+      die('--hour requires a valid YYYY-MM-DD-H value (e.g. 2025-05-01-15)');
+    }
+    return { mode: 'hour', hourId };
+  }
+
+  if (args[0] === '--range') {
+    const start = args[1];
+    const end = args[2];
+    if (!start || !DATE_RE.test(start) || !end || !DATE_RE.test(end)) {
+      die('--range requires two valid YYYY-MM-DD dates (e.g. --range 2025-05-01 2025-05-02)');
+    }
+    if (start > end) {
+      die('--range start date must be <= end date');
+    }
+    return { mode: 'range', start, end };
+  }
+
+  die('usage: fetcher.js --hour <YYYY-MM-DD-H> | --range <YYYY-MM-DD> <YYYY-MM-DD>');
+}
+
+function die(msg) {
+  process.stderr.write(`Error: ${msg}\n`);
+  process.exit(1);
+}

--- a/data-pipeline/fetcher/lib/cli.js
+++ b/data-pipeline/fetcher/lib/cli.js
@@ -10,6 +10,8 @@ export function parseCLI(argv) {
     if (!hourId || !HOUR_RE.test(hourId)) {
       die('--hour requires a valid YYYY-MM-DD-H value (e.g. 2025-05-01-15)');
     }
+    const h = parseInt(hourId.split('-')[3], 10);
+    if (h < 0 || h > 23) die('hour component must be 0–23');
     return { mode: 'hour', hourId };
   }
 

--- a/data-pipeline/fetcher/lib/disk-layout.js
+++ b/data-pipeline/fetcher/lib/disk-layout.js
@@ -13,7 +13,7 @@ export function pathToHourId(root, filePath) {
   const rel = path.relative(root, filePath);
   const parts = rel.split(path.sep);
   const [year, month, day, file] = parts;
-  const hour = file.replace('.json.gz', '');
+  const hour = file.replace(/\.json\.gz$/, '');
   return `${year}-${month}-${day}-${parseInt(hour, 10)}`;
 }
 

--- a/data-pipeline/fetcher/lib/disk-layout.js
+++ b/data-pipeline/fetcher/lib/disk-layout.js
@@ -1,0 +1,59 @@
+import { readdirSync, unlinkSync } from 'fs';
+import path from 'path';
+
+// hourId: YYYY-MM-DD-H (month/day zero-padded, hour unpadded 0–23)
+// returns: <root>/YYYY/MM/DD/H.json.gz
+export function hourIdToPath(root, hourId) {
+  const [year, month, day, hour] = hourId.split('-');
+  return path.join(root, year, month, day, `${hour}.json.gz`);
+}
+
+// Inverse of hourIdToPath — recovers the canonical hour ID from an on-disk path.
+export function pathToHourId(root, filePath) {
+  const rel = path.relative(root, filePath);
+  const parts = rel.split(path.sep);
+  const [year, month, day, file] = parts;
+  const hour = file.replace('.json.gz', '');
+  return `${year}-${month}-${day}-${parseInt(hour, 10)}`;
+}
+
+// Returns all hour IDs (YYYY-MM-DD-H) for every UTC hour in [startDate, endDate] inclusive.
+// startDate / endDate: 'YYYY-MM-DD'
+export function enumerateRange(startDate, endDate) {
+  const [sy, sm, sd] = startDate.split('-').map(Number);
+  const [ey, em, ed] = endDate.split('-').map(Number);
+  const start = Date.UTC(sy, sm - 1, sd, 0);
+  const end = Date.UTC(ey, em - 1, ed, 23);
+  const hours = [];
+  for (let t = start; t <= end; t += 3_600_000) {
+    const d = new Date(t);
+    const year = d.getUTCFullYear();
+    const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(d.getUTCDate()).padStart(2, '0');
+    const hour = d.getUTCHours();
+    hours.push(`${year}-${month}-${day}-${hour}`);
+  }
+  return hours;
+}
+
+// Recursively removes every *.partial file under root. Silently skips missing directories.
+export function cleanPartials(root) {
+  _sweepDir(root);
+}
+
+function _sweepDir(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      _sweepDir(full);
+    } else if (entry.name.endsWith('.partial')) {
+      try { unlinkSync(full); } catch {}
+    }
+  }
+}

--- a/data-pipeline/fetcher/lib/download.js
+++ b/data-pipeline/fetcher/lib/download.js
@@ -1,0 +1,70 @@
+import { createWriteStream, existsSync, mkdirSync, renameSync, unlinkSync } from 'fs';
+import { pipeline } from 'stream/promises';
+import { Readable } from 'stream';
+import path from 'path';
+import { hourIdToPath } from './disk-layout.js';
+
+const GH_ARCHIVE_BASE = 'https://data.gharchive.org';
+const MAX_ATTEMPTS = 4;
+const INITIAL_BACKOFF_MS = 1000;
+
+// Returns a discriminated-union result:
+//   { status: 'written' | 'skipped-already-present' | 'not-found' | 'failed-after-retries', hourId, error? }
+export async function downloadHour(root, hourId) {
+  const finalPath = hourIdToPath(root, hourId);
+
+  if (existsSync(finalPath)) {
+    return { status: 'skipped-already-present', hourId };
+  }
+
+  mkdirSync(path.dirname(finalPath), { recursive: true });
+
+  const url = `${GH_ARCHIVE_BASE}/${hourId}.json.gz`;
+  const partialPath = `${finalPath}.partial`;
+  let lastError;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await sleep(INITIAL_BACKOFF_MS * 2 ** (attempt - 1));
+    }
+
+    let res;
+    try {
+      res = await fetch(url);
+    } catch (err) {
+      lastError = err;
+      tryUnlink(partialPath);
+      continue;
+    }
+
+    if (res.status === 404) {
+      return { status: 'not-found', hourId };
+    }
+
+    if (res.status >= 500) {
+      lastError = new Error(`HTTP ${res.status}`);
+      continue;
+    }
+
+    if (!res.ok) {
+      return { status: 'failed-after-retries', hourId, error: `HTTP ${res.status}` };
+    }
+
+    try {
+      await pipeline(Readable.fromWeb(res.body), createWriteStream(partialPath));
+      renameSync(partialPath, finalPath);
+      return { status: 'written', hourId };
+    } catch (err) {
+      lastError = err;
+      tryUnlink(partialPath);
+    }
+  }
+
+  return { status: 'failed-after-retries', hourId, error: lastError?.message };
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function tryUnlink(p) {
+  try { unlinkSync(p); } catch {}
+}

--- a/data-pipeline/fetcher/lib/download.js
+++ b/data-pipeline/fetcher/lib/download.js
@@ -38,26 +38,36 @@ export async function downloadHour(root, hourId) {
     }
 
     if (res.status === 404) {
+      await res.body?.cancel();
       return { status: 'not-found', hourId };
     }
 
     if (res.status >= 500) {
+      await res.body?.cancel();
       lastError = new Error(`HTTP ${res.status}`);
       continue;
     }
 
     if (!res.ok) {
+      await res.body?.cancel();
       return { status: 'failed-after-retries', hourId, error: `HTTP ${res.status}` };
     }
 
     try {
       await pipeline(Readable.fromWeb(res.body), createWriteStream(partialPath));
-      renameSync(partialPath, finalPath);
-      return { status: 'written', hourId };
     } catch (err) {
       lastError = err;
       tryUnlink(partialPath);
+      continue;
     }
+
+    try {
+      renameSync(partialPath, finalPath);
+    } catch (err) {
+      tryUnlink(partialPath);
+      return { status: 'failed-after-retries', hourId, error: err.message };
+    }
+    return { status: 'written', hourId };
   }
 
   return { status: 'failed-after-retries', hourId, error: lastError?.message };

--- a/data-pipeline/fetcher/package-lock.json
+++ b/data-pipeline/fetcher/package-lock.json
@@ -1,0 +1,338 @@
+{
+  "name": "jobflow-fetcher",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jobflow-fetcher",
+      "version": "1.0.0",
+      "dependencies": {
+        "p-limit": "^6.0.0",
+        "pino": "^9.0.0"
+      },
+      "devDependencies": {
+        "pino-pretty": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
+      "integrity": "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/data-pipeline/fetcher/package.json
+++ b/data-pipeline/fetcher/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "jobflow-fetcher",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Downloads GH Archive hourly .json.gz files to a configurable on-disk root",
+  "main": "fetcher.js",
+  "engines": {
+    "node": ">=20.6.0"
+  },
+  "scripts": {
+    "start": "node --env-file=.env fetcher.js"
+  },
+  "dependencies": {
+    "p-limit": "^6.0.0",
+    "pino": "^9.0.0"
+  },
+  "devDependencies": {
+    "pino-pretty": "^13.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- New standalone Node package at `data-pipeline/fetcher/` that downloads GH Archive hourly `.json.gz` files to a configurable on-disk root
- Four modules: `disk-layout` (pure functions), `download` (HTTP + atomic write + retries), `cli` (argv parsing), and `fetcher.js` entry point
- Bounded concurrency via `p-limit(3)`; idempotent; cleans `.partial` files on every startup

## Acceptance criteria
- [x] New Node package at `data-pipeline/fetcher/` with `"engines": ">=20.6.0"` in `package.json`; runtime deps limited to `pino` and `p-limit`
- [x] Environment loaded via `node --env-file=.env`; `.env.example` committed with `GHARCHIVE_DIR=./data/gharchive` and `LOG_LEVEL=info`
- [x] Pino logger streams to stdout: `pino-pretty` transport when `NODE_ENV !== 'production'`, raw JSON otherwise; honours `LOG_LEVEL`
- [x] Disk-layout module converts between canonical hour ID `YYYY-MM-DD-H` (hour unpadded) and on-disk path `<root>/YYYY/MM/DD/H.json.gz` (month and day zero-padded); enumerates a date range inclusive on both bounds; sweeps and removes every `.partial` file under the root
- [x] Download module performs atomic writes via `.partial` → final-name rename; returns a discriminated status (`written`, `skipped-already-present`, `not-found`, `failed-after-retries`); retries HTTP 5xx and network errors with exponential backoff up to a small fixed retry budget; treats an already-present final file as a no-op (no network call)
- [x] CLI module accepts `--hour <YYYY-MM-DD-H>` with strict regex `^\d{4}-\d{2}-\d{2}-\d{1,2}$` and `--range <A> <B>` with both bounds inclusive; rejects invalid input with a single-line error and a non-zero exit
- [x] `fetcher.js` entry point loads env, configures pino, dispatches by mode, runs downloads through `p-limit(3)`
- [x] HTTP 404 in `--hour` and `--range` modes logs the missing file and continues — never fatal
- [x] Re-running any command for files already on disk is a silent no-op (no network calls made for present files)
- [x] On every Fetcher startup (regardless of mode), all `.partial` files under `GHARCHIVE_DIR` are removed before any work begins; no age threshold
- [ ] Manual smoke test passes: `node fetcher.js --hour 2025-05-01-15` writes the file; re-running is silent; `node fetcher.js --range 2025-05-01 2025-05-02` downloads 48 files; killing the process mid-download leaves only a `.partial` and the next invocation cleans it and re-downloads

## Related
Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)