### PR TITLE
[Cassandra pipeline PR2.D] Ingester: --catchup file-set discovery

### DIFF
--- a/data-pipeline/ingester/ingester.js
+++ b/data-pipeline/ingester/ingester.js
@@ -79,19 +79,16 @@ if (cmd.verb === 'hour') {
   hourIds = [cmd.hourId];
 } else if (cmd.verb === 'range') {
   hourIds = enumerateRange(cmd.start, cmd.end);
-} else {
+} else if (cmd.verb === 'catchup') {
   // catchup: walk disk, skip files already recorded in processed_files
   const allOnDisk = enumerateAllOnDisk(GHARCHIVE_DIR);
   if (allOnDisk.length === 0) {
-    logger.info('no files in GHARCHIVE_DIR');
+    logger.warn('no files in GHARCHIVE_DIR');
     await writer.shutdown();
     process.exit(0);
   }
-  const pending = [];
-  for (const id of allOnDisk) {
-    const done = await writer.isFileProcessed(id);
-    if (!done) pending.push(id);
-  }
+  const processedFlags = await Promise.all(allOnDisk.map(id => writer.isFileProcessed(id)));
+  const pending = allOnDisk.filter((_, i) => !processedFlags[i]);
   const alreadyProcessed = allOnDisk.length - pending.length;
   logger.info(
     { total: allOnDisk.length, alreadyProcessed, toProcess: pending.length },
@@ -103,6 +100,8 @@ if (cmd.verb === 'hour') {
     process.exit(0);
   }
   hourIds = pending;
+} else {
+  throw new Error(`unknown verb: ${cmd.verb}`);
 }
 
 // ── Process each hour file ────────────────────────────────────────────────────

--- a/data-pipeline/ingester/ingester.js
+++ b/data-pipeline/ingester/ingester.js
@@ -6,7 +6,7 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import pino from 'pino';
-import { hourIdToPath, enumerateRange, latestOnDisk, hourIdToMs, msToHourId } from 'disk-layout';
+import { hourIdToPath, enumerateRange, enumerateAllOnDisk } from 'disk-layout';
 import { parseCLI } from './lib/cli.js';
 import { CassandraWriter } from './lib/cassandra-writer.js';
 
@@ -80,24 +80,29 @@ if (cmd.verb === 'hour') {
 } else if (cmd.verb === 'range') {
   hourIds = enumerateRange(cmd.start, cmd.end);
 } else {
-  // catchup
-  const anchor = latestOnDisk(GHARCHIVE_DIR);
-  if (!anchor) {
-    logger.fatal('no anchor on disk — run --hour or --range first to seed the directory');
-    await writer.shutdown();
-    process.exit(1);
-  }
-  const ceilingMs = Date.now() - 2 * 3_600_000;
-  const anchorMs = hourIdToMs(anchor);
-  hourIds = [];
-  for (let t = anchorMs + 3_600_000; t <= ceilingMs; t += 3_600_000) {
-    hourIds.push(msToHourId(t));
-  }
-  if (hourIds.length === 0) {
-    logger.info({ anchor }, 'already up to date');
+  // catchup: walk disk, skip files already recorded in processed_files
+  const allOnDisk = enumerateAllOnDisk(GHARCHIVE_DIR);
+  if (allOnDisk.length === 0) {
+    logger.info('no files in GHARCHIVE_DIR');
     await writer.shutdown();
     process.exit(0);
   }
+  const pending = [];
+  for (const id of allOnDisk) {
+    const done = await writer.isFileProcessed(id);
+    if (!done) pending.push(id);
+  }
+  const alreadyProcessed = allOnDisk.length - pending.length;
+  logger.info(
+    { total: allOnDisk.length, alreadyProcessed, toProcess: pending.length },
+    'catchup startup summary'
+  );
+  if (pending.length === 0) {
+    logger.info('nothing to do');
+    await writer.shutdown();
+    process.exit(0);
+  }
+  hourIds = pending;
 }
 
 // ── Process each hour file ────────────────────────────────────────────────────

--- a/data-pipeline/ingester/lib/cli.js
+++ b/data-pipeline/ingester/lib/cli.js
@@ -73,6 +73,9 @@ export function parseCLI(argv) {
   }
 
   if (flags.catchup) {
+    if (flags.mode === 'backfill') {
+      die('--catchup --mode backfill is not supported; the Backfill Orchestrator uses --range, not --catchup');
+    }
     return { verb: 'catchup', mode: flags.mode ?? 'hourly', targetCompanies };
   }
 

--- a/data-pipeline/shared/disk-layout/index.js
+++ b/data-pipeline/shared/disk-layout/index.js
@@ -40,7 +40,9 @@ export function enumerateRange(startDate, endDate) {
 export function enumerateAllOnDisk(rootDir) {
   const ids = [];
   _collectHourIds(rootDir, rootDir, ids);
-  return ids.sort((a, b) => hourIdToMs(a) - hourIdToMs(b));
+  const decorated = ids.map(id => [id, hourIdToMs(id)]);
+  decorated.sort((a, b) => a[1] - b[1]);
+  return decorated.map(([id]) => id);
 }
 
 // Returns the most recent hour ID (YYYY-MM-DD-H) found under rootDir, or null if empty.

--- a/data-pipeline/shared/disk-layout/index.js
+++ b/data-pipeline/shared/disk-layout/index.js
@@ -36,6 +36,13 @@ export function enumerateRange(startDate, endDate) {
   return hours;
 }
 
+// Returns all hour IDs (YYYY-MM-DD-H) found under rootDir, sorted chronologically.
+export function enumerateAllOnDisk(rootDir) {
+  const ids = [];
+  _collectHourIds(rootDir, rootDir, ids);
+  return ids.sort((a, b) => hourIdToMs(a) - hourIdToMs(b));
+}
+
 // Returns the most recent hour ID (YYYY-MM-DD-H) found under rootDir, or null if empty.
 export function latestOnDisk(rootDir) {
   const ids = [];


### PR DESCRIPTION
## Summary
- Adds `enumerateAllOnDisk` to the `disk-layout` shared package: walks `GHARCHIVE_DIR` recursively and returns all hour IDs sorted chronologically
- Rejects `--catchup --mode backfill` at the CLI layer with a clear error (reserved for future PR)
- Replaces the old (wrong) catchup implementation with the correct one: walk disk → batch-check `processed_files` → log startup summary → process pending files in chronological order through the hourly pipeline

## Acceptance criteria
- [x] CLI accepts `--catchup` (with no other positional arguments) and defaults `--mode` to `hourly`
- [x] `--catchup` requires `--target-companies` (same as `--hour` and `--range`). Without it, exits non-zero with a clear error.
- [x] `--catchup --mode backfill` is rejected at the CLI layer with a single-line error and non-zero exit. This combination is reserved for a future PR.
- [x] On startup with `--catchup`, the Ingester walks every `.json.gz` file under `GHARCHIVE_DIR` recursively (matches the disk layout from the shared `disk-layout` package)
- [x] For each enumerated file, the Ingester queries `processed_files` for the corresponding canonical hour ID; already-present rows are skipped silently (no log noise per file)
- [x] A single startup log line summarises: total files enumerated, count already processed, count to process
- [x] Files to process are dispatched in canonical-hour-ID order (chronological), one at a time, through the same pipeline as `--hour --mode hourly` would
- [x] If any single file fails (crash, exhausted retries), the Ingester exits non-zero immediately without attempting later files
- [x] If no files are enumerated at all, the Ingester logs "no files in GHARCHIVE_DIR" and exits 0
- [x] If all enumerated files are already in `processed_files`, the Ingester logs "nothing to do" and exits 0
- [x] Re-running `--catchup` immediately after a successful run is a no-op (all files now in `processed_files`)

## Related
Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)