### PR TITLE
[Cassandra pipeline PR4] Production deployment wrapper (cron + flock + bootstrap)

### DIFF
--- a/data-pipeline/SETUP.md
+++ b/data-pipeline/SETUP.md
@@ -29,6 +29,12 @@ schema migrations).
 - **Creating the Operator user account.** Bootstrap runs as whoever invokes it.
 - **Log rotation, monitoring, alerting.** Out of scope for v1.
 
+> **Single-tenant assumption.** The locks live in world-writable `/var/lock/`. The
+> design assumes one operator user on the box. If you ever add another local user,
+> they could pre-create `/var/lock/jobflow-{backfill,hourly}.lock` and starve the
+> pipeline (it would skip silently). Move locks to a private path (e.g.
+> `/run/lock/<user>/`) if you violate this assumption.
+
 ---
 
 ## Step 1 — Manual prerequisites (one-time, per box)
@@ -81,10 +87,17 @@ docker compose version    # confirms the plugin is installed
 Used by `bootstrap.sh` to wait for Cassandra and apply schema migrations.
 
 ```bash
-sudo apt-get install -y python3-pip
-pip3 install cqlsh
+# Recent Ubuntu (22.04+) marks the system Python as PEP 668 "externally managed",
+# which makes a plain `pip3 install cqlsh` fail. Use pipx for an isolated install:
+sudo apt-get install -y pipx
+pipx ensurepath          # adds ~/.local/bin to PATH (re-login or `source ~/.profile` after)
+pipx install cqlsh
 cqlsh --version
 ```
+
+> If you prefer not to use `pipx`, the Cassandra Debian repo ships `cqlsh` inside the
+> `cassandra-tools` package — but installing that pulls in the Cassandra server too.
+> `pipx` is the minimal-footprint option.
 
 ### 1.5 Clone the repo
 

--- a/data-pipeline/SETUP.md
+++ b/data-pipeline/SETUP.md
@@ -1,0 +1,231 @@
+# JobFlow Data-Pipeline — Operator Setup Runbook
+
+This runbook brings a fresh Xubuntu box up to a self-running JobFlow data pipeline.
+The pipeline consists of four Node binaries (Fetcher, Ingester, Hourly Orchestrator,
+Backfill Orchestrator) wrapped by `bootstrap.sh`, cron, and `flock` lock coordination.
+
+`bootstrap.sh` is idempotent — safe to re-run any time (e.g. after pulling new
+schema migrations).
+
+---
+
+## What this runbook covers
+
+- Manual prerequisites the Operator must do once per box (mounting the HDD,
+  installing Node / Docker / `cqlsh`).
+- Cloning the repo and per-machine config.
+- Running `bootstrap.sh` to wire up Cassandra, schemas, log directories,
+  and the cron schedule.
+- Verifying everything came up correctly.
+
+## What this runbook does NOT cover
+
+- **Formatting the HDD or mounting it at `/mnt/hdd`** — done by the Operator before
+  `bootstrap.sh` runs. `bootstrap.sh` verifies the mount point exists but does not
+  create it.
+- **Installing Node ≥ 20.6, Docker (with the `docker compose` plugin), or `cqlsh`** —
+  installed via the OS package manager. `bootstrap.sh` checks they are on `PATH`
+  but does not install them.
+- **Creating the Operator user account.** Bootstrap runs as whoever invokes it.
+- **Log rotation, monitoring, alerting.** Out of scope for v1.
+
+---
+
+## Step 1 — Manual prerequisites (one-time, per box)
+
+### 1.1 Format and mount the HDD at `/mnt/hdd`
+
+The Fetcher writes GH Archive `.json.gz` files to `/mnt/hdd/gharchive/`. This must
+be the spinning HDD, not the SSD. Whatever filesystem you pick, ensure it is
+mounted at `/mnt/hdd` and the mount survives reboot (`/etc/fstab` entry).
+
+Verify with:
+
+```bash
+mountpoint /mnt/hdd
+```
+
+If the command prints `/mnt/hdd is a mountpoint`, you are good. If it says
+`is not a mountpoint`, `bootstrap.sh` will refuse to run.
+
+### 1.2 Install Node ≥ 20.6
+
+The orchestrators and fetcher require `node` 20.6 or newer (for stable
+`fetch`, `node:test`, and ESM-by-default).
+
+```bash
+# Example using nvm:
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+nvm install 20
+nvm use 20
+node --version    # → v20.x.x
+```
+
+### 1.3 Install Docker and the `docker compose` plugin
+
+Cassandra runs in a container managed by `data-pipeline/docker-compose.yml`.
+
+```bash
+# Standard Docker install:
+sudo apt-get update
+sudo apt-get install -y docker.io docker-compose-plugin
+
+# Give your user permission to talk to the docker socket (log out and back in after):
+sudo usermod -aG docker "$USER"
+
+docker compose version    # confirms the plugin is installed
+```
+
+### 1.4 Install `cqlsh`
+
+Used by `bootstrap.sh` to wait for Cassandra and apply schema migrations.
+
+```bash
+sudo apt-get install -y python3-pip
+pip3 install cqlsh
+cqlsh --version
+```
+
+### 1.5 Clone the repo
+
+```bash
+git clone https://github.com/tomerp20/jobflow.git
+cd jobflow
+```
+
+The data-pipeline lives at `data-pipeline/`. The remainder of this guide assumes
+your shell's working directory is the repo root.
+
+### 1.6 Install Node dependencies
+
+```bash
+( cd data-pipeline/fetcher       && npm install --omit=dev )
+( cd data-pipeline/ingester      && npm install --omit=dev )
+( cd data-pipeline/orchestrators && npm install --omit=dev )
+```
+
+### 1.7 Create a per-machine `.env` (optional but recommended)
+
+The cron-fired shell scripts source `data-pipeline/.env` if it exists. Use it to
+set Cassandra contact points, `GHARCHIVE_DIR`, etc. Without it, the Node binaries
+will read from the process environment only.
+
+```bash
+cat > data-pipeline/.env <<'EOF'
+CASSANDRA_CONTACT_POINTS=127.0.0.1
+CASSANDRA_LOCAL_DC=datacenter1
+CASSANDRA_KEYSPACE=jobflow
+GHARCHIVE_DIR=/mnt/hdd/gharchive
+LOG_LEVEL=info
+NODE_ENV=production
+EOF
+```
+
+Per-binary `.env.example` files live under `data-pipeline/{fetcher,ingester,orchestrators}/`
+for reference. The single `data-pipeline/.env` above is the one the cron scripts read.
+
+---
+
+## Step 2 — Run `bootstrap.sh`
+
+```bash
+data-pipeline/scripts/bootstrap.sh
+```
+
+What it does:
+
+1. Verifies `node` (≥ 20.6), `docker compose`, and `cqlsh` are on `PATH`.
+2. Verifies `/mnt/hdd` is a real mount point (not just a directory).
+3. Creates `/mnt/hdd/gharchive/` and `~/jobflow-logs/`.
+4. Brings up the Cassandra container via `docker compose up -d cassandra`
+   and polls `cqlsh` until it responds (up to 5 minutes).
+5. Applies every `.cql` file under `data-pipeline/schema/` in numeric order.
+   Tolerates "already exists" errors so re-runs are safe.
+6. Substitutes `@JOBFLOW_ROOT@` and `@USER@` in `cron/jobflow.cron.template` and
+   installs the result at `/etc/cron.d/jobflow` (this is the **only** step that
+   uses `sudo`).
+7. Prints a summary plus verification commands.
+
+If any step fails, the script exits non-zero with a `FATAL:` line on stderr.
+
+---
+
+## Step 3 — Verify the install
+
+```bash
+# Cron file installed with paths substituted:
+sudo cat /etc/cron.d/jobflow
+grep -E 'run-(backfill|hourly)\.sh' /etc/cron.d/jobflow   # should print both lines
+
+# Cron daemon running:
+sudo systemctl status cron
+
+# Cassandra keyspace and tables in place:
+cqlsh -e "DESCRIBE KEYSPACE jobflow"
+
+# Disk mount and log directory:
+mountpoint /mnt/hdd
+ls -la ~/jobflow-logs/
+
+# Tail logs once the first cron interval has fired:
+tail -F ~/jobflow-logs/hourly.log
+tail -F ~/jobflow-logs/backfill.log
+tail -F ~/jobflow-logs/hourly-skips.log
+```
+
+---
+
+## Day-to-day operation
+
+After bootstrap, the pipeline runs itself. Cron fires:
+
+- **Backfill** — every night at 00:00. Holds
+  `/var/lock/jobflow-backfill.lock` for the whole run. Logs to
+  `~/jobflow-logs/backfill.log`.
+- **Hourly** — every hour at :15. Holds
+  `/var/lock/jobflow-hourly.lock`, and checks the backfill lock; if backfill is
+  running, this hour is skipped and the skip is logged to
+  `~/jobflow-logs/hourly-skips.log`. The Ingester's `--catchup` mode handles the
+  resulting backlog on the next successful hourly invocation. Logs to
+  `~/jobflow-logs/hourly.log`.
+
+If a cron interval skips because the disk is below the safety threshold (50 GB
+free for backfill, 10 GB for hourly), the FATAL message is in the corresponding
+log file. The next interval tries again.
+
+### Manual invocation (testing)
+
+You can run either entry-point script directly to see output on the terminal:
+
+```bash
+data-pipeline/scripts/run-hourly.sh
+data-pipeline/scripts/run-backfill.sh
+```
+
+These scripts know nothing about log paths — that's the cron line's responsibility —
+so direct invocation prints to stdout/stderr as normal.
+
+### Re-running `bootstrap.sh`
+
+Re-running `bootstrap.sh` is safe. Use it to:
+
+- Apply newly-added schema migrations after pulling a new repo state.
+- Re-install the cron file after editing `cron/jobflow.cron.template`.
+- Recover from a partial setup that failed midway.
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `data-pipeline/scripts/bootstrap.sh` | One-time idempotent setup. |
+| `data-pipeline/scripts/run-backfill.sh` | Backfill cron entry point. |
+| `data-pipeline/scripts/run-hourly.sh` | Hourly cron entry point. |
+| `data-pipeline/cron/jobflow.cron.template` | Cron schedule with placeholders. |
+| `data-pipeline/schema/*.cql` | Cassandra schema migrations applied by bootstrap. |
+| `/etc/cron.d/jobflow` | Installed (not committed) — substituted output of the template. |
+| `~/jobflow-logs/` | Append-forever logs (`backfill.log`, `hourly.log`, `hourly-skips.log`). |
+| `/var/lock/jobflow-backfill.lock` | Backfill cron lock. |
+| `/var/lock/jobflow-hourly.lock` | Hourly cron lock. |
+| `/mnt/hdd/gharchive/` | GH Archive `.json.gz` files written by the Fetcher. |

--- a/data-pipeline/cron/jobflow.cron.template
+++ b/data-pipeline/cron/jobflow.cron.template
@@ -1,0 +1,19 @@
+# JobFlow data-pipeline cron schedule.
+#
+# Installed at /etc/cron.d/jobflow by data-pipeline/scripts/bootstrap.sh.
+# Placeholders @JOBFLOW_ROOT@ and @USER@ are substituted at install time.
+#
+# Lock coordination (docs/InjestionPlan.md §6.1):
+#   • Backfill holds /var/lock/jobflow-backfill.lock for the whole run.
+#   • Hourly takes its own lock AND checks the backfill lock; if backfill is
+#     running, the hourly skips this interval (logged to hourly-skips.log).
+
+SHELL=/bin/bash
+PATH=/usr/local/bin:/usr/bin:/bin
+HOME=/home/@USER@
+
+# Backfill — nightly at 00:00. flock -n means stacked backfills skip silently.
+0 0 * * * @USER@ flock -n /var/lock/jobflow-backfill.lock @JOBFLOW_ROOT@/data-pipeline/scripts/run-backfill.sh >> /home/@USER@/jobflow-logs/backfill.log 2>&1
+
+# Hourly — every hour at :15. Nested flock: outer = own lock, inner = check backfill lock without holding it.
+15 * * * * @USER@ flock -n /var/lock/jobflow-hourly.lock -c 'flock -n /var/lock/jobflow-backfill.lock true && @JOBFLOW_ROOT@/data-pipeline/scripts/run-hourly.sh || echo "$(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) skipping: backfill in progress" >> /home/@USER@/jobflow-logs/hourly-skips.log' >> /home/@USER@/jobflow-logs/hourly.log 2>&1

--- a/data-pipeline/cron/jobflow.cron.template
+++ b/data-pipeline/cron/jobflow.cron.template
@@ -1,19 +1,24 @@
 # JobFlow data-pipeline cron schedule.
 #
 # Installed at /etc/cron.d/jobflow by data-pipeline/scripts/bootstrap.sh.
-# Placeholders @JOBFLOW_ROOT@ and @USER@ are substituted at install time.
+# Placeholders @JOBFLOW_ROOT@, @USER@, @HOME@, @NODE_BIN_DIR@ are substituted
+# at install time.
 #
 # Lock coordination (docs/InjestionPlan.md §6.1):
 #   • Backfill holds /var/lock/jobflow-backfill.lock for the whole run.
 #   • Hourly takes its own lock AND checks the backfill lock; if backfill is
 #     running, the hourly skips this interval (logged to hourly-skips.log).
+#     The skip path is distinct from the failure path: a genuine run-hourly.sh
+#     failure propagates a non-zero exit to cron rather than being recorded
+#     as a skip.
 
 SHELL=/bin/bash
-PATH=/usr/local/bin:/usr/bin:/bin
-HOME=/home/@USER@
+PATH=@NODE_BIN_DIR@:/usr/local/bin:/usr/bin:/bin
+HOME=@HOME@
 
 # Backfill — nightly at 00:00. flock -n means stacked backfills skip silently.
-0 0 * * * @USER@ flock -n /var/lock/jobflow-backfill.lock @JOBFLOW_ROOT@/data-pipeline/scripts/run-backfill.sh >> /home/@USER@/jobflow-logs/backfill.log 2>&1
+0 0 * * * @USER@ flock -n /var/lock/jobflow-backfill.lock @JOBFLOW_ROOT@/data-pipeline/scripts/run-backfill.sh >> @HOME@/jobflow-logs/backfill.log 2>&1
 
 # Hourly — every hour at :15. Nested flock: outer = own lock, inner = check backfill lock without holding it.
-15 * * * * @USER@ flock -n /var/lock/jobflow-hourly.lock -c 'flock -n /var/lock/jobflow-backfill.lock true && @JOBFLOW_ROOT@/data-pipeline/scripts/run-hourly.sh || echo "$(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) skipping: backfill in progress" >> /home/@USER@/jobflow-logs/hourly-skips.log' >> /home/@USER@/jobflow-logs/hourly.log 2>&1
+# Branching `if` keeps the skip path (false branch) distinct from a genuine run-hourly.sh failure (true branch's exit code propagates).
+15 * * * * @USER@ flock -n /var/lock/jobflow-hourly.lock -c 'if flock -n /var/lock/jobflow-backfill.lock true; then @JOBFLOW_ROOT@/data-pipeline/scripts/run-hourly.sh; else echo "$(date -u +\%Y-\%m-\%dT\%H:\%M:\%SZ) skipping: backfill in progress" >> @HOME@/jobflow-logs/hourly-skips.log; fi' >> @HOME@/jobflow-logs/hourly.log 2>&1

--- a/data-pipeline/scripts/bootstrap.sh
+++ b/data-pipeline/scripts/bootstrap.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# JobFlow data-pipeline bootstrap.
+#
+# Idempotent one-time setup for a fresh Xubuntu box. Safe to re-run.
+# See data-pipeline/SETUP.md for the prerequisite checklist this script does NOT cover.
+
+set -euo pipefail
+
+# Resolve repo paths from this script's location.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DATA_PIPELINE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${DATA_PIPELINE_ROOT}/.." && pwd)"
+
+HDD_MOUNT="/mnt/hdd"
+GHARCHIVE_DIR="${HDD_MOUNT}/gharchive"
+LOG_DIR="${HOME}/jobflow-logs"
+CRON_DEST="/etc/cron.d/jobflow"
+CRON_TEMPLATE="${DATA_PIPELINE_ROOT}/cron/jobflow.cron.template"
+COMPOSE_FILE="${DATA_PIPELINE_ROOT}/docker-compose.yml"
+SCHEMA_DIR="${DATA_PIPELINE_ROOT}/schema"
+
+OPERATOR_USER="$(whoami)"
+
+log()  { printf '[bootstrap] %s\n' "$*"; }
+fail() { printf '[bootstrap] FATAL: %s\n' "$*" >&2; exit 1; }
+
+# ── 1. Prerequisite checks ───────────────────────────────────────────────────
+log "Step 1: checking prerequisites"
+
+command -v node >/dev/null 2>&1 || fail "node is not on PATH (need >= 20.6). See data-pipeline/SETUP.md"
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')"
+NODE_MINOR="$(node -p 'process.versions.node.split(".")[1]')"
+if [ "${NODE_MAJOR}" -lt 20 ] || { [ "${NODE_MAJOR}" -eq 20 ] && [ "${NODE_MINOR}" -lt 6 ]; }; then
+  fail "node $(node -v) is too old (need >= 20.6). See data-pipeline/SETUP.md"
+fi
+
+docker compose version >/dev/null 2>&1 || fail "'docker compose' plugin is missing. See data-pipeline/SETUP.md"
+command -v cqlsh >/dev/null 2>&1 || fail "cqlsh is not on PATH. See data-pipeline/SETUP.md"
+command -v sudo  >/dev/null 2>&1 || fail "sudo is not on PATH (needed for cron install)"
+
+# ── 2. Mount-point check ─────────────────────────────────────────────────────
+log "Step 2: verifying ${HDD_MOUNT} is a real mount point"
+mountpoint -q "${HDD_MOUNT}" || fail "${HDD_MOUNT} is not a mount point. See data-pipeline/SETUP.md"
+
+# ── 3. Directory creation ────────────────────────────────────────────────────
+log "Step 3: creating runtime directories"
+mkdir -p "${GHARCHIVE_DIR}"
+mkdir -p "${LOG_DIR}"
+
+# ── 4. Cassandra container ───────────────────────────────────────────────────
+log "Step 4: bringing up Cassandra via docker compose"
+if docker ps --filter "name=jf-cassandra" --filter "status=running" --format '{{.Names}}' | grep -q '^jf-cassandra$'; then
+  log "  jf-cassandra container already running; skipping 'docker compose up'"
+else
+  docker compose -f "${COMPOSE_FILE}" up -d cassandra
+fi
+
+log "  waiting for Cassandra to accept CQL connections..."
+DELAY=2
+MAX_DELAY=30
+DEADLINE=$(( $(date +%s) + 300 ))  # 5 minutes
+until cqlsh -e "SELECT release_version FROM system.local" >/dev/null 2>&1; do
+  if [ "$(date +%s)" -ge "${DEADLINE}" ]; then
+    fail "Cassandra did not become reachable on 127.0.0.1:9042 within 5 minutes"
+  fi
+  sleep "${DELAY}"
+  if [ "${DELAY}" -lt "${MAX_DELAY}" ]; then
+    DELAY=$(( DELAY * 2 ))
+    [ "${DELAY}" -gt "${MAX_DELAY}" ] && DELAY="${MAX_DELAY}"
+  fi
+done
+log "  Cassandra is reachable"
+
+# ── 5. Schema migrations ─────────────────────────────────────────────────────
+log "Step 5: applying schema migrations in numeric order"
+for schema_file in $(find "${SCHEMA_DIR}" -maxdepth 1 -name '*.cql' | sort); do
+  schema_name="$(basename "${schema_file}")"
+  log "  applying ${schema_name}"
+  # ALTER TABLE ADD raises InvalidRequest("conflicts with an existing column") when re-run.
+  # Tolerate that specific case to keep bootstrap idempotent; abort on anything else.
+  if ! out="$(cqlsh -f "${schema_file}" 2>&1)"; then
+    if printf '%s' "${out}" | grep -Eq 'conflicts with an existing column|already exists'; then
+      log "    (already applied, skipping)"
+    else
+      printf '%s\n' "${out}" >&2
+      fail "schema ${schema_name} failed"
+    fi
+  fi
+done
+
+# ── 6. Cron install ──────────────────────────────────────────────────────────
+log "Step 6: installing cron file to ${CRON_DEST}"
+[ -f "${CRON_TEMPLATE}" ] || fail "cron template not found at ${CRON_TEMPLATE}"
+
+TMP_CRON="$(mktemp -t jobflow.cron.XXXXXX)"
+trap 'rm -f "${TMP_CRON}"' EXIT
+# Use | as sed delimiter — JOBFLOW_ROOT contains slashes.
+sed -e "s|@JOBFLOW_ROOT@|${REPO_ROOT}|g" \
+    -e "s|@USER@|${OPERATOR_USER}|g" \
+    "${CRON_TEMPLATE}" > "${TMP_CRON}"
+
+sudo cp "${TMP_CRON}" "${CRON_DEST}"
+sudo chown root:root "${CRON_DEST}"
+sudo chmod 0644 "${CRON_DEST}"
+
+# ── 7. Summary ───────────────────────────────────────────────────────────────
+log ""
+log "─────────────────────────────────────────────────────────────────"
+log "Bootstrap complete."
+log ""
+log "What was set up:"
+log "  • Cassandra container running (jf-cassandra)"
+log "  • Keyspace 'jobflow' schemas applied from ${SCHEMA_DIR}"
+log "  • Directories: ${GHARCHIVE_DIR}, ${LOG_DIR}"
+log "  • Cron schedule installed at ${CRON_DEST}"
+log "    user=${OPERATOR_USER}, JOBFLOW_ROOT=${REPO_ROOT}"
+log ""
+log "Verify with:"
+log "  cqlsh -e \"DESCRIBE KEYSPACE jobflow\""
+log "  cat ${CRON_DEST}"
+log "  mountpoint ${HDD_MOUNT}"
+log "  ls ${LOG_DIR}"
+log "  sudo systemctl status cron"
+log "─────────────────────────────────────────────────────────────────"

--- a/data-pipeline/scripts/bootstrap.sh
+++ b/data-pipeline/scripts/bootstrap.sh
@@ -47,6 +47,8 @@ mountpoint -q "${HDD_MOUNT}" || fail "${HDD_MOUNT} is not a mount point. See dat
 log "Step 3: creating runtime directories"
 mkdir -p "${GHARCHIVE_DIR}"
 mkdir -p "${LOG_DIR}"
+# Keep logs private to the operator; Node binaries log Cassandra context at LOG_LEVEL=info.
+chmod 700 "${LOG_DIR}"
 
 # ── 4. Cassandra container ───────────────────────────────────────────────────
 log "Step 4: bringing up Cassandra via docker compose"
@@ -74,13 +76,18 @@ log "  Cassandra is reachable"
 
 # ── 5. Schema migrations ─────────────────────────────────────────────────────
 log "Step 5: applying schema migrations in numeric order"
-for schema_file in $(find "${SCHEMA_DIR}" -maxdepth 1 -name '*.cql' | sort); do
+# mapfile (not `for f in $(find ...)`) keeps word-splitting safe even with quirky filenames.
+mapfile -t schema_files < <(find "${SCHEMA_DIR}" -maxdepth 1 -name '*.cql' | sort)
+for schema_file in "${schema_files[@]}"; do
   schema_name="$(basename "${schema_file}")"
   log "  applying ${schema_name}"
   # ALTER TABLE ADD raises InvalidRequest("conflicts with an existing column") when re-run.
-  # Tolerate that specific case to keep bootstrap idempotent; abort on anything else.
+  # Treat as benign only when *every* error-bearing line matches a known-idempotent pattern.
+  # Without that "every line" check, a real failure mixed into a multi-statement file would be masked.
   if ! out="$(cqlsh -f "${schema_file}" 2>&1)"; then
-    if printf '%s' "${out}" | grep -Eq 'conflicts with an existing column|already exists'; then
+    error_lines="$(printf '%s' "${out}" | grep -E 'InvalidRequest|Error|Exception' || true)"
+    non_benign="$(printf '%s' "${error_lines}" | grep -vE 'conflicts with an existing column|already exists' || true)"
+    if [ -n "${error_lines}" ] && [ -z "${non_benign}" ]; then
       log "    (already applied, skipping)"
     else
       printf '%s\n' "${out}" >&2
@@ -95,9 +102,13 @@ log "Step 6: installing cron file to ${CRON_DEST}"
 
 TMP_CRON="$(mktemp -t jobflow.cron.XXXXXX)"
 trap 'rm -f "${TMP_CRON}"' EXIT
-# Use | as sed delimiter — JOBFLOW_ROOT contains slashes.
+# Resolve node's directory so the cron PATH points at the actual node install (e.g. nvm) rather than guessing.
+NODE_BIN_DIR="$(dirname "$(command -v node)")"
+# Use | as sed delimiter — JOBFLOW_ROOT, HOME, and NODE_BIN_DIR contain slashes.
 sed -e "s|@JOBFLOW_ROOT@|${REPO_ROOT}|g" \
     -e "s|@USER@|${OPERATOR_USER}|g" \
+    -e "s|@HOME@|${HOME}|g" \
+    -e "s|@NODE_BIN_DIR@|${NODE_BIN_DIR}|g" \
     "${CRON_TEMPLATE}" > "${TMP_CRON}"
 
 sudo cp "${TMP_CRON}" "${CRON_DEST}"

--- a/data-pipeline/scripts/run-backfill.sh
+++ b/data-pipeline/scripts/run-backfill.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Backfill cron entry point: disk-space guard → Fetcher (full range) → Backfill Orchestrator.
+# Exits non-zero on failure so cron records it; the next interval will try again.
+
+set -euo pipefail
+
+MIN_FREE_GB=50
+HDD_MOUNT="/mnt/hdd"
+BACKFILL_START_DATE="2025-05-22"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DATA_PIPELINE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${DATA_PIPELINE_ROOT}/.." && pwd)"
+
+# Load per-machine env (Cassandra contact points, GHARCHIVE_DIR, etc.) if present.
+if [ -f "${DATA_PIPELINE_ROOT}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${DATA_PIPELINE_ROOT}/.env"
+  set +a
+fi
+
+# Disk-space guard.
+AVAILABLE_GB_HDD="$(df --output=avail -BG "${HDD_MOUNT}" | tail -1 | tr -dc '0-9')"
+if [ "${AVAILABLE_GB_HDD:-0}" -lt "${MIN_FREE_GB}" ]; then
+  printf 'FATAL: less than %s GB free on %s (have %s GB)\n' "${MIN_FREE_GB}" "${HDD_MOUNT}" "${AVAILABLE_GB_HDD:-0}" >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+END_DATE="$(date -u -d 'yesterday' +%Y-%m-%d)"
+
+node data-pipeline/fetcher/fetcher.js --range "${BACKFILL_START_DATE}" "${END_DATE}"
+node data-pipeline/orchestrators/backfill.js

--- a/data-pipeline/scripts/run-backfill.sh
+++ b/data-pipeline/scripts/run-backfill.sh
@@ -21,7 +21,12 @@ if [ -f "${DATA_PIPELINE_ROOT}/.env" ]; then
   set +a
 fi
 
-# Disk-space guard.
+# Mount + disk-space guard. Checking the mountpoint first surfaces "/mnt/hdd missing" as a real cause
+# rather than letting df fall back to the root filesystem and silently mislead the threshold check.
+if ! mountpoint -q "${HDD_MOUNT}"; then
+  printf 'FATAL: %s is not a mount point — see data-pipeline/SETUP.md\n' "${HDD_MOUNT}" >&2
+  exit 1
+fi
 AVAILABLE_GB_HDD="$(df --output=avail -BG "${HDD_MOUNT}" | tail -1 | tr -dc '0-9')"
 if [ "${AVAILABLE_GB_HDD:-0}" -lt "${MIN_FREE_GB}" ]; then
   printf 'FATAL: less than %s GB free on %s (have %s GB)\n' "${MIN_FREE_GB}" "${HDD_MOUNT}" "${AVAILABLE_GB_HDD:-0}" >&2

--- a/data-pipeline/scripts/run-hourly.sh
+++ b/data-pipeline/scripts/run-hourly.sh
@@ -20,7 +20,12 @@ if [ -f "${DATA_PIPELINE_ROOT}/.env" ]; then
   set +a
 fi
 
-# Disk-space guard.
+# Mount + disk-space guard. Checking the mountpoint first surfaces "/mnt/hdd missing" as a real cause
+# rather than letting df fall back to the root filesystem and silently mislead the threshold check.
+if ! mountpoint -q "${HDD_MOUNT}"; then
+  printf 'FATAL: %s is not a mount point — see data-pipeline/SETUP.md\n' "${HDD_MOUNT}" >&2
+  exit 1
+fi
 AVAILABLE_GB_HDD="$(df --output=avail -BG "${HDD_MOUNT}" | tail -1 | tr -dc '0-9')"
 if [ "${AVAILABLE_GB_HDD:-0}" -lt "${MIN_FREE_GB}" ]; then
   printf 'FATAL: less than %s GB free on %s (have %s GB)\n' "${MIN_FREE_GB}" "${HDD_MOUNT}" "${AVAILABLE_GB_HDD:-0}" >&2

--- a/data-pipeline/scripts/run-hourly.sh
+++ b/data-pipeline/scripts/run-hourly.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Hourly cron entry point: disk-space guard → Fetcher (--catchup) → Hourly Orchestrator.
+# Exits non-zero on failure so cron records it; the next interval will try again.
+
+set -euo pipefail
+
+MIN_FREE_GB=10
+HDD_MOUNT="/mnt/hdd"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DATA_PIPELINE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd -- "${DATA_PIPELINE_ROOT}/.." && pwd)"
+
+# Load per-machine env (Cassandra contact points, GHARCHIVE_DIR, etc.) if present.
+if [ -f "${DATA_PIPELINE_ROOT}/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${DATA_PIPELINE_ROOT}/.env"
+  set +a
+fi
+
+# Disk-space guard.
+AVAILABLE_GB_HDD="$(df --output=avail -BG "${HDD_MOUNT}" | tail -1 | tr -dc '0-9')"
+if [ "${AVAILABLE_GB_HDD:-0}" -lt "${MIN_FREE_GB}" ]; then
+  printf 'FATAL: less than %s GB free on %s (have %s GB)\n' "${MIN_FREE_GB}" "${HDD_MOUNT}" "${AVAILABLE_GB_HDD:-0}" >&2
+  exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+node data-pipeline/fetcher/fetcher.js --catchup
+node data-pipeline/orchestrators/hourly.js


### PR DESCRIPTION
## Summary
- Wraps the four already-shipped Node binaries (Fetcher, Ingester, Hourly Orchestrator, Backfill Orchestrator) into a cron-driven production pipeline on a single Xubuntu box.
- Five files only — no changes to the Node binaries: `data-pipeline/scripts/bootstrap.sh`, `data-pipeline/scripts/run-backfill.sh`, `data-pipeline/scripts/run-hourly.sh`, `data-pipeline/cron/jobflow.cron.template`, `data-pipeline/SETUP.md`.
- The load-bearing coordination from `docs/InjestionPlan.md` §6.1 is implemented via a nested `flock` on the hourly cron line, so backfill and hourly cannot race on a shared host.

## Acceptance criteria
(From issue #208 — 35 user stories. Key load-bearing behaviours:)

- [x] **#1, #11** — `bootstrap.sh` is one command, idempotent, safe to re-run.
- [x] **#3** — Fails loudly if `node`, `docker compose`, or `cqlsh` is missing.
- [x] **#4** — Verifies `/mnt/hdd` is a real mount point via `mountpoint -q` before proceeding.
- [x] **#5** — Creates `/mnt/hdd/gharchive/` and `~/jobflow-logs/` if missing.
- [x] **#6** — Brings up Cassandra via `docker compose up -d cassandra` and waits for cqlsh to respond (5 min cap, exponential backoff).
- [x] **#7, #8** — Applies every schema file in numeric order; tolerates "already exists" / "conflicts with an existing column" so re-runs are safe.
- [x] **#9, #28, #29** — Installs the cron file to `/etc/cron.d/jobflow` with `@JOBFLOW_ROOT@` and `@USER@` substituted via `sed`; template stays generic in the repo.
- [x] **#10, #33** — Prints a summary with verification commands at the end.
- [x] **#12, #13** — Backfill cron fires at 00:00 nightly; hourly cron fires at :15 every hour.
- [x] **#14, #15** — Hourly skips cleanly when the backfill lock is held; skip line is appended to `~/jobflow-logs/hourly-skips.log`.
- [x] **#16** — Backfill cron uses `flock -n` so a stacked second backfill silently skips.
- [x] **#17, #18** — `run-backfill.sh` requires 50 GB free on `/mnt/hdd`; `run-hourly.sh` requires 10 GB; both exit non-zero with `FATAL:` if below threshold.
- [x] **#19, #20** — `run-backfill.sh` invokes Fetcher (with `--range BACKFILL_START_DATE yesterday-UTC`) then Backfill Orchestrator. `run-hourly.sh` invokes Fetcher (`--catchup`) then Hourly Orchestrator.
- [x] **#21, #22** — All stdout/stderr is appended to `~/jobflow-logs/{backfill,hourly,hourly-skips}.log` via cron-line redirects; shell scripts know nothing about log paths so direct invocation prints to the terminal.
- [x] **#23, #30** — Scripts resolve paths via `$(dirname "$0")/..` and use `set -euo pipefail`.
- [x] **#24, #34** — Cron jobs run as `@USER@` (the Operator's `whoami` at bootstrap time), so `~/jobflow-logs/` and all on-disk artefacts are owned by that user.
- [x] **#25, #26** — Cron file lives at `/etc/cron.d/jobflow`; `sudo` is used only by `bootstrap.sh` for the `cp` into `/etc/cron.d/`.
- [x] **#27, #35** — `data-pipeline/SETUP.md` is the operator runbook; it explicitly lists what bootstrap does NOT do (mount, install Node/Docker/cqlsh, create the user).
- [x] **#31** — Failed cron runs exit non-zero with `FATAL:` lines visible in the log files.
- [x] **#32** — Bootstrap detects an already-running `jf-cassandra` container and skips `docker compose up`.

## Notes / deviations from the PRD

- The PRD's user-story #34 says scripts should source per-machine config, but the PRD's "semantics" sections don't address how the Node binaries get their env vars under cron. I added a single optional `data-pipeline/.env` that the shell scripts source if present; SETUP.md documents this. This keeps the cron line free of secrets and matches the existing per-binary `.env.example` pattern. If reviewers prefer a different env-loading strategy (per-binary, cron-line vars, etc.), happy to switch.
- The schema-idempotency claim in the PRD ("Cassandra rejects duplicate-column adds gracefully") is not strictly true — duplicate ALTER ADD raises `InvalidRequest`. Bootstrap tolerates that specific error and re-raises anything else, which preserves the intended idempotency.

## Related
Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)