### PR TITLE
fix: Reaper container starts cleanly + Cassandra JMX exposed for Reaper

### DIFF
--- a/data-pipeline/docker-compose.yml
+++ b/data-pipeline/docker-compose.yml
@@ -9,6 +9,13 @@ services:
       - MAX_HEAP_SIZE=4G
       - HEAP_NEWSIZE=800M
       - CASSANDRA_CLUSTER_NAME=jobflow
+      # Open JMX so the Reaper container can connect to Cassandra over JMX.
+      # LOCAL_JMX=no turns off the default localhost-only bind. The JVM extra
+      # opts disable JMX authentication (acceptable on a single-host learning
+      # deployment) and pin the RMI hostname so Reaper can resolve back to the
+      # Cassandra service.
+      - LOCAL_JMX=no
+      - JVM_EXTRA_OPTS=-Djava.rmi.server.hostname=cassandra -Dcom.sun.jndi.rmiregistry.noLocalStubs=true -Dcom.sun.management.jmxremote.authenticate=false
     volumes:
       - /home/tomer/cassandra-data:/var/lib/cassandra
     healthcheck:
@@ -25,6 +32,12 @@ services:
     environment:
       - REAPER_STORAGE_TYPE=memory
       - REAPER_CASS_CONTACT_POINTS=[cassandra]
+      # Disable Reaper's access-control layer. Without this, the latest Reaper
+      # image refuses to start with "ACCESS CONTROL: User configuration missing
+      # username" because the default config block points at users that aren't
+      # defined. Disabling auth is acceptable for a single-host learning
+      # deployment behind LAN-only port exposure.
+      - REAPER_AUTH_ENABLED=false
     depends_on:
       cassandra:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Two small env-var additions to `data-pipeline/docker-compose.yml` so the `jf-reaper` companion container actually starts and can connect to Cassandra.

These changes were made by the operator on the Xubuntu deployment box during Reaper troubleshooting and have been verified to fix two real failure modes; this PR upstreams them into main so future `bootstrap.sh` invocations on a fresh box don't hit the same wall.

## What's broken without these

**1. Reaper crashes at startup**

The latest `thelastpickle/cassandra-reaper` image refuses to start with:

```
java.lang.IllegalArgumentException:
  ACCESS CONTROL: User configuration missing username.
  All users must have a non-empty username.
```

This is because the image's default `accessControl` config block points at users that aren't defined in our compose env. The container exits immediately; the next `docker compose up -d` re-creates it, and it crashes again.

**Fix:** `REAPER_AUTH_ENABLED=false`. Acceptable for a single-host learning deployment that's never exposed beyond LAN-only / SSH-tunnelled access. If we ever expose the Reaper UI more broadly, revisit by populating `REAPER_AUTH_USER` / `REAPER_AUTH_PASSWORD` instead.

**2. Even if Reaper started, it can't reach Cassandra over JMX**

Cassandra's default JMX bind is `127.0.0.1` only (set by the upstream Cassandra Docker entrypoint). That means a separate Reaper container on the same docker network cannot connect to Cassandra over JMX, and Reaper's "Cluster" tab stays empty / errors out.

**Fix:** `LOCAL_JMX=no` (opens the bind from localhost-only) plus the three JVM extra opts:
- `-Dcom.sun.management.jmxremote.authenticate=false` — disable JMX auth (same single-host trade-off as above).
- `-Djava.rmi.server.hostname=cassandra` — pin the RMI server hostname so Reaper resolves back to the docker service name.
- `-Dcom.sun.jndi.rmiregistry.noLocalStubs=true` — required when JMX is bound to a non-localhost address.

## Verification

Verified on the Xubuntu deployment box (tomer-server, 192.168.10.12):

- Before: `jf-reaper` repeatedly exits with `ACCESS CONTROL` error; `docker logs jf-reaper` shows the Java stack trace.
- After: `docker compose -f data-pipeline/docker-compose.yml up -d` brings Cassandra healthy and Reaper starts cleanly without errors.
- Reaper UI at `http://localhost:8080` loads and lists the `jobflow` cluster.

## Files changed

- `data-pipeline/docker-compose.yml` — 4 new env-var lines (2 per service), each with an inline comment explaining the reasoning.

## Test plan

- [ ] `docker compose -f data-pipeline/docker-compose.yml up -d` brings both containers up
- [ ] `docker ps` shows `jf-cassandra` healthy and `jf-reaper` running
- [ ] `docker logs jf-reaper` is free of `ACCESS CONTROL: User configuration missing username` errors
- [ ] Reaper UI loads at `http://localhost:8080` and shows the `jobflow` cluster
- [ ] All schemas 001–008 still apply via `cqlsh` (no behavioural change to Cassandra)

## Not in scope

- Tighter auth on Reaper or JMX. Acceptable as a single-host learning trade-off; tracked under #213 (production hardening) if/when the deployment shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)