### PR TITLE
docs: PR2 ingester grill outcomes (glossary + ADR + org_name column)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,14 @@ _Avoid_: Initial load, Catchup (Catchup is the Hourly Ingest's fetcher mode)
 One execution of the Backfill process, identified by a `timeuuid` `run_id`. At start, the Run locks the set of (Company, Org) pairs currently marked `initialized = false`; any (Company, Org) pair added after the Run starts is ignored by that Run and waits for the next night's Run. A Run progresses one Date at a time and records per-Date status in the `backfill_progress` table; the Run itself is recorded in `backfill_runs` with status `in_progress`, `completed`, or `failed`.
 _Avoid_: Job, Batch, Sweep
 
+**Hourly Ingest**:
+The frequent, low-latency counterpart to the Backfill. Targets only (Company, Org) rows that have already been initialised by a prior Backfill Run, and incorporates each new GH Archive file as it becomes available. Backfill brings a row up to date once; Hourly Ingest keeps it current thereafter.
+_Avoid_: Live ingest, Streaming ingest
+
+**Tracked Event**:
+A row in the `company_events` Cassandra table — one piece of public activity on a Company's Org repos (a code push, a pull request, an issue, a release) that survived the Ingester's filter. The set of accepted GH Archive event types is curated for analytical value, not exhaustive. Each Tracked Event carries the Company partition it belongs to, the event-time-derived month bucket, extracted Tech Tags, and an AI-attributed flag.
+_Avoid_: Activity (already used for the JobFlow web app's `card_activities` rows), Event log entry
+
 **Activity**:
 A row in `card_activities` representing either a system-recorded event (action = `created`, `updated`, or `moved`) or a user-authored Note (action = `note_added`). System Activities are created automatically when an Application is created, a field changes, or the Application moves to a new Stage.
 _Avoid_: Log entry, History, Event

--- a/data-pipeline/schema/008_alter_company_events_org_name.cql
+++ b/data-pipeline/schema/008_alter_company_events_org_name.cql
@@ -1,0 +1,1 @@
+ALTER TABLE jobflow.company_events ADD org_name text;

--- a/docs/CassandraPlan.md
+++ b/docs/CassandraPlan.md
@@ -118,11 +118,12 @@ CREATE TABLE jobflow.company_events (
     year_month     text,        -- partition bucket, e.g. '2026-05'
     event_time     timestamp,
     event_id       text,        -- GitHub's event UUID
-    event_type     text,        -- 'PushEvent' | 'PullRequestReviewCommentEvent' | ...
-    repo_name      text,
+    event_type     text,        -- 'PushEvent' | 'PullRequestEvent' | 'IssuesEvent' | 'ReleaseEvent'
+    repo_name      text,        -- the GitHub 'org/repo' form
+    org_name       text,        -- added by PR2; the Org component of repo_name, denormalised for queryability
     actor_login    text,
-    is_ai          boolean,     -- bot or AI-tool authored
-    tech_tags      set<text>,   -- extracted from commit messages
+    is_ai          boolean,     -- bot or AI-tool authored, per the Ingester's heuristic
+    tech_tags      set<text>,   -- extracted by per-event-type regexes
     PRIMARY KEY ((company, year_month), event_time, event_id)
 ) WITH CLUSTERING ORDER BY (event_time DESC, event_id ASC);
 ```
@@ -131,8 +132,10 @@ CREATE TABLE jobflow.company_events (
 
 - **Composite partition key `(company, year_month)`** bounds partition size. A single active company over a single month is well under the 100 MB / 100k row Cassandra soft limit. Without time-bucketing, a Wix partition grows unbounded and eventually destroys read latency.
 - **`event_id` in the clustering key** prevents silent overwrites when two events share a second-resolution timestamp. This is the most common Cassandra modeling mistake and silently drops 1–5% of rows.
+- **`org_name` as a denormalised column** (added by PR2) lets readers split a Company's activity by Org without re-parsing `repo_name` on every row. Wix's `wix` vs `wix-incubator` events become directly groupable. Cost is ~12 bytes per row; the table doesn't even notice.
 - **`is_ai` as a boolean column** replaces the original counter table. Idempotent: re-ingesting the same event twice produces an UPSERT with identical contents, not a doubled count. Aggregation happens at read time.
 - **`tech_tags` as a set** rather than a join table — leverages C*'s collection type, no JOIN needed.
+- The set of `event_type` values is curated for analytical value (see ADR 0003 and `docs/InjestionPlan.md` §5). The string column itself can hold any future value if the curated set is expanded.
 
 ### 4.3 Table: `processed_files`
 

--- a/docs/adr/0003-backfill-hourly-relay-race.md
+++ b/docs/adr/0003-backfill-hourly-relay-race.md
@@ -1,0 +1,29 @@
+# ADR 0003: Backfill and Hourly Ingest hand off via the per-row `initialized` flag
+
+## Status
+Proposed
+
+## Context
+
+The JobFlow Analytics ingestion pipeline has two operational modes — the Backfill (a nightly catch-everything sweep) and the Hourly Ingest (a frequent low-latency loop processing the newest GH Archive file). Both processes read from the same on-disk archive and write to the same `company_events` Cassandra partition for a given Company. Without a clear ownership rule, the two would race: the Hourly Ingest could write a few hours of recent events for a brand-new (Company, Org) row before the Backfill ever runs, leaving an inconsistent "Cassandra has the last 8 hours but nothing else" state that has to be reconciled.
+
+Three approaches were considered for dividing the work:
+
+1. **Hourly processes everything; Backfill fills gaps.** The Hourly Ingest writes events for every active (Company, Org) row, including brand-new ones. The Backfill later walks the local archive to fill in older events that Hourly never saw. Simplest to think about but creates a per-Company partial-state window of variable length, complicates Backfill (it has to reason about "what's already there?"), and risks gaps if the Backfill never runs for some reason.
+
+2. **A workflow flag on the Company table.** Add an enum like `state ∈ {pending, backfilling, ready}` and have Hourly skip Companies not in `ready`. Workable but conflates "this (Company, Org) row is current" with workflow state that could grow unrelated states later. State machines invite more states.
+
+3. **A per-row `initialized` boolean owned by the Backfill.** The Backfill targets and processes rows where `initialized = false`; on success it flips them to `initialized = true`. The Hourly Ingest only processes rows where `initialized = true`. The two modes are mutually exclusive per (Company, Org) row.
+
+## Decision
+
+Use approach 3. Each `(company, org)` row in the `companies` Cassandra table carries an `initialized boolean` flag (default `false`). The Backfill Run is the only writer that flips the flag to `true`, and it does so only after every event in the local archive for that row has been written to `company_events`. The Hourly Ingest reads `companies` at startup, filters to rows where `initialized = true`, builds its `orgRegex` from just those orgs, and writes events accordingly. The Backfill reads the same table, filters to `initialized = false`, and uses an analogous filter for its own scans.
+
+The two processes are coordinated at the operational level by a `flock`-based cron lock that prevents Hourly from running concurrently with the Backfill — but the per-row filter is the *correctness* guarantee, independent of the lock. Even if the lock were broken, the filter ensures no row is written by both jobs at the same time.
+
+## Consequences
+
+- A new (Company, Org) row added by the Company Scout will be invisible to the Hourly Ingest until the next Backfill Run completes for it. This delay is bounded by the Backfill cadence (nightly) plus the Backfill's runtime. For a freshly added Company on Tuesday morning, events for that Company will appear in `company_events` after the Wednesday-morning Backfill completes — not before. This is an acceptable trade-off for the integrity guarantee.
+- Backfill becomes the single writer of historical state for new rows, so its idempotency and resumability properties (already designed into `processed_files` and the `backfill_progress` table) are the only mechanisms that need to be correct for correctness of the whole pipeline.
+- Adding a new Org to an already-`initialized` Company creates a new row with `initialized = false`. The next Backfill Run picks up just that new row and processes it independently — the already-initialized siblings are untouched. This is the reason the `initialized` flag lives at the (Company, Org) row level rather than at the Company level.
+- The Ingester needs only one piece of state to know which filter to apply: the `--mode` flag (`hourly` or `backfill`). The mode determines both the write strategy and the `initialized` filter direction. This keeps the Ingester's control flow simple — one read of `companies` at startup, one filter, one orgRegex.


### PR DESCRIPTION
## Summary

Captures the design decisions from the PR2 (Ingester) grill before any implementation work starts. Follows the same precursor-PR pattern as #186 did for PR1. No application code — just glossary, an ADR, a small schema migration, and a docs touch.

## Changes

### Glossary (`CONTEXT.md`)
- **Hourly Ingest** — the low-latency counterpart to Backfill. Targets (Company, Org) rows that have already been initialised; takes over a row from Backfill forever after.
- **Tracked Event** — a row in `company_events`. Named carefully to avoid the JobFlow web app's "Activity" (`card_activities`) which is a different concept.

### ADR 0003 — Backfill/Hourly relay-race handoff via `initialized`
Documents the per-row `initialized` flag as the correctness boundary between the two ingestion modes, the two alternatives that were considered and rejected (Hourly-processes-everything; a workflow state machine on `companies`), and the trade-off (a freshly added (Company, Org) row is invisible to Hourly until the next Backfill Run completes for it — accepted in exchange for clean per-row ownership).

### Schema — `org_name` column on `company_events`
- `data-pipeline/schema/008_alter_company_events_org_name.cql` — `ALTER TABLE company_events ADD org_name text`.
- Decision rationale: the existing `repo_name` carries `org/repo` and forces every reader to split on `/` to group by Org. Denormalising costs ~12 bytes per row and makes "Wix activity split by `wix` vs `wix-incubator`" a direct column query.

### Plan doc (`docs/CassandraPlan.md` §4.2)
- Add `org_name` to the schema block with a design-rationale bullet.
- Update the `event_type` comment to list the curated four-type filter (`PushEvent`, `PullRequestEvent`, `IssuesEvent`, `ReleaseEvent`) — the grill expanded the original two-type filter for analytical value.
- Update the `tech_tags` comment to reflect that the regex sources differ per event type (commits[].message for Push; PR title+body; issue title+body+labels; release name+body+tag_name).

## Out of scope

- The Ingester implementation itself (lands in PR2 on a child branch).
- The `disk-layout` shared-lib extraction (also PR2 — depends on #189 first).
- Cron/flock coordination, runner shell scripts, SSD scratch (PR3).

## Test plan

- [ ] CONTEXT.md renders correctly on GitHub
- [ ] ADR 0003 renders correctly on GitHub
- [ ] No code or runtime behaviour changes
- [ ] `008_alter_company_events_org_name.cql` parses without error in `cqlsh` (deferred verification — table doesn't have data yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)