### PR TITLE
[Cassandra pipeline followup] run-backfill.sh: BACKFILL_START_DATE hardcoded; should default to 1y ago + env-overridable; END_DATE should also be overridable

### DIFF
--- a/data-pipeline/SETUP.md
+++ b/data-pipeline/SETUP.md
@@ -147,11 +147,19 @@ passed to the Fetcher and Backfill Orchestrator:
 | `BACKFILL_START_DATE` | `$(date -u -d '1 year ago' +%Y-%m-%d)` | Inclusive start of the range. |
 | `END_DATE` | `$(date -u -d 'yesterday' +%Y-%m-%d)` | Inclusive end of the range. |
 
-Both can be overridden in three places (later wins):
+Both can be overridden in three places. All three use the same `${VAR:-default}`
+mechanism — they only differ in persistence:
 
-1. The cron line or operator shell (e.g. `BACKFILL_START_DATE=2026-01-01 ./data-pipeline/scripts/run-backfill.sh`).
-2. The persistent `data-pipeline/.env` file (sourced after the defaults are set).
-3. A one-off invocation that exports the var before calling the script.
+1. **Inline on the cron line** in `/etc/cron.d/jobflow` — persistent across cron
+   invocations, but requires editing the installed cron file (and re-running
+   `bootstrap.sh` if you regenerate from the template).
+2. **`data-pipeline/.env`** — persistent across cron invocations; the
+   recommended place for a long-running custom backfill window.
+3. **Exported in the operator's shell** before a manual invocation — one-off,
+   lost on the next cron fire. Useful for ad-hoc backfills or smoke tests.
+
+`.env` is sourced *after* the script's defaults are assigned, so any value set
+there overwrites the default.
 
 The 1-year default matches the plan's stated yearly-coverage goal. Add a line
 like `BACKFILL_START_DATE=2024-01-01` to `data-pipeline/.env` for a persistent

--- a/data-pipeline/SETUP.md
+++ b/data-pipeline/SETUP.md
@@ -137,6 +137,26 @@ EOF
 Per-binary `.env.example` files live under `data-pipeline/{fetcher,ingester,orchestrators}/`
 for reference. The single `data-pipeline/.env` above is the one the cron scripts read.
 
+#### Backfill date-range overrides
+
+`run-backfill.sh` accepts two optional env vars that control the date range
+passed to the Fetcher and Backfill Orchestrator:
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `BACKFILL_START_DATE` | `$(date -u -d '1 year ago' +%Y-%m-%d)` | Inclusive start of the range. |
+| `END_DATE` | `$(date -u -d 'yesterday' +%Y-%m-%d)` | Inclusive end of the range. |
+
+Both can be overridden in three places (later wins):
+
+1. The cron line or operator shell (e.g. `BACKFILL_START_DATE=2026-01-01 ./data-pipeline/scripts/run-backfill.sh`).
+2. The persistent `data-pipeline/.env` file (sourced after the defaults are set).
+3. A one-off invocation that exports the var before calling the script.
+
+The 1-year default matches the plan's stated yearly-coverage goal. Add a line
+like `BACKFILL_START_DATE=2024-01-01` to `data-pipeline/.env` for a persistent
+custom backfill window.
+
 ---
 
 ## Step 2 — Run `bootstrap.sh`

--- a/data-pipeline/scripts/run-backfill.sh
+++ b/data-pipeline/scripts/run-backfill.sh
@@ -7,7 +7,11 @@ set -euo pipefail
 
 MIN_FREE_GB=50
 HDD_MOUNT="/mnt/hdd"
-BACKFILL_START_DATE="2025-05-22"
+
+# Default: 1 year of data, matching the plan's stated yearly-coverage goal.
+# Override via env on the cron line, the operator's shell, or data-pipeline/.env
+# (the .env block below runs after this line, so an override there still wins).
+BACKFILL_START_DATE="${BACKFILL_START_DATE:-$(date -u -d '1 year ago' +%Y-%m-%d)}"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 DATA_PIPELINE_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
@@ -35,7 +39,7 @@ fi
 
 cd "${REPO_ROOT}"
 
-END_DATE="$(date -u -d 'yesterday' +%Y-%m-%d)"
+END_DATE="${END_DATE:-$(date -u -d 'yesterday' +%Y-%m-%d)}"
 
 node data-pipeline/fetcher/fetcher.js --range "${BACKFILL_START_DATE}" "${END_DATE}"
 node data-pipeline/orchestrators/backfill.js

--- a/data-pipeline/scripts/run-backfill.sh
+++ b/data-pipeline/scripts/run-backfill.sh
@@ -39,6 +39,8 @@ fi
 
 cd "${REPO_ROOT}"
 
+# Also set after .env source above — .env entries for END_DATE still win.
+# Keep this assignment here (not hoisted) so that ordering invariant holds.
 END_DATE="${END_DATE:-$(date -u -d 'yesterday' +%Y-%m-%d)}"
 
 node data-pipeline/fetcher/fetcher.js --range "${BACKFILL_START_DATE}" "${END_DATE}"


### PR DESCRIPTION
## Summary
- Removed the hardcoded `BACKFILL_START_DATE="2025-05-22"` literal in `run-backfill.sh` and replaced it with a `$(date -u -d '1 year ago')` default that is overridable via env (command line, operator shell, or `data-pipeline/.env`).
- Made `END_DATE` env-overridable the same way; default behaviour (yesterday UTC) is unchanged.
- Documented the override mechanism in `data-pipeline/SETUP.md` §1.7.

## Acceptance criteria
- [x] `BACKFILL_START_DATE` defaults to `$(date -u -d '1 year ago' +%Y-%m-%d)` if unset.
- [x] `END_DATE` defaults to `$(date -u -d 'yesterday' +%Y-%m-%d)` if unset.
- [x] Both can be overridden via env var on the cron line, the operator's shell, or `data-pipeline/.env`.
- [x] No hardcoded date literals remain in `run-backfill.sh`.
- [x] Smoke test: override semantics demonstrated (transcript in commit message + below).
- [x] `run-hourly.sh` does not need this change (uses `--catchup`, no explicit date).
- [x] Update `data-pipeline/SETUP.md` to document the override behaviour and the recommended approach (set in `data-pipeline/.env` for persistent customisation).

## Smoke test
GNU `date -d '1 year ago'` is Linux-only; the host running this verification is macOS, so the smoke test stubs `date()` and exercises the `${VAR:-default}` mechanism that is the actual change. The five cases below show every combination behaves correctly. A `BACKFILL_START_DATE=2026-01-01 END_DATE=2026-01-31 ./data-pipeline/scripts/run-backfill.sh` invocation on the Xubuntu box (the criterion's named smoke test) will exercise the same overrides end-to-end on the next operator run.

```
[defaults]    BACKFILL_START_DATE=2025-05-23 END_DATE=2026-05-22
[start-only]  BACKFILL_START_DATE=2026-01-01 END_DATE=2026-05-22
[end-only]    BACKFILL_START_DATE=2025-05-23 END_DATE=2026-01-31
[both]        BACKFILL_START_DATE=2026-01-01 END_DATE=2026-01-31
[from-dotenv] BACKFILL_START_DATE=2024-06-15 END_DATE=2026-05-22
```

## Related
Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)