### PR TITLE
docs: PR3 backfill orchestrator grill outcomes (ADRs + plan amendments)

### DIFF
--- a/docs/CassandraPlan.md
+++ b/docs/CassandraPlan.md
@@ -152,7 +152,9 @@ CREATE TABLE jobflow.processed_files (
 
 The `file_name` column stores the canonical hour ID `YYYY-MM-DD-H` (hour unpadded — `2025-05-01-15`, not `15.json.gz` or a full filesystem path). This matches GH Archive's URL convention and decouples the table from the on-disk layout. `event_count` is the total number of events parsed from the file; `filtered_count` is the subset that survived company-filtering and was written to `company_events`. Row existence implies successful processing — there is no status column.
 
-The ingestion script checks this table before processing each file. Re-running the pipeline on already-processed files becomes a no-op. Without this, re-runs during development produce duplicate rows in `company_events` (harmless thanks to the schema, but pollutes counts and wastes time).
+**Read and written only by the Hourly Ingest.** The Backfill never touches this table — it uses `backfill_progress` (per-date) for crash recovery instead. See ADR 0005 for the design rationale; the per-file marker keyed only by file_name caused data loss when a Company was added between Backfill Runs, because the file appeared "done" globally even though no events for the new Company had been written.
+
+The Hourly Ingest checks this table before processing each file. Re-running the Hourly Ingest on already-processed files is a no-op. Without this, re-runs during development would produce duplicate rows in `company_events` (harmless thanks to the upsert schema, but pollutes counts and wastes time).
 
 ### 4.4 Table: `companies`
 

--- a/docs/InjestionPlan.md
+++ b/docs/InjestionPlan.md
@@ -135,9 +135,11 @@ CREATE TABLE jobflow.backfill_progress (
 
 **Companies added mid-backfill wait for the next night's run.** The current run's `target_rows` is locked at row insert in step 3 and never changes for the lifetime of that run.
 
-### 3.3 `processed_files` — already in main RFC
+### 3.3 `processed_files` — already in main RFC, hourly-only
 
-No schema changes in PR1. The `file_name` column stores the canonical hour ID `YYYY-MM-DD-H` (hour unpadded — `2025-05-01-15`), matching GH Archive's URL convention. See main RFC §4.3 for full semantics. The hourly path uses this to skip already-ingested files.
+No schema changes in PR1. The `file_name` column stores the canonical hour ID `YYYY-MM-DD-H` (hour unpadded — `2025-05-01-15`), matching GH Archive's URL convention. See main RFC §4.3 for full semantics.
+
+**Only the Hourly Ingest reads or writes this table.** Backfill mode never touches `processed_files` — it uses `backfill_progress` (per-date) for crash recovery instead. See ADR 0005 for the design rationale; the short version is that a per-file "done" marker keyed only by file_name causes data loss for Companies added between Backfill Runs.
 
 ---
 
@@ -202,18 +204,21 @@ All modes use `p-limit(3)` for download concurrency. v1 needs nothing more — t
 ## 5. Ingester
 
 ### 5.1 Responsibilities
-- Read one `.json.gz` file from disk.
-- Filter events by company against the in-memory company-org map.
+- Read one or more `.json.gz` files from disk (range determined by CLI args).
+- Filter events by company against the in-memory company-org map **built from the `--target-companies` CLI argument** (per ADR 0004, the Ingester is companies-agnostic; it never reads the `companies` Cassandra table).
 - Extract tech tags and AI signal.
 - Write to `company_events`.
-- Mark the file as processed in `processed_files`.
+- In `--mode hourly`: mark each file as processed in `processed_files`.
+- In `--mode backfill`: write a `backfill_progress` row per completed date (using the `--run-id` arg); do not touch `processed_files`.
+
+The Ingester is a pure stateless worker. All per-job parameters arrive as CLI args; service-level configuration arrives as env vars. See ADR 0004 for the discipline; see ADR 0005 for why `processed_files` is hourly-only.
 
 ### 5.2 The fast filter (load-bearing optimization)
 
 For each line in the file, **before parsing JSON**, run a substring check for any tracked org name. If no match, skip immediately. Only parse JSON for lines that pass the fast filter.
 
 ```javascript
-// Build at startup from the companies table:
+// Build at startup from the --target-companies CLI argument:
 //   "wix/" | "honeybook/" | "upwind/" | ...
 // The "/" suffix anchors to repo.name's "org/repo" format,
 // reducing false positives from arbitrary text matching org names.
@@ -261,18 +266,27 @@ Cassandra batches are tricky — only batch rows in the same partition (`(compan
 ### 5.5 Modes
 
 ```bash
-node ingester.js --file /mnt/hdd/gharchive/2026/05/22/15.json.gz
-node ingester.js --range 2026-05-01 2026-05-22 --mode backfill
-node ingester.js --catchup --mode hourly
+node ingester.js --hour 2026-05-22-15 --mode hourly \
+  --target-companies wix:wix,microsoft:azure
+node ingester.js --range 2026-05-01 2026-05-22 --mode backfill \
+  --target-companies wix:wix,microsoft:azure \
+  --run-id <timeuuid>
+node ingester.js --catchup --mode hourly \
+  --target-companies wix:wix,microsoft:azure
 ```
 
-`--mode` switches the write strategy (individual vs batched) and the company filter (initialized=true vs initialized=false).
+`--mode` switches the write strategy (individual prepared inserts via p-limit(50) for hourly; UNLOGGED per-partition batches for backfill) and toggles the per-mode side effects:
+- `--mode hourly` reads and writes `processed_files`; does not touch `backfill_progress` or `backfill_runs`.
+- `--mode backfill` writes `backfill_progress` rows per completed date (requires `--run-id`); never touches `processed_files`.
+
+`--target-companies` is required in both modes and is the sole source of truth for the in-memory company-org filter. The Orchestrator (PR3) is responsible for reading `companies` from Cassandra and passing the appropriate filtered list. See ADR 0004 for the args-vs-env-vars contract.
 
 ### 5.6 Idempotency
 
-Re-ingesting the same file is safe:
+Re-ingesting the same file is safe in both modes:
 - `company_events` upserts on the full primary key — re-writes produce identical rows.
-- `processed_files` row already exists → ingester logs "already processed, skipping" and exits.
+- `--mode hourly`: `processed_files` row already exists → Ingester logs "already processed, skipping" and exits.
+- `--mode backfill`: the Ingester walks dates from the `--range` start. On startup, the Backfill Orchestrator has already adjusted `--range` to begin at the first non-completed date from `backfill_progress`, so the Ingester re-processes at most one in-progress date's files from scratch. Crash recovery cost: ~30 min to 2 hours of re-reads per crash; the writes are idempotent.
 
 ### 5.7 SSD scratch optimization (backfill only)
 

--- a/docs/adr/0004-microservices-shaped-cli-contract.md
+++ b/docs/adr/0004-microservices-shaped-cli-contract.md
@@ -1,0 +1,44 @@
+# ADR 0004: Microservices-shaped CLI contract — per-job parameters as args, service-level config as env vars
+
+## Status
+Proposed
+
+## Context
+
+The JobFlow Analytics ingestion pipeline ships as three Node packages (Fetcher, Ingester, Backfill orchestrator) that talk to each other via OS subprocess spawns and a shared Cassandra database. This is a deliberately conservative deployment shape for a single-machine learning project: no message queue, no service discovery, no container orchestration.
+
+There is, however, a stated intention to one day migrate the pipeline to a microservices architecture — separate deployable services communicating via message queues, with independently scalable workers consuming jobs from a fan-out broker. Today's subprocess invocations would become "publish job to queue" calls; today's exit-code waiting would become "subscribe to job-completed events"; today's local file paths would become object storage references.
+
+For the microservices migration to be cheap, the contract between the orchestrator (publisher of jobs) and the Ingester (consumer of jobs) needs to look queue-shaped today. Specifically, the data that travels with one job invocation should map cleanly to a message body: a small, well-typed JSON object containing exactly the parameters that vary per job (date range, mode, target rows, etc.) — and nothing more.
+
+Two alternatives were considered for how the Ingester receives its per-invocation parameters:
+
+1. **CLI arguments only.** Per-job parameters arrive as `--hour`, `--range`, `--mode`, etc. Env vars are reserved for service-level config (Cassandra contact points, the local data center name, the on-disk archive root, the log level, the worker count default). The Ingester treats env vars as "things that would be a pod's env in Kubernetes" — i.e. unchanging across all jobs the pod processes.
+
+2. **Mixed args and env vars.** Per-job parameters can arrive either way. For example, `INGEST_MODE=backfill` env var with `--range A B` args; or `--mode backfill` and `INGEST_TARGET_ROWS` env var. Whatever is convenient for the immediate caller.
+
+## Decision
+
+The Ingester (and any future per-job worker in this subsystem) accepts **per-job parameters strictly as CLI arguments**. Environment variables are reserved for **service-level configuration** that does not change across job invocations. The two categories are mutually exclusive: nothing that varies per job is ever read from an env var, and nothing that is service-level config is ever passed as a CLI argument.
+
+Per-job parameters (CLI args only):
+- The work unit identifier: `--hour`, `--range`, `--catchup`
+- The mode dispatch: `--mode hourly | backfill`
+- The locked target set, if/when introduced: `--target-rows` (or equivalent)
+- Any per-invocation overrides of concurrency: `--hourly-write-concurrency`
+
+Service-level config (env vars only):
+- `CASSANDRA_CONTACT_POINTS`, `CASSANDRA_LOCAL_DC`, `CASSANDRA_KEYSPACE`
+- `GHARCHIVE_DIR`
+- `LOG_LEVEL`
+- `INGEST_WORKERS` (default — overridable per invocation only if a strong reason emerges)
+
+The Orchestrator (Backfill) follows the same discipline when constructing the Ingester's argv: it assembles a JSON-shaped argument object first (`{mode, range, targetRows}`), then translates that object to argv just before the `spawn()` call. The argument object is the message body of a future queue publish.
+
+## Consequences
+
+- The future migration from subprocess to message queue is local to one file in the Orchestrator (the `spawn()` call) and one file in the Ingester (`lib/cli.js`, which becomes a queue consumer's job decoder). The rest of both packages — companies-loader, worker pool, Cassandra writer, tag/AI extractors — does not change.
+- New per-job parameters always go in as args. Reviewers should reject PRs that introduce per-job env vars.
+- New service-level config always goes in as env vars. Reviewers should reject PRs that introduce CLI args for things like Cassandra contact points or the archive root.
+- The discipline imposes a small mental overhead at every PR ("is this thing per-job or per-service?") that is the price of the migration optionality. Without it, the migration becomes a per-parameter audit of every entrypoint.
+- This ADR does not commit to building a microservices abstraction layer now. There is no `JobInvoker` interface, no proto definition, no message envelope schema. Those investments happen if and only if the migration actually starts. This ADR is a behavioural discipline, not a structural one.

--- a/docs/adr/0005-processed-files-hourly-only.md
+++ b/docs/adr/0005-processed-files-hourly-only.md
@@ -1,0 +1,43 @@
+# ADR 0005: `processed_files` is hourly-only; Backfill uses `backfill_progress` instead
+
+## Status
+Proposed
+
+## Context
+
+The `processed_files` Cassandra table records "this GH Archive hour file has been ingested." Both the Backfill and the Hourly Ingest were originally specified (`docs/InjestionPlan.md` §5.6) to read and write this table for crash recovery and re-run idempotency.
+
+This design caused a subtle but serious correctness problem when a new Company is added to the system after a Backfill Run has begun walking the archive. The PR3 grill walked through the scenario in detail; the short version is:
+
+1. A Backfill Run starts at midnight targeting Company X. Walks the archive day by day. Each file it processes gets a row in `processed_files`.
+2. At 02:30, the Company Scout adds Company Y (with `initialized = false`).
+3. The Backfill Run continues, filtering only for Company X's Org per the locked `target_companies` set. Each file is added to `processed_files` as "done."
+4. The Backfill Run completes at 06:00. Company X is flipped to `initialized = true`. Company Y is still `initialized = false`.
+5. The next night's Backfill Run targets Company Y. It walks the archive. But every file is already in `processed_files`. The Ingester skips them all. **Company Y's historical events from before 06:00 are never written to Cassandra.**
+
+The data loss happens because `processed_files` keys on file name alone. The notebook entry says "file is done" without saying "done for which set of companies." Three approaches were considered to fix this:
+
+1. **Per-(file, target-set) keying on `processed_files`.** Each combination of file + set of target companies gets its own row. The "done" check becomes "done for the current target set?" instead of "done globally?" Correct but expensive — 24 × dates × runs rows and a hash-comparison on every check.
+
+2. **Truncate `processed_files` between runs.** Simpler but breaks the Hourly Ingest, which relies on `processed_files` across multiple invocations to know which hourly files it has already processed.
+
+3. **Stop using `processed_files` for the Backfill entirely.** Backfill uses `backfill_progress` (per-date completion) for crash recovery — the granularity is the date, not the file. Inside a single Ingester invocation walking a date, all 24 hourly files are processed sequentially in one process; crash recovery just restarts the in-progress date from scratch (re-reading 24 files; their writes to `company_events` are idempotent upserts).
+
+## Decision
+
+Use approach 3. `processed_files` is **only** read or written by the Ingester when it is running in `--mode hourly`. In `--mode backfill`, the Ingester does not touch `processed_files`. Backfill crash recovery is handled by `backfill_progress`:
+
+- The Backfill Orchestrator queries `backfill_progress` on startup to find the max date marked `completed` for the active Run.
+- It then spawns the Ingester with `--range <next-day> <yesterday>` to resume.
+- The Ingester walks dates internally; for each date, it writes a `backfill_progress` row (`status = 'completed', completed_at = now(), events_written = N`) once all 24 hourly files for that date have been processed and their events written to `company_events`.
+- A crash mid-date means that date's `backfill_progress` row remains `in_progress` (or absent); on restart, the date is reprocessed from hour 0. The ~24 files re-ingested cost CPU and disk reads but produce no duplicate rows in `company_events` (full-key upserts).
+
+The Hourly Ingest mode keeps using `processed_files` exactly as before: read at startup to know which files in `GHARCHIVE_DIR` are already done; write a row on each successful file completion. The semantics are unchanged from the original specification.
+
+## Consequences
+
+- **Data-loss scenario eliminated.** A new Company added mid-Backfill or between Backfill Runs will be picked up by the next Backfill Run and walked through the full local archive without interference from earlier runs' `processed_files` entries. The next Backfill writes events for the new Company; the earlier Backfill's writes for already-initialised Companies are upserts and produce no duplicates.
+- **Each Backfill Run re-reads the full local archive for its target_companies.** This is wasteful CPU + disk for already-initialised Companies whose events are already in `company_events`. Bounded by the number of Backfill Runs ever (one per night when there's pending work, none otherwise) and the size of the local archive (~470 GB compressed per year). Acceptable for a learning project; documented as a known cost.
+- **Backfill crash recovery has coarser granularity.** A crash mid-date forces re-reading 24 hourly files for that date on resume, vs. the prior design's per-file resume. Worst-case wasted work per crash: 30 minutes to 2 hours. Crashes are rare; this is accepted.
+- **No schema change.** `processed_files` keeps its existing primary key `(file_name)`. `backfill_progress` keeps its existing shape from PR1's schema migrations (005–007).
+- **The Ingester's behaviour now branches on `--mode`** for `processed_files` reads and writes. This branching is documented in `docs/InjestionPlan.md` §5.6 and in the PR2 issue bodies.


### PR DESCRIPTION
## Summary

Captures the design decisions from the PR3 (Backfill Orchestrator) grill before any implementation work starts. Follows the same precursor-PR pattern as #186 and #193. No application code — two new ADRs plus amendments to the plan docs that revise the Ingester's contract.

## Why two ADRs

The grill surfaced two decisions that pass the ADR bar (hard to reverse, surprising without context, real trade-off):

1. **ADR 0004 — Microservices-shaped CLI contract.** Per-job parameters always arrive as CLI args; service-level configuration always arrives as env vars. The two categories are mutually exclusive. Future migration from subprocess-spawn to message-queue publish becomes a one-file change in the Orchestrator rather than a per-parameter audit.

2. **ADR 0005 — `processed_files` is hourly-only.** Backfill never reads or writes the table; uses `backfill_progress` (per-date) for crash recovery instead. Fixes a data-loss scenario where a Company added between Backfill Runs had its earlier-date events skipped because files were globally marked "done" without recording which target Companies they were done for. Trade-off: each Backfill Run re-reads the full local archive for its target set (wasteful CPU + disk but idempotent upserts on `company_events`).

## Changes

### New ADRs
- `docs/adr/0004-microservices-shaped-cli-contract.md`
- `docs/adr/0005-processed-files-hourly-only.md`

### `docs/InjestionPlan.md`
- **§3.3** — `processed_files` is hourly-only.
- **§5.1** — Ingester responsibilities clarified: companies-agnostic; receives target list via `--target-companies`; per-mode side effects documented.
- **§5.2** — fast filter regex now built from the `--target-companies` arg, not from a `companies` table query.
- **§5.5** — CLI examples updated for the new contract (`--target-companies` always; `--run-id` required in `--mode backfill`; `--hour` as the canonical smoke-test verb).
- **§5.6** — idempotency section updated for backfill mode (re-reads at most one in-progress date's files on crash).

### `docs/CassandraPlan.md`
- **§4.3** — `processed_files` description amended to state the hourly-only ownership.

## Out of scope

- Any application code (Orchestrators implementation lands on a child branch as PR3.x slices).
- Edits to the PR2 issue bodies (#197 / #198 / #199) to reflect the amended Ingester contract — those go in via `gh issue edit` after this PR merges, no PR needed.
- The PR3 PRD and slice issues — `/write-a-prd` and `/prd-to-issues` are queued for after this PR merges.

## Test plan

- [ ] CONTEXT.md and the two new ADRs render correctly on GitHub
- [ ] No code or schema changes — pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)