### PR TITLE
[Cassandra pipeline followup] Partition-write-rate logger should emit at info, not debug

### DIFF
--- a/data-pipeline/ingester/lib/cassandra-writer.js
+++ b/data-pipeline/ingester/lib/cassandra-writer.js
@@ -74,7 +74,7 @@ export class CassandraWriter {
       const sorted = [...this._partitionWindow.entries()]
         .sort((a, b) => b[1] - a[1])
         .slice(0, 3);
-      this._logger.debug(
+      this._logger.info(
         { partitions: sorted.map(([k, v]) => ({ partition: k, writesPerSec: +(v / TICK_INTERVAL_S).toFixed(1) })) },
         'partition write rate'
       );


### PR DESCRIPTION
## Summary
- Change `startRateLogger` in `data-pipeline/ingester/lib/cassandra-writer.js` from `this._logger.debug(...)` to `this._logger.info(...)` so the partition-write-rate line is visible with the default `LOG_LEVEL=info`.
- One-line fix; matches PRD #194 / #204 user story 31 and the literal AC from #198 ("silenced when LOG_LEVEL >= warn").

## Acceptance criteria
- [x] `startRateLogger` in `data-pipeline/ingester/lib/cassandra-writer.js` uses `this._logger.info(...)` instead of `debug`.
- [ ] Smoke test: `node ingester.js --range 2025-05-22 2025-05-22 --mode backfill --run-id <uuid> --target-companies <real-pairs>` with default `LOG_LEVEL=info` shows at least one "partition write rate" log line over a 10-second-or-longer run.
- [ ] Smoke test: same invocation with `LOG_LEVEL=warn` shows NO partition-write-rate log lines.

## Related
Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)