### PR TITLE
[Cassandra pipeline PR1.3] Fetcher: --catchup mode

### DIFF
--- a/data-pipeline/fetcher/fetcher.js
+++ b/data-pipeline/fetcher/fetcher.js
@@ -1,7 +1,7 @@
 import pino from 'pino';
 import pLimit from 'p-limit';
 import { parseCLI } from './lib/cli.js';
-import { cleanPartials, enumerateRange } from './lib/disk-layout.js';
+import { cleanPartials, enumerateRange, latestOnDisk } from './lib/disk-layout.js';
 import { downloadHour } from './lib/download.js';
 
 const ROOT = process.env.GHARCHIVE_DIR ?? './data/gharchive';
@@ -19,6 +19,11 @@ async function main() {
 
   logger.info({ root: ROOT }, 'cleaning partial files');
   cleanPartials(ROOT);
+
+  if (cmd.mode === 'catchup') {
+    await runCatchup(ROOT, logger);
+    return;
+  }
 
   const hours =
     cmd.mode === 'hour'
@@ -56,6 +61,77 @@ async function main() {
     {}
   );
   logger.info(tally, 'done');
+}
+
+async function runCatchup(root, log) {
+  const anchor = latestOnDisk(root);
+  if (!anchor) {
+    log.error('no anchor to walk from — run --hour or --range first to seed the directory');
+    process.exit(1);
+  }
+
+  const ceilingMs = Date.now() - 2 * 3_600_000;
+  const anchorMs = _hourIdToMs(anchor);
+
+  const candidates = [];
+  for (let t = anchorMs + 3_600_000; t <= ceilingMs; t += 3_600_000) {
+    candidates.push(_msToHourId(t));
+  }
+
+  if (candidates.length === 0) {
+    log.info({ anchor }, 'already up to date');
+    return;
+  }
+
+  log.info({ count: candidates.length, from: candidates[0], to: candidates[candidates.length - 1] }, 'starting catchup walk');
+
+  const limit = pLimit(3);
+  let found404 = false;
+
+  // All candidates are enqueued; p-limit starts up to 3 concurrently.
+  // The found404 flag prevents new HTTP requests from being issued after the first 404;
+  // any already-in-flight requests are awaited but their results don't extend the walk.
+  const promises = candidates.map((hourId) =>
+    limit(async () => {
+      if (found404) return { status: 'skipped-catchup-abort', hourId };
+      const result = await downloadHour(root, hourId);
+      if (result.status === 'not-found') {
+        found404 = true;
+        log.warn({ hourId }, 'first 404 — halting catchup walk');
+      } else if (result.status === 'written') {
+        log.info({ hourId }, 'written');
+      } else if (result.status === 'failed-after-retries') {
+        log.error({ hourId, error: result.error }, 'failed after retries');
+      }
+      return result;
+    })
+  );
+
+  const settled = await Promise.allSettled(promises);
+  const results = settled.map((s) =>
+    s.status === 'fulfilled'
+      ? s.value
+      : { status: 'failed-after-retries', error: s.reason?.message }
+  );
+  const tally = results.reduce(
+    (acc, r) => { acc[r.status] = (acc[r.status] ?? 0) + 1; return acc; },
+    {}
+  );
+  log.info(tally, 'catchup done');
+}
+
+function _hourIdToMs(hourId) {
+  const [y, m, d, h] = hourId.split('-').map(Number);
+  return Date.UTC(y, m - 1, d, h);
+}
+
+function _msToHourId(ms) {
+  const d = new Date(ms);
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const hour = d.getUTCHours();
+  return `${year}-${month}-${day}-${hour}`;
 }
 
 main().catch((err) => {

--- a/data-pipeline/fetcher/fetcher.js
+++ b/data-pipeline/fetcher/fetcher.js
@@ -1,7 +1,7 @@
 import pino from 'pino';
 import pLimit from 'p-limit';
 import { parseCLI } from './lib/cli.js';
-import { cleanPartials, enumerateRange, latestOnDisk } from './lib/disk-layout.js';
+import { cleanPartials, enumerateRange, hourIdToMs, latestOnDisk, msToHourId } from './lib/disk-layout.js';
 import { downloadHour } from './lib/download.js';
 
 const ROOT = process.env.GHARCHIVE_DIR ?? './data/gharchive';
@@ -66,16 +66,17 @@ async function main() {
 async function runCatchup(root, log) {
   const anchor = latestOnDisk(root);
   if (!anchor) {
-    log.error('no anchor to walk from — run --hour or --range first to seed the directory');
-    process.exit(1);
+    // Throw so the main().catch handler exits consistently with other fatal errors
+    // and pino's transport gets a chance to flush before exit.
+    throw new Error('no anchor to walk from — run --hour or --range first to seed the directory');
   }
 
   const ceilingMs = Date.now() - 2 * 3_600_000;
-  const anchorMs = _hourIdToMs(anchor);
+  const anchorMs = hourIdToMs(anchor);
 
   const candidates = [];
   for (let t = anchorMs + 3_600_000; t <= ceilingMs; t += 3_600_000) {
-    candidates.push(_msToHourId(t));
+    candidates.push(msToHourId(t));
   }
 
   if (candidates.length === 0) {
@@ -118,20 +119,6 @@ async function runCatchup(root, log) {
     {}
   );
   log.info(tally, 'catchup done');
-}
-
-function _hourIdToMs(hourId) {
-  const [y, m, d, h] = hourId.split('-').map(Number);
-  return Date.UTC(y, m - 1, d, h);
-}
-
-function _msToHourId(ms) {
-  const d = new Date(ms);
-  const year = d.getUTCFullYear();
-  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
-  const day = String(d.getUTCDate()).padStart(2, '0');
-  const hour = d.getUTCHours();
-  return `${year}-${month}-${day}-${hour}`;
 }
 
 main().catch((err) => {

--- a/data-pipeline/fetcher/lib/cli.js
+++ b/data-pipeline/fetcher/lib/cli.js
@@ -27,7 +27,14 @@ export function parseCLI(argv) {
     return { mode: 'range', start, end };
   }
 
-  die('usage: fetcher.js --hour <YYYY-MM-DD-H> | --range <YYYY-MM-DD> <YYYY-MM-DD>');
+  if (args[0] === '--catchup') {
+    if (args.length > 1) {
+      die('--catchup takes no arguments');
+    }
+    return { mode: 'catchup' };
+  }
+
+  die('usage: fetcher.js --hour <YYYY-MM-DD-H> | --range <YYYY-MM-DD> <YYYY-MM-DD> | --catchup');
 }
 
 function die(msg) {

--- a/data-pipeline/fetcher/lib/disk-layout.js
+++ b/data-pipeline/fetcher/lib/disk-layout.js
@@ -36,6 +36,36 @@ export function enumerateRange(startDate, endDate) {
   return hours;
 }
 
+// Returns the most recent hour ID (YYYY-MM-DD-H) found under rootDir, or null if empty.
+export function latestOnDisk(rootDir) {
+  const ids = [];
+  _collectHourIds(rootDir, rootDir, ids);
+  if (ids.length === 0) return null;
+  return ids.reduce((best, cur) => _hourIdToMs(cur) > _hourIdToMs(best) ? cur : best);
+}
+
+function _collectHourIds(root, dir, ids) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      _collectHourIds(root, full, ids);
+    } else if (entry.name.endsWith('.json.gz')) {
+      ids.push(pathToHourId(root, full));
+    }
+  }
+}
+
+function _hourIdToMs(hourId) {
+  const [y, m, d, h] = hourId.split('-').map(Number);
+  return Date.UTC(y, m - 1, d, h);
+}
+
 // Recursively removes every *.partial file under root. Silently skips missing directories.
 export function cleanPartials(root) {
   _sweepDir(root);

--- a/data-pipeline/fetcher/lib/disk-layout.js
+++ b/data-pipeline/fetcher/lib/disk-layout.js
@@ -41,7 +41,7 @@ export function latestOnDisk(rootDir) {
   const ids = [];
   _collectHourIds(rootDir, rootDir, ids);
   if (ids.length === 0) return null;
-  return ids.reduce((best, cur) => _hourIdToMs(cur) > _hourIdToMs(best) ? cur : best);
+  return ids.reduce((best, cur) => hourIdToMs(cur) > hourIdToMs(best) ? cur : best);
 }
 
 function _collectHourIds(root, dir, ids) {
@@ -56,14 +56,31 @@ function _collectHourIds(root, dir, ids) {
     if (entry.isDirectory()) {
       _collectHourIds(root, full, ids);
     } else if (entry.name.endsWith('.json.gz')) {
+      // Only accept files at the canonical depth root/YYYY/MM/DD/H.json.gz.
+      // Stray .json.gz files at other depths would otherwise yield malformed
+      // hour IDs (e.g. undefined-undefined-undefined-NaN) and silently poison
+      // the anchor selection.
+      const rel = path.relative(root, full).split(path.sep);
+      if (rel.length !== 4) continue;
       ids.push(pathToHourId(root, full));
     }
   }
 }
 
-function _hourIdToMs(hourId) {
+// Parses a canonical hour ID (YYYY-MM-DD-H) into a UTC ms timestamp.
+export function hourIdToMs(hourId) {
   const [y, m, d, h] = hourId.split('-').map(Number);
   return Date.UTC(y, m - 1, d, h);
+}
+
+// Formats a UTC ms timestamp as a canonical hour ID (YYYY-MM-DD-H, hour unpadded).
+export function msToHourId(ms) {
+  const d = new Date(ms);
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  const hour = d.getUTCHours();
+  return `${year}-${month}-${day}-${hour}`;
 }
 
 // Recursively removes every *.partial file under root. Silently skips missing directories.


### PR DESCRIPTION
## Summary
- Adds `latestOnDisk(rootDir)` to `disk-layout.js` — recursively scans the archive root and returns the most recent hour ID, or `null` if empty
- Adds `--catchup` as a valid CLI mode (bare flag, no extra args)
- `runCatchup` walks from `latestOnDisk + 1h` toward `now − 2h` in 1-hour steps with `p-limit(3)` concurrency; cold-start (null anchor) exits 1 with a clear message; first HTTP 404 sets a shared flag that prevents queued tasks from issuing further HTTP requests while in-flight requests are awaited

## Acceptance criteria
- [x] Disk-layout module gains a `latestOnDisk(rootDir)` function that returns the most recent hour ID found under the root, or `null` if the root is empty
- [x] CLI module recognises bare `--catchup` (no extra arguments) as a valid mode
- [x] `fetcher.js` dispatches `--catchup` to a walk that starts at `latestOnDisk + 1 hour` and steps forward in 1-hour increments toward `now − 2h` (UTC)
- [x] Cold start: when `latestOnDisk` returns `null`, log a single clear "no anchor to walk from" message and exit non-zero without making any network requests
- [x] First HTTP 404 encountered during the walk halts the walk immediately; no further requests are issued for any later hour
- [x] Concurrency is still bounded by `p-limit(3)` — but the first-404 short-circuit works correctly even when several requests are in flight (in-flight requests for hours past the 404 are awaited but their results do not cause additional walks)
- [x] All existing behaviours from #189 (atomic writes, `.partial` cleanup, retries, idempotency, logging, env config) continue to apply
- [x] Manual smoke test passes: `--catchup` against an empty directory exits 1 with the cold-start message; walk candidate logic verified with seeded temp directories

## Related
Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)