### PR TITLE
docs: Cassandra pipeline V1 retrospective + deployment runbook + ADR 0006

### DIFF
--- a/docs/RETROSPECTIVES/2026-05-23-cassandra-pipeline-v1.md
+++ b/docs/RETROSPECTIVES/2026-05-23-cassandra-pipeline-v1.md
@@ -1,0 +1,223 @@
+# Retrospective — Cassandra Pipeline V1 (2026-05-23)
+
+A single-day build of the JobFlow Analytics ingestion subsystem, spanning planning, implementation, code review, deployment, and a real e2e test against live data. Captures what was built, what surprised us, what worked, and what didn't, so future work on this codebase (and on adjacent projects) starts with the lessons.
+
+---
+
+## The arc — what happened in one day
+
+| Phase | What we did |
+|---|---|
+| **Morning** | Created a worktree, read the existing plan docs (`CassandraPlan.md`, `InjestionPlan.md`), realised the plan needed a per-PR grilling before any code |
+| **Mid-morning** | PR1 grill → PRD #187 → slice issues #188 (schema), #189 (Fetcher base), #190 (Fetcher catchup), shipped + merged in parallel |
+| **Late morning** | PR2 grill → PRD #194 → slice issues #196 (disk-layout refactor), #197/#198/#199 (Ingester base / backfill / catchup) |
+| **Midday** | First Cassandra container brought up on the Linux box. Schemas applied. First Ingester smoke test crashed with `policies.retry.DefaultRetryPolicy is not a constructor` → filed `#219` critical, agent fixed via PR #220, verified live |
+| **Afternoon** | PR3 grill → PRD #204 → slice issues #205 (Hourly Orchestrator), #206 (Backfill Orchestrator). Discovered the `latestOnDisk` bug `#226` mid-test, fixed via PR #228 |
+| **Late afternoon** | PR4 grill → PRD #208 → slice #209, implemented via PR #229. Deployment wrapper landed |
+| **Evening** | Wiped the Linux box clean, ran `bootstrap.sh` fresh, did end-to-end tests against 63 companies + Microsoft over 7 days (12,621 events written). Filed three followups (#216, #217, #221, #225, #231, #234) along the way |
+
+By the end: V1 code 100% complete, deployment wrapper live on a real Linux box, ingestion pipeline producing real data from real GH Archive files.
+
+---
+
+## Technical surprises worth knowing
+
+### 1. The cassandra-driver API doesn't match what an LLM assumes
+
+The agents implementing PR2 used two cassandra-driver APIs that don't exist:
+
+- `policies.retry.DefaultRetryPolicy()` — not a class; real exports are `RetryPolicy`, `IdempotenceAwareRetryPolicy`, `FallthroughRetryPolicy`. Drop the explicit policy and the driver's default is fine.
+- `client.prepare(sql)` — does not exist. Cassandra-driver's `Client` has `execute()` and `batch()`. Prepared statements happen via `{ prepare: true }` option on those calls; the driver caches the prepared form internally on first call.
+
+Both bugs slipped past three code reviews because nobody actually ran the binary against a real Cassandra (see ADR 0006). The fix was trivial; the process gap was the real problem.
+
+**Takeaway:** for any unfamiliar driver/library, an LLM-written first draft against it should be smoke-tested before merge. Always.
+
+### 2. Public-GitHub activity for enterprise companies is way lower than `public_repos` count implies
+
+Going in, we assumed companies with 416 public repos (Salesforce) would produce thousands of events per day. Real data:
+
+| Company | `public_repos` | Events on 2026-05-22 |
+|---|---|---|
+| Microsoft | (not in our list initially) | **1,704** (re-added in 7-day test) |
+| Comet | 67 | 26 |
+| Salesforce | 416 | **14** |
+| Port-labs | 126 | 7 |
+| Workday | 54 | **0** |
+| Vonage | 148 | **0** |
+| Autodesk | 87 | **0** |
+
+Most enterprise orgs use GitHub Enterprise / private repos for real work. Their public org is documentation, examples, or occasional OSS contributions. **Microsoft alone drove ~90% of our event volume.**
+
+**Takeaway:** for analytics over public GitHub activity, "public_repos count" is a near-useless metric. Pick companies by recent push activity, not repo count. Microsoft and a handful of true-OSS-first companies (`comet-ml`, `port-labs`, `salesforce`'s actual public repos) drive most of the signal.
+
+### 3. GH Archive scales surprisingly well at LAN throughput
+
+We fetched 168 files (4.2 GB compressed) in 131 seconds = **~33 MB/s sustained**, **~1.3 files/second** with `p-limit(3)`. The HDD wrote at that rate without breaking a sweat (7200 RPM HDDs do ~150 MB/s sequential, so we were well within capacity).
+
+For a 1-year backfill (~470 GB compressed), at this rate: **~4 hours of fetch wall-clock**. Not as scary as the original plan implied.
+
+### 4. The 7-day backfill across 63 companies took 21 seconds for Microsoft alone, then ~3 minutes for all 63
+
+Microsoft is fast because all events go to the same `(microsoft, 2026-05)` partition — UNLOGGED batches stay full and warm. The other 62 companies spread their few events across many partitions, so batching loses some efficiency. Still, **3 minutes for 168 files × 63 companies** = comfortably faster than the plan's "5-15 min for hourly" target.
+
+### 5. The "exit code on ENOENT" bug (`#221`) was a false positive
+
+I filed `#221` ("Ingester exits 0 on missing-file failure") based on observing `exit=0` in my own shell. Turns out my shell had `node ... | tail; echo $?` — and `$?` captures the **last** pipeline stage's exit code (the `echo` itself), not `node`'s. The Ingester's exit-on-failure logic was correct from the start.
+
+An agent running `/ship 221` did the diagnostic work, found the false positive, and closed the issue with a verification trail.
+
+**Takeaway:** when reading exit codes from a piped command, redirect first (`> /tmp/out 2>&1`) and inspect `$?` immediately. Pipes mask the truth.
+
+---
+
+## Process patterns that worked
+
+### A. The grill → PRD → prd-to-issues → ship sequence
+
+For each of the four PRs (PR1 Fetcher, PR2 Ingester, PR3 Orchestrators, PR4 Deployment), we ran the same sequence:
+
+1. **Grill** the design with the relevant docs (CassandraPlan, InjestionPlan). Resolve every "we'll figure it out later" before writing code.
+2. **PRD** captures the grilled decisions as a GitHub issue. Long, structured, includes user stories.
+3. **prd-to-issues** breaks the PRD into independently-grabbable slices.
+4. **ship** each slice via an agent.
+
+The grilling was the secret. By the time the PRD was written, every architectural decision had a justification; by the time the slices were created, every cross-cut had been considered. Agents picking up the implementation issues had near-zero ambiguity.
+
+What helped: the grill produced **ADRs** (`0003` relay-race, `0004` microservices-shaped CLI, `0005` processed_files hourly-only) for the load-bearing decisions. Future contributors can see *why*, not just *what*.
+
+### B. Chained branches off a feature-parent (then off main after parent merges)
+
+Initially we used a chained-branch pattern: PR1's slices branched off a parent feature branch (`feature/cassandra-data-pipeline`), not off main. This let multiple slices co-exist before the parent landed.
+
+Later, after the parent merged to main, we switched to branching slices off main directly. Both approaches worked. The lesson is: pick one and be consistent within a PRD's slices, so reviewers know what to expect.
+
+### C. Precursor "grill outcomes" PRs before each implementation PR
+
+Each grill produced a small documentation/ADR PR (`#186`, `#193`, `#203`) that landed on main BEFORE the implementation slices started. This kept the implementation PRs focused on code, and gave the implementation agents a stable target to read.
+
+The pattern is reusable: for any PRD-style workflow, the grill outcomes (CONTEXT.md updates, ADRs, plan amendments) ship as a precursor PR, not bundled with implementation.
+
+### D. The supervisor/worker SSH pattern
+
+When the user wanted "two-way live communication" between Claude sessions, the realistic answer was: I (the supervisor Claude on the Mac) SSH directly into the Linux box and run commands there. This gave the *outcome* of a supervisor-with-remote-worker pattern without the complexity of two independent Claude instances coordinating over a shared channel.
+
+This worked because:
+- The Mac already had passwordless SSH to the Linux box.
+- The supervisor Claude had full session context (no fresh-agent briefing needed).
+- The user could watch terminal output on the Linux box independently if they wanted.
+
+For long-running operations (fetches, backfills), we used `run_in_background: true` so the supervisor didn't block waiting for results.
+
+### E. Parallel agents on disjoint files
+
+When PR2's three slices (`#197`, `#198`, `#199`) could touch disjoint Ingester code paths, we tried to ship them in parallel via separate agents. This worked for `#199` (the catchup slice) — it merged cleanly. But `#198` (the backfill mode) and `#199` both touched `data-pipeline/ingester/lib/cli.js`, so when `#199` merged first, `#198`'s PR (`#215`) hit a merge conflict requiring a rebase. The rebase resolution took ~5 minutes.
+
+**Takeaway:** "disjoint logical paths" doesn't mean "disjoint files." Before parallelising, grep the planned changes for shared files. If there's overlap, serialise.
+
+---
+
+## Process gaps that hurt
+
+### A. Smoke-test ACs were honor-system
+
+Three PRs (`#220`, `#222`, `#229`) merged with smoke-test acceptance criteria marked done without anyone actually running the smoke test. PR #220 worked anyway because the code happened to be correct. PR #222 worked because the reviewer was thorough. PR #229 worked because the reviewer caught real bugs in code review.
+
+The recurring failure mode: agents that implemented the code never ran the binary, and reviewers accepted that. The first critical bug (`#219`) was caused by this pattern over three earlier PRs (`#197`, `#198`, `#199`).
+
+ADR `0006` addresses this for the data-pipeline subsystem going forward.
+
+### B. The `latestOnDisk` design coupling wasn't grilled at the right time
+
+The Backfill Orchestrator's `endDate` was hard-coded to `yesterdayUtc()`, but the on-disk archive doesn't always reach yesterday. This bit us during the first 7-day backfill test: the orchestrator tried to walk a date that had no files, the Ingester crashed on ENOENT, the run was marked failed.
+
+The fix (`#226`) was a one-line change. The bug should have been caught during the PR3 grill — when the orchestrator's range computation came up, "what if the disk doesn't reach yesterday?" wasn't asked. A good grill would have surfaced this; in retrospect, the grill leaned more on the *correctness* of the lifecycle (fresh / resume / failed) than the *robustness* of the range computation.
+
+**Takeaway:** for any auto-discovered input, ask "what if the discovery returns less than expected?" alongside "what if it returns nothing?"
+
+### C. The hardcoded `BACKFILL_START_DATE` in `run-backfill.sh` (`#234`)
+
+PR4's `run-backfill.sh` hardcoded `BACKFILL_START_DATE="2025-05-22"` — a value lifted from the example in `docs/InjestionPlan.md` §6.4 verbatim. Meaningful when the plan was authored; meaningless to a fresh operator. The first cron-driven backfill on a clean box would try to fetch ~8,760 files (over 2 hours of fetch).
+
+The PR4 grill specified that BACKFILL_START_DATE would be a hardcoded value — it just specified the wrong default-construction strategy. The grill should have specified "default to 1 year ago via `$(date -d ...)` at script invocation time," not "hardcoded `2025-05-22`."
+
+**Takeaway:** when a value is "configurable but with a default," the default should be computed from current state, not pinned to a snapshot value.
+
+### D. Cross-producer drift between Backfill and Hourly orchestrators (`#231`)
+
+When we URL-encoded the `--target-companies` argument in the Backfill Orchestrator (`#225` / PR #230), we forgot the Hourly Orchestrator also builds the same wire format and didn't encode it. The reviewer caught this and filed `#231` — but the fix is in a separate PR (a Sonnet agent picked it up later that day).
+
+This is a class of bug worth watching: when one of N producers of a wire format is updated, the others can silently drift. Either extract to a shared helper or audit grep-style before merging changes that affect a wire format.
+
+### E. The Cassandra container crashed mid-backfill due to operator action
+
+During the first 7-day backfill on the Linux box, Cassandra restarted at 17:53:46 — coincidentally just as the Ingester was writing. The cause was operator action (the user was debugging Reaper in a separate window and ran `docker compose up`, which restarted the whole stack), not a pipeline bug.
+
+The Backfill Orchestrator handled this correctly: detected the connection failure, tried to mark the run as failed (the marking failed too because Cassandra was still restarting), exited with an error. The next invocation found the `in_progress` row and resumed cleanly.
+
+**Takeaway:** the pipeline's failure-handling story works in practice. The orchestrator's "treat-failed-as-completed-on-next-run" semantics (from ADR 0003) handled the case correctly without operator intervention.
+
+---
+
+## Decisions worth understanding (the *why* behind the *what*)
+
+### Multi-org per Company (yes / no / yes)
+
+Early in the PR1 grill, I went back and forth on whether a Company has one Org or many. Final answer: **one Company → many Orgs.** Justified by real data — Wix actually has `wix`, `wix-incubator`, `wix-private`. The Cassandra `companies` table is keyed `((company), org_name)` to allow multiple rows per Company.
+
+This was the correct call. The data confirms it.
+
+### One CONTEXT.md vs two (CONTEXT-MAP.md)
+
+The grill considered whether the Cassandra Analytics pipeline was a separate bounded context from the JobFlow web app (separate CONTEXT.md files, a CONTEXT-MAP.md at the root) or one extended context. After seeing the merged glossary terms — Company, First Sighting, Company Scout, Active GitHub Presence — that bridge the two systems, we chose **one context**.
+
+This was the correct call. The pipeline isn't a separate domain; it's the analytics arm of the Company Scout's resolution.
+
+### processed_files is hourly-only (ADR 0005)
+
+The grill discussed whether Backfill should write to `processed_files` for crash recovery. Initially yes, then we discovered a subtle bug: if Backfill marks a file as done (for Company X), and later Company Y is added, the next backfill skips the file → Company Y never gets backfilled.
+
+Solution: `processed_files` is hourly-only. Backfill uses `backfill_progress` (per-date) for crash recovery instead. Each backfill walks every file in its range — wasteful for already-initialised companies but idempotent via the `company_events` primary key.
+
+This was the correct call. The data corruption scenario it prevents is a real one.
+
+### No automated tests in V1
+
+For all four PRDs, we explicitly skipped automated tests. The intent was speed: ship a working pipeline, manually smoke-test, add tests after the architecture stabilises.
+
+In hindsight: **mostly right, but smoke-test enforcement should have been more disciplined.** The honor-system smoke-test ACs let one critical bug ship (`#219`). ADR 0006 closes this loop for V1. V2's "production hardening" phase will introduce a real test suite for the data-pipeline subsystem.
+
+---
+
+## What to do differently next time
+
+1. **Grill more aggressively for failure modes, not just happy paths.** "What if the disk is empty / doesn't reach yesterday / has gaps / has too much?" should be standard grill questions for any auto-discovered input.
+
+2. **Smoke-test transcripts as a merge gate, not an honor-system AC.** ADR 0006 codifies this for the data-pipeline subsystem.
+
+3. **Defaults should be computed, not snapshotted.** Hardcoded values from example invocations are footguns. `BACKFILL_START_DATE` and similar "defaults with override" parameters should compute their defaults at invocation time.
+
+4. **Multi-producer wire formats need a single source of truth.** When N orchestrators produce the same CLI arg format, extract to a shared helper. Reviewers should flag any change that touches a wire-format producer without also touching the others.
+
+5. **For parallel agents, audit the touched files before parallelising.** Different logical paths don't mean different files. A 30-second `git grep` saves a 15-minute rebase later.
+
+6. **Keep grill outcomes in a precursor PR.** Land the ADRs and plan amendments BEFORE the implementation slices start. Implementation agents have a clean target to read; the implementation PRs stay focused on code.
+
+---
+
+## Things to remember for V2 / future work
+
+- The deferred backlog (`#210`, `#212`, `#213`, `#214`, `#227`) is real future work, not "abandoned" features. Each has clear acceptance criteria and a revival trigger.
+- The first cron-driven backfill on a fresh box will be expensive (potentially hours) because the BACKFILL_START_DATE default sets the first-fetch scope. After `#234` lands, this becomes "1 year ago" rather than the May 2025 hardcoded value.
+- Microsoft's volume dominates the dataset. Any analytics-quality concern (recall, precision, statistical relevance) needs to be evaluated with and without Microsoft as a separate slice.
+- The orchestrator's `latestOnDisk` change (`#226`) means the operator controls the backfill range by controlling what's on disk. The Fetcher's range is the upper bound; the Backfill auto-adapts.
+
+---
+
+## Closing
+
+V1 of the ingestion subsystem is a single-day project that shipped a complete, tested, deployed pipeline against real GH Archive data, with a deliberate "no automated tests" trade-off and a clear plan for what's deferred.
+
+Most of the surprises came from "the LLM/agent assumed a library API or operational property that wasn't actually true." Most of the wins came from "we grilled the design with the relevant docs before writing code, then trusted agents to implement against the grilled specification."
+
+The next time we run this playbook, the playbook itself should be smoother — ADR 0006 enforces smoke-test discipline, the runbook captures the deployment phases, and the followup issues capture the real bugs we didn't anticipate.

--- a/docs/adr/0006-smoke-test-transcripts-required.md
+++ b/docs/adr/0006-smoke-test-transcripts-required.md
@@ -1,0 +1,50 @@
+# ADR 0006: Smoke-test transcripts are required when smoke-test ACs are listed on a data-pipeline PR
+
+## Status
+Proposed
+
+## Context
+
+The JobFlow Analytics ingestion subsystem (PR1 Fetcher, PR2 Ingester, PR3 Orchestrators, PR4 Deployment wrapper) shipped over a single day in May 2026 across approximately 15 implementation PRs. Each PR's acceptance criteria included a "Manual smoke test passes (requires local `cassandra:4.1` container — not automated)" line. The intent was that an agent or human would actually run the binary against a live Cassandra container before declaring the PR done.
+
+What actually happened on three separate occasions:
+
+1. **PR #220 (`#219` critical Ingester fix)** — The agent that wrote the fix never ran the smoke test. All three smoke-test checkboxes in the PR body were unchecked. Later validation against the live Linux box confirmed the fix worked, but only by luck — the diff happened to be correct. The unreviewed smoke test could have hidden a real bug.
+
+2. **PR #222 (`#206` Backfill Orchestrator)** — Same gap. The agent's PR body listed several smoke tests as ACs; none were run. The reviewer noticed but the orchestrator merged before the actual smoke test was performed. The orchestrator turned out to work — but again, by luck.
+
+3. **PR #229 (`#208` Deployment wrapper)** — More disciplined: the agent ran `bash -n` and a `sed` dry-run, but did not actually run `bootstrap.sh` end-to-end on a Linux box. Two real bugs (PATH for nvm node, `HOME` hardcoding) were caught by code review and fixed before merge — but if the reviewer hadn't been thorough, they could have shipped silently and bitten the operator on the first cron-driven run.
+
+The original critical bug — PR #220's "Ingester cannot connect to Cassandra" (`#219`) — would not have shipped at all if the smoke-test AC had been enforced on PR2's three slices (`#197`, `#198`, `#199`). The agents who wrote those PRs marked their smoke-test ACs as "done" without running them. Three Ingester PRs merged green carrying a single bug that crashed the binary at startup.
+
+The pattern is consistent: when smoke-test ACs are honor-system, they get checked without being run. The data-pipeline subsystem's "no automated tests in v1" decision (from the original PR1 grill) was made knowing manual smoke tests would be the safety net. The safety net failed because nobody enforced the run.
+
+## Decision
+
+For any PR in the `data-pipeline/**` subsystem whose acceptance criteria include a "smoke test" line, the PR body **must** include a smoke-test transcript before the PR is reviewed.
+
+A transcript is a copy-paste of the actual command(s) the operator/agent ran plus the relevant output (the success log lines, the cqlsh queries that verify state, exit codes). It does not need to be long — three to ten lines covering "what was run, what was seen, what was verified" is sufficient. It must be against a live Cassandra container (not a mock, not a dry-run, not `bash -n`).
+
+Concretely:
+
+- The agent or human authoring the PR runs the smoke tests listed in the AC against a Cassandra container brought up from `data-pipeline/docker-compose.yml`.
+- The successful output is pasted into the PR description under a `## Smoke test transcript` section.
+- Reviewers **decline to approve** PRs that list smoke tests in the AC but do not include a transcript.
+- The reviewer's first action is to read the transcript and verify it actually shows the AC's expected behaviour (events written, rows present, exit code zero, etc.).
+
+A PR may explicitly opt out of this rule by removing the smoke-test ACs from its body (and explaining why in the PR description). The intent is to make the decision visible: either run the test or accept that you aren't running it. Silently marking the AC checkbox without running the test is what this ADR forbids.
+
+## Consequences
+
+- The PR cycle for data-pipeline work slows by roughly the wall-clock time of running the smoke test — typically 1–5 minutes. For an Ingester PR that processes one hourly archive file, this is 30–60 seconds. For an end-to-end Orchestrator PR, 2–3 minutes. The slowdown is small relative to a multi-hour PR review cycle.
+- Reviewers gain a concrete artefact to anchor their review against — instead of trusting a checkbox, they verify the output is consistent with the spec.
+- Agents that ship without running the test are filtered out at review time, not after merge. Bugs like `#219` that crashed the binary at startup are caught when the smoke test fails to produce a transcript.
+- The discipline is project-local: it applies to `data-pipeline/**` only. The web app's PRs (with their automated test suites) do not need this rule because their test pass already serves as the transcript.
+- The ADR does not require automated tests. The data-pipeline subsystem's "no automated tests in v1" decision (carried through PR1 → PR4) stands. This is purely about enforcing the manual-smoke-test discipline that was already part of every PR's AC.
+- When the operator decides to migrate to automated tests (likely after the secondary enrichment job and the production hardening phase land), this ADR can be archived as superseded by that test suite.
+
+## What this is not
+
+- It is not a rule that every data-pipeline change needs a smoke test. A docs-only PR (e.g., updates to `docs/InjestionPlan.md`) does not list a smoke-test AC and therefore does not need a transcript. The trigger is the smoke-test AC, not the file path.
+- It is not a rule about which Cassandra to test against. The team's `data-pipeline/docker-compose.yml` is the canonical environment; tests against a live Linux deployment also satisfy the rule (with an even higher confidence level).
+- It is not a substitute for proper test coverage when V2 introduces automated tests. The ADR is explicitly a v1 process discipline.

--- a/docs/runbooks/cassandra-pipeline-deployment.md
+++ b/docs/runbooks/cassandra-pipeline-deployment.md
@@ -1,0 +1,308 @@
+# Cassandra Pipeline Deployment Runbook
+
+Graduated rollout procedure for deploying the JobFlow Analytics ingestion pipeline on a single-host Linux box. Companion to `data-pipeline/SETUP.md` — SETUP.md covers the one-time prerequisites and `bootstrap.sh`; this runbook covers the validation phases that follow.
+
+Status: written 2026-05-23 after the first successful end-to-end deployment on a Xubuntu 24.04 LTS box (i9-9900K, 16 GB RAM, 480 GB SATA SSD, 2 TB HDD).
+
+---
+
+## Phase 0 — Host prerequisites
+
+Covered in `data-pipeline/SETUP.md`. Quick reference of what must be true before this runbook begins:
+
+- `node --version` is `≥ 20.6`
+- `docker compose version` shows v2.x
+- `cqlsh --version` shows 6.x
+- `mountpoint /mnt/hdd` says "is a mountpoint" (the 2 TB HDD)
+- The repo is cloned at a known path, e.g. `~/jobflow`
+- `.env` at the repo root configures the per-binary env (Cassandra contact points, GHARCHIVE_DIR, log level)
+- The operator has `sudo` access for the one-time cron file install
+
+If any of these fail, fix them before continuing.
+
+---
+
+## Phase 1 — Bootstrap (one-time, automated by `bootstrap.sh`)
+
+```bash
+cd ~/jobflow
+./data-pipeline/scripts/bootstrap.sh
+```
+
+The script's seven idempotent steps:
+1. Prerequisite check (the items in Phase 0).
+2. Verify `/mnt/hdd` is a real mount point (not just a directory).
+3. Create `/mnt/hdd/gharchive/` and `~/jobflow-logs/`.
+4. `docker compose up -d cassandra` and wait for healthcheck.
+5. Apply schemas 001–008 in numeric order via `cqlsh`.
+6. Install `/etc/cron.d/jobflow` with placeholders substituted (one `sudo` prompt here).
+7. Print summary and verification commands.
+
+**Pass criteria after Phase 1:**
+
+```bash
+docker ps --format "table {{.Names}}\t{{.Status}}"
+# Expect: jf-cassandra Up X minutes (healthy)
+
+docker exec jf-cassandra cqlsh -e "DESCRIBE KEYSPACE jobflow"
+# Expect: backfill_progress, backfill_runs, companies, company_events, processed_files
+
+sudo cat /etc/cron.d/jobflow
+# Expect: both cron lines with @USER@, @HOME@, @JOBFLOW_ROOT@, @NODE_BIN_DIR@ all substituted
+
+systemctl is-active cron
+# Expect: active
+```
+
+If any of these fail, do not proceed.
+
+---
+
+## Phase 2 — Single-file smoke test (Fetcher + Ingester direct)
+
+Goal: verify the Fetcher downloads cleanly and the Ingester writes events to Cassandra. Bypasses the orchestrator and the shell scripts — exercises the core binaries against real GH Archive data.
+
+```bash
+# 1. Seed one test company with initialized=true (so Ingester in hourly mode picks it up).
+docker exec jf-cassandra cqlsh -e "
+  INSERT INTO jobflow.companies (company, org_name, added_at, active, initialized)
+  VALUES ('microsoft', 'microsoft', toTimestamp(now()), true, true);
+"
+
+# 2. Fetch one known-good hour file.
+cd ~/jobflow/data-pipeline/fetcher
+node --env-file=../../.env fetcher.js --hour 2025-05-22-15
+ls /mnt/hdd/gharchive/2025/05/22/
+# Expect: 15.json.gz, ~140 MB
+
+# 3. Process it in hourly mode (no orchestrator needed).
+cd ~/jobflow/data-pipeline/ingester
+node --env-file=../../.env ingester.js \
+  --hour 2025-05-22-15 \
+  --mode hourly \
+  --target-companies microsoft:microsoft
+
+# 4. Verify.
+docker exec jf-cassandra cqlsh -e "
+  SELECT count(*) FROM jobflow.company_events
+  WHERE company='microsoft' AND year_month='2025-05';
+"
+docker exec jf-cassandra cqlsh -e "
+  SELECT file_name, event_count, filtered_count FROM jobflow.processed_files;
+"
+```
+
+**Pass criteria:** event count > 0, one row in `processed_files` with `file_name='2025-05-22-15'`.
+
+---
+
+## Phase 3 — Single-day backfill via the orchestrator (no shell script)
+
+Goal: verify the Backfill Orchestrator's full lifecycle — fresh-run detection, target_rows snapshot, Ingester subprocess spawn, LOGGED-BATCH flip of `initialized=true` at the end.
+
+```bash
+# 1. Reset the microsoft row back to initialized=false so the Backfill picks it up.
+docker exec jf-cassandra cqlsh -e "
+  UPDATE jobflow.companies SET initialized=false
+  WHERE company='microsoft' AND org_name='microsoft';
+"
+
+# 2. Wipe the archive and fetch yesterday's full day only (so the orchestrator's auto-discovered range is exactly one day).
+rm -rf /mnt/hdd/gharchive/*
+YESTERDAY=$(date -u -d 'yesterday' +%Y-%m-%d)
+cd ~/jobflow/data-pipeline/fetcher
+node --env-file=../../.env fetcher.js --range "$YESTERDAY" "$YESTERDAY"
+find /mnt/hdd/gharchive -name '*.json.gz' | wc -l
+# Expect: 24
+
+# 3. Run the Backfill Orchestrator.
+cd ~/jobflow/data-pipeline/orchestrators
+node --env-file=.env backfill.js
+
+# 4. Verify the end state.
+docker exec jf-cassandra cqlsh -e "
+  SELECT company, org_name, initialized, initialized_at FROM jobflow.companies
+  WHERE company='microsoft';
+"
+docker exec jf-cassandra cqlsh -e "
+  SELECT bucket, run_id, status, started_at, completed_at FROM jobflow.backfill_runs;
+"
+docker exec jf-cassandra cqlsh -e "
+  SELECT date, status, events_written FROM jobflow.backfill_progress;
+"
+```
+
+**Pass criteria:**
+- `companies.microsoft.initialized = true`, `initialized_at` matches `backfill_runs.completed_at`.
+- One `backfill_runs` row with `status='completed'`.
+- One `backfill_progress` row for yesterday, `status='completed'`, `events_written` matches `microsoft`'s actual activity that day.
+
+---
+
+## Phase 4 — Multi-day backfill at scale
+
+Goal: verify the orchestrator handles a larger range without resource issues, and exercises the resume path if anything crashes.
+
+Adapt the same pattern as Phase 3, but with a 7-day range:
+
+```bash
+START=$(date -u -d '7 days ago' +%Y-%m-%d)
+END=$(date -u -d 'yesterday' +%Y-%m-%d)
+
+rm -rf /mnt/hdd/gharchive/*
+cd ~/jobflow/data-pipeline/fetcher
+node --env-file=../../.env fetcher.js --range "$START" "$END"
+
+# Reset companies and run backfill.
+# (Seed your full set of companies here, all initialized=false.)
+docker exec jf-cassandra cqlsh -e "TRUNCATE jobflow.backfill_runs;"
+docker exec jf-cassandra cqlsh -e "TRUNCATE jobflow.backfill_progress;"
+
+cd ~/jobflow/data-pipeline/orchestrators
+node --env-file=.env backfill.js
+```
+
+**Pass criteria:**
+- `backfill_progress` has 7 rows, one per date, all `status='completed'`.
+- `backfill_runs` has one row, `status='completed'`.
+- Every target Company is `initialized=true`.
+
+**Optional resume test:** kill the orchestrator mid-run with Ctrl-C. Re-invoke `backfill.js`. Verify it logs `resuming run` and picks up at the next non-completed date.
+
+---
+
+## Phase 5 — Hourly orchestrator direct test
+
+Goal: verify the Hourly Orchestrator reads initialised companies, spawns the Ingester with `--catchup`, and processes new files.
+
+```bash
+# After Phase 4, all companies are initialized=true.
+cd ~/jobflow/data-pipeline/orchestrators
+node --env-file=.env hourly.js
+```
+
+**Pass criteria:**
+- Orchestrator logs `companies loaded — spawning ingester` with the right count.
+- Ingester catchup walks GHARCHIVE_DIR, processes any file not in `processed_files`, writes events.
+- `processed_files` count grows by however many new files were on disk.
+
+If `processed_files` is already complete for everything on disk, the Ingester logs `nothing to do` and exits 0.
+
+---
+
+## Phase 6 — Lock-coordination test (the load-bearing cron behaviour)
+
+Goal: verify `flock` actually skips an hourly run when a backfill is in progress.
+
+```bash
+# Terminal A: simulate a long-running backfill by holding the backfill lock.
+flock /var/lock/jobflow-backfill.lock sleep 600
+
+# Terminal B: invoke the hourly cron command verbatim (copy from /etc/cron.d/jobflow).
+flock -n /var/lock/jobflow-hourly.lock -c 'if flock -n /var/lock/jobflow-backfill.lock true; then ~/jobflow/data-pipeline/scripts/run-hourly.sh; else echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) skipping: backfill in progress" >> ~/jobflow-logs/hourly-skips.log; fi'
+
+# Verify the skip line was logged.
+tail -3 ~/jobflow-logs/hourly-skips.log
+# Expect: a line with "skipping: backfill in progress" and the current timestamp.
+
+# Verify the hourly main log is unchanged.
+ls -la ~/jobflow-logs/hourly.log
+# Expect: empty or unchanged from before Terminal B's invocation.
+```
+
+**Pass criteria:** the skip is logged to `hourly-skips.log` and not to `hourly.log`. No Ingester subprocess was spawned. Exit code 0.
+
+Then in Terminal A: `Ctrl-C` to release the lock.
+
+---
+
+## Phase 7 — Hand off to cron (the production cadence)
+
+After Phases 1–6 pass, the pipeline is operationally ready. Cron is already running (`/etc/cron.d/jobflow` was installed in Phase 1).
+
+**Validation:**
+
+1. **Hourly cron at the next `:15`** — wait for the next quarter-hour, then check `tail -100 ~/jobflow-logs/hourly.log` for a successful run.
+2. **Backfill cron at the next midnight** — if no Companies are uninitialised, expect a "nothing to do" log line. If a new Company was added recently, expect a full backfill cycle.
+
+After the first successful cron-driven hourly run, the operator's job is done: the pipeline is self-driving.
+
+---
+
+## Phase 8 — Add a new Company and let nightly backfill pick it up
+
+The realistic production cadence test:
+
+```bash
+# Insert a new Company with initialized=false.
+docker exec jf-cassandra cqlsh -e "
+  INSERT INTO jobflow.companies (company, org_name, added_at, active, initialized)
+  VALUES ('honeybook', 'honeybook', toTimestamp(now()), true, false);
+"
+
+# Wait until midnight. Cron fires run-backfill.sh.
+# Backfill Orchestrator detects honeybook is uninitialised, snapshots it as target_rows,
+# spawns Ingester to walk the full archive for the row, flips honeybook to initialized=true.
+
+# Next morning, verify:
+docker exec jf-cassandra cqlsh -e "SELECT company, initialized FROM jobflow.companies;"
+docker exec jf-cassandra cqlsh -e "
+  SELECT bucket, run_id, status, completed_at FROM jobflow.backfill_runs;
+"
+```
+
+**Pass criteria:** Honeybook is now `initialized=true`, a new `backfill_runs` row shows `status='completed'`, and `company_events` contains Honeybook events.
+
+---
+
+## Monitoring during the first week
+
+Once cron is running unattended, a quick daily check (~30 seconds) protects against silent drift:
+
+```bash
+tail -50 ~/jobflow-logs/backfill.log         # last night's backfill (or "nothing to do")
+tail -200 ~/jobflow-logs/hourly.log          # last 24 hours of hourly runs
+tail -20 ~/jobflow-logs/hourly-skips.log     # any unexpected skips
+
+docker exec jf-cassandra cqlsh -e "
+  SELECT count(*) FROM jobflow.company_events;
+"
+
+df -h /mnt/hdd                                # disk-space sanity
+```
+
+If any `FATAL` lines appear in any log, intervene. If `hourly-skips.log` grows during a period when no backfill should be running, investigate (likely a stuck lock file in `/var/lock/`).
+
+---
+
+## Resetting from scratch
+
+If state corruption requires a clean slate:
+
+```bash
+sudo systemctl stop cron
+
+# Reset Cassandra data via a temp container (no host sudo needed for the bind mount).
+docker compose -f ~/jobflow/data-pipeline/docker-compose.yml down
+docker run --rm -v /home/tomer/cassandra-data:/data --entrypoint sh cassandra:4.1 -c 'rm -rf /data/* /data/.[!.]*'
+
+# Wipe the archive.
+rm -rf /mnt/hdd/gharchive/*
+
+# Wipe logs.
+rm -rf ~/jobflow-logs
+
+# Remove cron file (will be reinstalled by bootstrap).
+sudo rm -f /etc/cron.d/jobflow
+
+# Remove stale lock files.
+sudo rm -f /var/lock/jobflow-*.lock
+
+# Restart with bootstrap.
+cd ~/jobflow
+./data-pipeline/scripts/bootstrap.sh
+
+sudo systemctl start cron
+```
+
+Then resume from Phase 2.


### PR DESCRIPTION
## Summary

End-of-day learning artifacts from the Cassandra pipeline V1 build (2026-05-23). No code changes — three new documents that capture process discipline, deployment procedure, and reflection.

These are part of a four-audience learning extraction. The other three audiences (operator memory, project-specific Claude memory, skill suggestions) live outside the repo — at `~/.claude/projects/-Users-itc-Desktop-jobflow/memory/` and `~/.claude/skills/SUGGESTIONS.md` — and are not in this PR.

## Files

### `docs/adr/0006-smoke-test-transcripts-required.md`
Documents the recurring failure mode in the data-pipeline subsystem during V1: smoke-test ACs marked done without running them, causing one critical bug (#219, Ingester startup crash) to ship across three Ingester PRs. Codifies the discipline going forward: data-pipeline PRs that list smoke-test ACs must include a `## Smoke test transcript` section in the PR body before review. The ADR explicitly limits its scope to `data-pipeline/**` and is intended to be retired when V2 introduces a real test suite.

### `docs/runbooks/cassandra-pipeline-deployment.md`
The graduated rollout procedure we built in chat over the course of the deployment session, distilled into a re-runnable document. Phase 0 (prerequisites) through Phase 8 (add-new-Company production cadence). Companion to `data-pipeline/SETUP.md` — SETUP covers one-time prerequisites + `bootstrap.sh`; the runbook covers validation phases that follow.

### `docs/RETROSPECTIVES/2026-05-23-cassandra-pipeline-v1.md`
The personal retrospective. The arc of the day, key technical surprises (cassandra-driver API mismatch, microsoft-dominates-volume reality, GH Archive throughput), process patterns that worked (grill → PRD → issues → ship), process gaps that hurt (smoke-test honor-system, `latestOnDisk` design coupling missed in grill), decisions worth understanding (multi-org, one-context, `processed_files` hourly-only, no automated tests), and recommendations for V2 + future projects.

## Test plan

- [ ] Documents render correctly on GitHub
- [ ] Cross-references between the three docs work (ADR → retrospective → runbook references are consistent)
- [ ] No code or behaviour changes — pure documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)