### PR TITLE
[Cassandra pipeline followup] Backfill Orchestrator --target-companies encoding is brittle

### DIFF
--- a/data-pipeline/ingester/lib/cli.js
+++ b/data-pipeline/ingester/lib/cli.js
@@ -27,9 +27,18 @@ function parseTargetCompanies(raw) {
   return pairs.map(pair => {
     const colon = pair.indexOf(':');
     if (colon === -1) die(`invalid --target-companies entry "${pair}" — expected company:org format`);
-    const company = pair.slice(0, colon).trim();
-    const org = pair.slice(colon + 1).trim();
-    if (!company || !org) die(`invalid --target-companies entry "${pair}" — company and org must be non-empty`);
+    const rawCompany = pair.slice(0, colon).trim();
+    const rawOrg = pair.slice(colon + 1).trim();
+    if (!rawCompany || !rawOrg) die(`invalid --target-companies entry "${pair}" — company and org must be non-empty`);
+    // Components are URL-encoded by the Backfill Orchestrator so values
+    // containing ':' or ',' survive the wire format. Decode here.
+    let company, org;
+    try {
+      company = decodeURIComponent(rawCompany);
+      org = decodeURIComponent(rawOrg);
+    } catch (err) {
+      die(`invalid --target-companies entry "${pair}" — malformed URL encoding`);
+    }
     return { company, org };
   });
 }

--- a/data-pipeline/ingester/lib/cli.js
+++ b/data-pipeline/ingester/lib/cli.js
@@ -31,13 +31,18 @@ function parseTargetCompanies(raw) {
     const rawOrg = pair.slice(colon + 1).trim();
     if (!rawCompany || !rawOrg) die(`invalid --target-companies entry "${pair}" — company and org must be non-empty`);
     // Components are URL-encoded by the Backfill Orchestrator so values
-    // containing ':' or ',' survive the wire format. Decode here.
+    // containing ':' or ',' survive the wire format. Decode each side
+    // separately so the operator knows which component was malformed.
     let company, org;
     try {
       company = decodeURIComponent(rawCompany);
+    } catch {
+      die(`invalid --target-companies entry "${pair}" — malformed URL encoding in company component`);
+    }
+    try {
       org = decodeURIComponent(rawOrg);
-    } catch (err) {
-      die(`invalid --target-companies entry "${pair}" — malformed URL encoding`);
+    } catch {
+      die(`invalid --target-companies entry "${pair}" — malformed URL encoding in org component`);
     }
     return { company, org };
   });

--- a/data-pipeline/orchestrators/backfill.js
+++ b/data-pipeline/orchestrators/backfill.js
@@ -153,7 +153,11 @@ async function main() {
     }
 
     // ── Spawn Ingester ────────────────────────────────────────────────────────
-    const targetCompaniesArg = targetRows.map(r => `${r.company}:${r.org_name}`).join(',');
+    // URL-encode each token so values containing ':' or ',' can't break the
+    // company:org,company:org wire format the Ingester parses.
+    const targetCompaniesArg = targetRows
+      .map(r => `${encodeURIComponent(r.company)}:${encodeURIComponent(r.org_name)}`)
+      .join(',');
     const ingesterPath = path.resolve(__dirname, '..', 'ingester', 'ingester.js');
 
     logger.info({ startDate, endDate, companies: targetRows.length }, 'spawning ingester');


### PR DESCRIPTION
## Summary
- URL-encode each `(company, org_name)` token in the Backfill Orchestrator before joining into `--target-companies`
- URL-decode in the Ingester's `parseTargetCompanies` after splitting
- Defends the `company:org,company:org` wire format against future values containing `:` or `,`

## Acceptance criteria
- [x] Orchestrator URL-encodes each component when building `--target-companies`.
- [x] Ingester URL-decodes each component when parsing.
- [x] Existing values (`microsoft:microsoft`, `wix:wix-incubator`, etc.) decode identically (URL encoding is a no-op for `[a-zA-Z0-9-]`).
- [ ] Smoke test: insert a Company with name `foo:bar,baz` (deliberately pathological), trigger a backfill via the orchestrator, verify the Ingester correctly parses it as a single `(company='foo:bar,baz', org='...')` pair and writes events to the right partition. — _Local round-trip verified via inline node script; full end-to-end smoke test against the orchestrator left for review/manual run._

## Verification
Local round-trip sanity test (encode in orchestrator shape, decode in ingester shape):
```
encoded: microsoft:microsoft,wix:wix-incubator,foo%3Abar%2Cbaz:evil-org
parsed:  [{company:'microsoft',org:'microsoft'},{company:'wix',org:'wix-incubator'},{company:'foo:bar,baz',org:'evil-org'}]
PASS: round-trip identical
```

## Related
Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)