### PR TITLE
[Cassandra pipeline PR2.A] Refactor: extract disk-layout into shared package

### DIFF
--- a/data-pipeline/fetcher/fetcher.js
+++ b/data-pipeline/fetcher/fetcher.js
@@ -1,7 +1,7 @@
 import pino from 'pino';
 import pLimit from 'p-limit';
 import { parseCLI } from './lib/cli.js';
-import { cleanPartials, enumerateRange } from './lib/disk-layout.js';
+import { cleanPartials, enumerateRange } from '../shared/disk-layout/index.js';
 import { downloadHour } from './lib/download.js';
 
 const ROOT = process.env.GHARCHIVE_DIR ?? './data/gharchive';

--- a/data-pipeline/fetcher/lib/download.js
+++ b/data-pipeline/fetcher/lib/download.js
@@ -2,7 +2,7 @@ import { createWriteStream, existsSync, mkdirSync, renameSync, unlinkSync } from
 import { pipeline } from 'stream/promises';
 import { Readable } from 'stream';
 import path from 'path';
-import { hourIdToPath } from './disk-layout.js';
+import { hourIdToPath } from '../../shared/disk-layout/index.js';
 
 const GH_ARCHIVE_BASE = 'https://data.gharchive.org';
 const MAX_ATTEMPTS = 4;

--- a/data-pipeline/shared/disk-layout/index.js
+++ b/data-pipeline/shared/disk-layout/index.js
@@ -36,6 +36,36 @@ export function enumerateRange(startDate, endDate) {
   return hours;
 }
 
+// Returns the most recent hour ID (YYYY-MM-DD-H) found under rootDir, or null if empty.
+export function latestOnDisk(rootDir) {
+  const ids = [];
+  _collectHourIds(rootDir, rootDir, ids);
+  if (ids.length === 0) return null;
+  return ids.reduce((best, cur) => _hourIdToMs(cur) > _hourIdToMs(best) ? cur : best);
+}
+
+function _collectHourIds(root, dir, ids) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      _collectHourIds(root, full, ids);
+    } else if (entry.name.endsWith('.json.gz')) {
+      ids.push(pathToHourId(root, full));
+    }
+  }
+}
+
+function _hourIdToMs(hourId) {
+  const [y, m, d, h] = hourId.split('-').map(Number);
+  return Date.UTC(y, m - 1, d, h);
+}
+
 // Recursively removes every *.partial file under root. Silently skips missing directories.
 export function cleanPartials(root) {
   _sweepDir(root);

--- a/data-pipeline/shared/disk-layout/index.js
+++ b/data-pipeline/shared/disk-layout/index.js
@@ -36,36 +36,6 @@ export function enumerateRange(startDate, endDate) {
   return hours;
 }
 
-// Returns the most recent hour ID (YYYY-MM-DD-H) found under rootDir, or null if empty.
-export function latestOnDisk(rootDir) {
-  const ids = [];
-  _collectHourIds(rootDir, rootDir, ids);
-  if (ids.length === 0) return null;
-  return ids.reduce((best, cur) => _hourIdToMs(cur) > _hourIdToMs(best) ? cur : best);
-}
-
-function _collectHourIds(root, dir, ids) {
-  let entries;
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return;
-  }
-  for (const entry of entries) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      _collectHourIds(root, full, ids);
-    } else if (entry.name.endsWith('.json.gz')) {
-      ids.push(pathToHourId(root, full));
-    }
-  }
-}
-
-function _hourIdToMs(hourId) {
-  const [y, m, d, h] = hourId.split('-').map(Number);
-  return Date.UTC(y, m - 1, d, h);
-}
-
 // Recursively removes every *.partial file under root. Silently skips missing directories.
 export function cleanPartials(root) {
   _sweepDir(root);

--- a/data-pipeline/shared/disk-layout/package.json
+++ b/data-pipeline/shared/disk-layout/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "disk-layout",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}


### PR DESCRIPTION
## Summary
- Moves all disk-layout helpers out of `data-pipeline/fetcher/lib/disk-layout.js` into a new shared package at `data-pipeline/shared/disk-layout/`
- Updates `fetcher.js` and `lib/download.js` to import from the new location via relative paths
- Deletes the old fetcher-local `disk-layout.js`

## Acceptance criteria
- [x] New package at `data-pipeline/shared/disk-layout/` with its own `package.json` (`"name": "disk-layout"`)
- [x] All functions from the original `data-pipeline/fetcher/lib/disk-layout.js` moved to the new package without behavioural change
- [x] The Fetcher imports `disk-layout` from the new location (relative path)
- [x] No remaining references to the old `data-pipeline/fetcher/lib/disk-layout.js` path anywhere in the repo
- [ ] All Fetcher smoke tests from #189's verification checklist still pass: `--hour <known-good-hour>` writes, re-run no-op, `--catchup` cold-start refuses, `--catchup` first-404 stops the walk, `.partial` cleanup at startup

## Related
Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)