### PR TITLE
[Cassandra pipeline followup] Ingester CLI: reject --mode backfill for non-range verbs

### DIFF
--- a/data-pipeline/ingester/lib/cli.js
+++ b/data-pipeline/ingester/lib/cli.js
@@ -75,6 +75,9 @@ export function parseCLI(argv) {
     }
     const h = parseInt(hourId.split('-')[3], 10);
     if (h < 0 || h > 23) die('hour component must be 0–23');
+    if (flags.mode === 'backfill') {
+      die('--hour --mode backfill is not supported; use --range A A for a one-day backfill');
+    }
     const mode = flags.mode ?? 'hourly';
     requireValidRunIdForBackfill(mode, flags.runId);
     return { verb: 'hour', hourId, mode, runId: flags.runId ?? null, targetCompanies };


### PR DESCRIPTION
## Summary
- Adds an early-exit guard in `cli.js` that rejects `--hour --mode backfill` with a clear error message and non-zero exit before any work begins
- Matches the existing `--catchup --mode backfill` rejection pattern already on main (added by PR #211)
- The Backfill Orchestrator always uses `--range`, so this combination is only reachable via manual developer invocations

## Acceptance criteria
- [x] `cli.js` rejects `--mode backfill` when `--hour` is the verb, with a single-line error and non-zero exit, BEFORE any other work.
- [x] Smoke test: `node ingester.js --hour 2025-05-22-15 --mode backfill --run-id <uuid> --target-companies wix:wix` exits non-zero with the new error message.
- [x] Existing supported invocations remain unchanged: `--range A B` (default backfill), `--range A B --mode hourly` (override), `--hour --mode hourly`, `--catchup --mode hourly`.

## Related
Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)