### PR TITLE
chore: recover stranded Cassandra schema migrations 005-007

### DIFF
--- a/data-pipeline/schema/005_alter_companies_initialized.cql
+++ b/data-pipeline/schema/005_alter_companies_initialized.cql
@@ -1,0 +1,2 @@
+ALTER TABLE jobflow.companies ADD initialized boolean;
+ALTER TABLE jobflow.companies ADD initialized_at timestamp;

--- a/data-pipeline/schema/006_backfill_runs.cql
+++ b/data-pipeline/schema/006_backfill_runs.cql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS jobflow.backfill_runs (
+    bucket          text,
+    run_id          timeuuid,
+    started_at      timestamp,
+    completed_at    timestamp,
+    status          text,
+    target_rows     set<frozen<tuple<text, text>>>,
+    PRIMARY KEY ((bucket), run_id)
+) WITH CLUSTERING ORDER BY (run_id DESC);

--- a/data-pipeline/schema/007_backfill_progress.cql
+++ b/data-pipeline/schema/007_backfill_progress.cql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS jobflow.backfill_progress (
+    run_id          timeuuid,
+    date            date,
+    status          text,
+    started_at      timestamp,
+    completed_at    timestamp,
+    events_written  bigint,
+    PRIMARY KEY ((run_id), date)
+) WITH CLUSTERING ORDER BY (date ASC);


### PR DESCRIPTION
## Summary

Recovers three Cassandra schema migrations that were merged via PR #191 into the parent `feature/cassandra-data-pipeline` branch **after** that parent was already merged to main (in PR #186). The result: the schema commit `7764f06` is stranded on `feature/cassandra-data-pipeline` and never reached `main`. This PR re-lands those three files on `main` directly.

## Why

Without these three migrations on `main`, the Backfill orchestrator (PR3) and the Ingester's backfill mode (issues #197 / #198) have no tables to read or write — the `companies.initialized` lifecycle flag and the `backfill_runs` / `backfill_progress` state tables don't exist anywhere on the deployable branch.

## Changes

Three new schema files under `data-pipeline/schema/`:

- `005_alter_companies_initialized.cql` — `ALTER TABLE companies ADD initialized boolean, initialized_at timestamp`
- `006_backfill_runs.cql` — new table for Backfill Run metadata (singleton-bucket partition for the "latest run" lookup, per `docs/InjestionPlan.md` §3.2)
- `007_backfill_progress.cql` — new table tracking per-date completion within a Run

The files are cherry-picked verbatim from commit `7764f06` on `feature/cassandra-data-pipeline`. No content changes.

## Test plan

- [ ] `cqlsh -f` applies all eight schemas (001–008) cleanly against a fresh `cassandra:4.1` container started from `docker-compose.yml`
- [ ] `cqlsh -e "DESCRIBE KEYSPACE jobflow"` shows the two new columns on `companies` plus the two new tables (`backfill_runs`, `backfill_progress`) with the expected primary keys and clustering orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)