### PR TITLE
[Cassandra pipeline followup] hourly.js builds --target-companies without URL-encoding (drift from backfill.js)

### DIFF
--- a/data-pipeline/orchestrators/hourly.js
+++ b/data-pipeline/orchestrators/hourly.js
@@ -58,7 +58,11 @@ async function main() {
     process.exit(0);
   }
 
-  const targetCompanies = companies.map(r => `${r.company}:${r.org_name}`).join(',');
+  // URL-encode each token so values containing ':' or ',' can't break the
+  // company:org,company:org wire format the Ingester parses. Mirrors backfill.js.
+  const targetCompanies = companies
+    .map(r => `${encodeURIComponent(r.company)}:${encodeURIComponent(r.org_name)}`)
+    .join(',');
   logger.info({ count: companies.length, targetCompanies }, 'companies loaded — spawning ingester');
 
   // ── Spawn ingester ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Mirrors the URL-encoding convention from `backfill.js` (introduced in PR #230) in `hourly.js`, so both producers of `--target-companies` agree on the wire format.
- No behaviour change for existing data (all current company/org values are `[a-zA-Z0-9-]`, where `encodeURIComponent` is a no-op); closes the latent drift where a future name containing `:` or `,` would be mis-routed by the hourly path.
- Grepped `data-pipeline/` to confirm only two producers exist (hourly.js, backfill.js) — no third drift point.

## Acceptance criteria
- [x] `hourly.js` URL-encodes each component (same pattern as `backfill.js:158`).
- [x] Both orchestrators use the identical encoding convention.
- [x] Existing values (`microsoft:microsoft`, `wix:wix-incubator`, etc.) round-trip identically — verified via `encodeURIComponent`/`decodeURIComponent` no-op check.
- [x] Grepped `data-pipeline/` for other code paths constructing `--target-companies` — no third producer exists.

## Note on shared helper
The issue mentioned optionally extracting a shared helper. Skipped intentionally — with only two call sites and a one-liner each, a helper would be more indirection than the duplication it removes. If a third producer appears, that's the right time to extract.

## Related
Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)