### PR TITLE
chore: isolate integration tests with a Postgres service container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,21 @@ jobs:
       run:
         working-directory: backend
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: jobflow_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 
@@ -60,7 +75,7 @@ jobs:
       - name: Run integration tests
         run: npm run test:integration
         env:
-          INTEGRATION_DATABASE_URL: ${{ secrets.INTEGRATION_DATABASE_URL }}
+          INTEGRATION_DATABASE_URL: postgres://postgres:postgres@localhost:5432/jobflow_test
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
 
   frontend-build:


### PR DESCRIPTION
## Summary
- Replace the shared Neon \`INTEGRATION_DATABASE_URL\` with an ephemeral \`postgres:16\` service container, scoped per CI job
- Eliminates the cross-job database collision that caused intermittent FK-on-\`user_id\` failures in \`positions.integration.test.ts\` (seen in run [26330325174](https://github.com/tomerp20/jobflow/actions/runs/26330325174/job/77515266618))
- Each integration run now gets its own isolated database

## Changes
- \`.github/workflows/ci.yml\`: add \`services.postgres\` (postgres:16) to the \`backend-integration\` job with a \`pg_isready\` health check; point \`INTEGRATION_DATABASE_URL\` at \`postgres://postgres:postgres@localhost:5432/jobflow_test\`. \`JWT_SECRET\` still comes from repo secrets.
- The existing \`tests/integration/globalSetup.ts\` already runs \`knex migrate:latest\` against whatever URL is provided, so no test-side changes are needed.

## Why this fixes the flake
The integration job previously used a single shared Neon database for every CI run across every branch. When two runs overlapped, one job's \`afterAll → truncateAll()\` would wipe the \`users\` rows another job's \`beforeAll\` had just inserted, producing the FK-violation pattern in \`positions.integration.test.ts\` where the earlier describe blocks pass and the later ones fail.

A service container is fully isolated per job — no two runs can collide.

## Test plan
- [ ] CI on this PR runs the \`Backend Integration Tests\` job green against the new service container
- [ ] Confirm the job adds only ~10–15s of overhead (container boot + health check)
- [ ] Confirm migrations still run via \`globalSetup.ts\` (\`Already up to date\` or equivalent appears in the log)
- [ ] No reference to the old \`INTEGRATION_DATABASE_URL\` secret remains in the CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)