### PR TITLE
fix(data-pipeline): restructure processed_files to single-partition for O(1) catchup max lookup

### DIFF
--- a/data-pipeline/ingester/ingester.js
+++ b/data-pipeline/ingester/ingester.js
@@ -6,7 +6,7 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import pino from 'pino';
-import { hourIdToPath, enumerateRange, enumerateAllOnDisk } from 'disk-layout';
+import { hourIdToPath, enumerateRange, enumerateAllOnDisk, hourIdToMs } from 'disk-layout';
 import { parseCLI } from './lib/cli.js';
 import { CassandraWriter } from './lib/cassandra-writer.js';
 
@@ -88,7 +88,11 @@ if (cmd.verb === 'hour') {
     process.exit(0);
   }
   const maxProcessed = await writer.getMaxProcessedFile();
-  const pending = maxProcessed ? allOnDisk.filter(id => id > maxProcessed) : allOnDisk;
+  // Compare chronologically (hourIdToMs), not lexicographically — the hour
+  // component of the canonical hourId is unpadded (`YYYY-MM-DD-H`, 0–23), so
+  // string compare yields '…-9' > '…-10'. Using ms timestamps avoids the bug.
+  const maxMs = maxProcessed !== null ? hourIdToMs(maxProcessed) : null;
+  const pending = maxMs !== null ? allOnDisk.filter(id => hourIdToMs(id) > maxMs) : allOnDisk;
   const alreadyProcessed = allOnDisk.length - pending.length;
   logger.info(
     { total: allOnDisk.length, alreadyProcessed, toProcess: pending.length },
@@ -158,9 +162,11 @@ async function processHour(hourId) {
 
   // In --mode hourly: check processed_files for idempotency.
   // Catchup pre-filters to only unprocessed hours, so skip the query there.
+  // Compare chronologically (hourIdToMs), not lexicographically — see catchup
+  // block above for the unpadded-hour rationale.
   if (cmd.mode === 'hourly' && cmd.verb !== 'catchup') {
     const maxProcessed = await writer.getMaxProcessedFile();
-    if (maxProcessed !== null && hourId <= maxProcessed) {
+    if (maxProcessed !== null && hourIdToMs(hourId) <= hourIdToMs(maxProcessed)) {
       logger.info({ hourId }, 'already processed, skipping');
       return 0;
     }
@@ -296,7 +302,7 @@ async function processHour(hourId) {
   // In --mode hourly: mark file processed
   if (cmd.mode === 'hourly') {
     await writer.markFileProcessed(hourId);
-    logger.info({ hourId }, 'processed_files row written');
+    logger.info({ hourId, totalParsed, totalFiltered }, 'processed_files row written');
   }
 
   return totalFiltered;

--- a/data-pipeline/ingester/ingester.js
+++ b/data-pipeline/ingester/ingester.js
@@ -80,15 +80,15 @@ if (cmd.verb === 'hour') {
 } else if (cmd.verb === 'range') {
   hourIds = enumerateRange(cmd.start, cmd.end);
 } else if (cmd.verb === 'catchup') {
-  // catchup: walk disk, skip files already recorded in processed_files
+  // catchup: walk disk, find all hours after the highest already-processed hour
   const allOnDisk = enumerateAllOnDisk(GHARCHIVE_DIR);
   if (allOnDisk.length === 0) {
     logger.warn('no files in GHARCHIVE_DIR');
     await writer.shutdown();
     process.exit(0);
   }
-  const processedFlags = await Promise.all(allOnDisk.map(id => writer.isFileProcessed(id)));
-  const pending = allOnDisk.filter((_, i) => !processedFlags[i]);
+  const maxProcessed = await writer.getMaxProcessedFile();
+  const pending = maxProcessed ? allOnDisk.filter(id => id > maxProcessed) : allOnDisk;
   const alreadyProcessed = allOnDisk.length - pending.length;
   logger.info(
     { total: allOnDisk.length, alreadyProcessed, toProcess: pending.length },
@@ -156,10 +156,11 @@ process.exit(exitCode);
 async function processHour(hourId) {
   const filePath = hourIdToPath(GHARCHIVE_DIR, hourId);
 
-  // In --mode hourly: check processed_files for idempotency
-  if (cmd.mode === 'hourly') {
-    const alreadyDone = await writer.isFileProcessed(hourId);
-    if (alreadyDone) {
+  // In --mode hourly: check processed_files for idempotency.
+  // Catchup pre-filters to only unprocessed hours, so skip the query there.
+  if (cmd.mode === 'hourly' && cmd.verb !== 'catchup') {
+    const maxProcessed = await writer.getMaxProcessedFile();
+    if (maxProcessed !== null && hourId <= maxProcessed) {
       logger.info({ hourId }, 'already processed, skipping');
       return 0;
     }
@@ -294,7 +295,7 @@ async function processHour(hourId) {
 
   // In --mode hourly: mark file processed
   if (cmd.mode === 'hourly') {
-    await writer.markFileProcessed(hourId, totalParsed, totalFiltered);
+    await writer.markFileProcessed(hourId);
     logger.info({ hourId }, 'processed_files row written');
   }
 

--- a/data-pipeline/ingester/lib/cassandra-writer.js
+++ b/data-pipeline/ingester/lib/cassandra-writer.js
@@ -39,7 +39,7 @@ export class CassandraWriter {
     this._limit = null;
     this._insertCql = null;
     this._processedFilesInsertCql = null;
-    this._processedFilesSelectCql = null;
+    this._processedFilesMaxCql = null;
     this._backfillProgressInsertCql = null;
 
     // Partition write rate tracking
@@ -56,11 +56,11 @@ export class CassandraWriter {
       `INSERT INTO ${this._keyspace}.company_events
          (company, org_name, year_month, event_time, event_id, event_type, repo_name, actor_login, is_ai, tech_tags)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
-    this._processedFilesSelectCql =
-      `SELECT file_name FROM ${this._keyspace}.processed_files WHERE file_name = ?`;
+    this._processedFilesMaxCql =
+      `SELECT file_name FROM ${this._keyspace}.processed_files WHERE bucket = ? LIMIT 1`;
     this._processedFilesInsertCql =
-      `INSERT INTO ${this._keyspace}.processed_files (file_name, processed_at, event_count, filtered_count)
-       VALUES (?, ?, ?, ?)`;
+      `INSERT INTO ${this._keyspace}.processed_files (bucket, file_name, processed_at)
+       VALUES (?, ?, ?)`;
     this._backfillProgressInsertCql =
       `INSERT INTO ${this._keyspace}.backfill_progress (run_id, date, status, completed_at, events_written)
        VALUES (?, ?, ?, ?, ?)`;
@@ -87,9 +87,9 @@ export class CassandraWriter {
     if (this._rateTimer) clearInterval(this._rateTimer);
   }
 
-  async isFileProcessed(fileName) {
-    const result = await this._client.execute(this._processedFilesSelectCql, [fileName], { prepare: true });
-    return result.rowLength > 0;
+  async getMaxProcessedFile() {
+    const result = await this._client.execute(this._processedFilesMaxCql, ['singleton'], { prepare: true });
+    return result.rowLength > 0 ? result.rows[0].file_name : null;
   }
 
   async writeEvent(event) {
@@ -208,10 +208,10 @@ export class CassandraWriter {
     }
   }
 
-  async markFileProcessed(fileName, eventCount, filteredCount) {
+  async markFileProcessed(fileName) {
     await this._client.execute(
       this._processedFilesInsertCql,
-      [fileName, new Date(), eventCount, filteredCount],
+      ['singleton', fileName, new Date()],
       { prepare: true }
     );
   }

--- a/data-pipeline/ingester/lib/cassandra-writer.js
+++ b/data-pipeline/ingester/lib/cassandra-writer.js
@@ -40,7 +40,7 @@ export class CassandraWriter {
     this._limit = null;
     this._insertCql = null;
     this._processedFilesInsertCql = null;
-    this._processedFilesScanCql = null;
+    this._processedFilesMaxCql = null;
     this._backfillProgressInsertCql = null;
 
     // Partition write rate tracking
@@ -57,17 +57,13 @@ export class CassandraWriter {
       `INSERT INTO ${this._keyspace}.company_events
          (company, org_name, year_month, event_time, event_id, event_type, repo_name, actor_login, is_ai, tech_tags)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
-    // Scan the singleton partition and compute the chronological max in JS.
-    // We cannot use `LIMIT 1` on the clustered DESC table because `file_name`
-    // sorts lexicographically and the canonical hour ID has an unpadded hour
-    // component (`YYYY-MM-DD-H`, 0–23), so `'…-9' > '…-10'` as strings.
-    // Scanning the whole partition once is a single round-trip; the partition
-    // stays bounded (~26k rows per 3 years of hourly ingest).
-    this._processedFilesScanCql =
-      `SELECT file_name FROM ${this._keyspace}.processed_files WHERE bucket = ?`;
+    // LIMIT 1 on the hour_time DESC clustering column is a true O(1) key lookup —
+    // timestamp sorts chronologically, so the first row is always the latest hour.
+    this._processedFilesMaxCql =
+      `SELECT file_name FROM ${this._keyspace}.processed_files WHERE bucket = ? LIMIT 1`;
     this._processedFilesInsertCql =
-      `INSERT INTO ${this._keyspace}.processed_files (bucket, file_name, processed_at)
-       VALUES (?, ?, ?)`;
+      `INSERT INTO ${this._keyspace}.processed_files (bucket, hour_time, file_name, processed_at)
+       VALUES (?, ?, ?, ?)`;
     this._backfillProgressInsertCql =
       `INSERT INTO ${this._keyspace}.backfill_progress (run_id, date, status, completed_at, events_written)
        VALUES (?, ?, ?, ?, ?)`;
@@ -95,22 +91,10 @@ export class CassandraWriter {
   }
 
   // Returns the chronologically latest processed file_name, or null if none.
-  // Single Cassandra round-trip (paged read of the singleton partition).
-  // Max is computed in JS via hourIdToMs so the ordering is chronological,
-  // not lexicographic — the hour component of file_name is unpadded.
+  // O(1): LIMIT 1 on the hour_time DESC clustering column is a direct key lookup.
   async getMaxProcessedFile() {
-    const result = await this._client.execute(this._processedFilesScanCql, ['singleton'], { prepare: true });
-    if (result.rowLength === 0) return null;
-    let maxId = null;
-    let maxMs = -Infinity;
-    for (const row of result.rows) {
-      const ms = hourIdToMs(row.file_name);
-      if (ms > maxMs) {
-        maxMs = ms;
-        maxId = row.file_name;
-      }
-    }
-    return maxId;
+    const result = await this._client.execute(this._processedFilesMaxCql, ['singleton'], { prepare: true });
+    return result.rowLength > 0 ? result.rows[0].file_name : null;
   }
 
   async writeEvent(event) {
@@ -232,7 +216,7 @@ export class CassandraWriter {
   async markFileProcessed(fileName) {
     await this._client.execute(
       this._processedFilesInsertCql,
-      ['singleton', fileName, new Date()],
+      ['singleton', new Date(hourIdToMs(fileName)), fileName, new Date()],
       { prepare: true }
     );
   }

--- a/data-pipeline/ingester/lib/cassandra-writer.js
+++ b/data-pipeline/ingester/lib/cassandra-writer.js
@@ -1,5 +1,6 @@
 import cassandra from 'cassandra-driver';
 import pLimit from 'p-limit';
+import { hourIdToMs } from 'disk-layout';
 
 const { Client, types, errors } = cassandra;
 
@@ -39,7 +40,7 @@ export class CassandraWriter {
     this._limit = null;
     this._insertCql = null;
     this._processedFilesInsertCql = null;
-    this._processedFilesMaxCql = null;
+    this._processedFilesScanCql = null;
     this._backfillProgressInsertCql = null;
 
     // Partition write rate tracking
@@ -56,8 +57,14 @@ export class CassandraWriter {
       `INSERT INTO ${this._keyspace}.company_events
          (company, org_name, year_month, event_time, event_id, event_type, repo_name, actor_login, is_ai, tech_tags)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
-    this._processedFilesMaxCql =
-      `SELECT file_name FROM ${this._keyspace}.processed_files WHERE bucket = ? LIMIT 1`;
+    // Scan the singleton partition and compute the chronological max in JS.
+    // We cannot use `LIMIT 1` on the clustered DESC table because `file_name`
+    // sorts lexicographically and the canonical hour ID has an unpadded hour
+    // component (`YYYY-MM-DD-H`, 0–23), so `'…-9' > '…-10'` as strings.
+    // Scanning the whole partition once is a single round-trip; the partition
+    // stays bounded (~26k rows per 3 years of hourly ingest).
+    this._processedFilesScanCql =
+      `SELECT file_name FROM ${this._keyspace}.processed_files WHERE bucket = ?`;
     this._processedFilesInsertCql =
       `INSERT INTO ${this._keyspace}.processed_files (bucket, file_name, processed_at)
        VALUES (?, ?, ?)`;
@@ -87,9 +94,23 @@ export class CassandraWriter {
     if (this._rateTimer) clearInterval(this._rateTimer);
   }
 
+  // Returns the chronologically latest processed file_name, or null if none.
+  // Single Cassandra round-trip (paged read of the singleton partition).
+  // Max is computed in JS via hourIdToMs so the ordering is chronological,
+  // not lexicographic — the hour component of file_name is unpadded.
   async getMaxProcessedFile() {
-    const result = await this._client.execute(this._processedFilesMaxCql, ['singleton'], { prepare: true });
-    return result.rowLength > 0 ? result.rows[0].file_name : null;
+    const result = await this._client.execute(this._processedFilesScanCql, ['singleton'], { prepare: true });
+    if (result.rowLength === 0) return null;
+    let maxId = null;
+    let maxMs = -Infinity;
+    for (const row of result.rows) {
+      const ms = hourIdToMs(row.file_name);
+      if (ms > maxMs) {
+        maxMs = ms;
+        maxId = row.file_name;
+      }
+    }
+    return maxId;
   }
 
   async writeEvent(event) {

--- a/data-pipeline/schema/009_processed_files_single_partition.cql
+++ b/data-pipeline/schema/009_processed_files_single_partition.cql
@@ -3,14 +3,11 @@
 -- --catchup mode (one per on-disk hour). With 3,426 on-disk files, this hit the
 -- cassandra-driver default pooling.maxRequestsPerConnection = 2048 limit.
 --
--- New design: single partition (bucket='singleton'). The catchup query is a single
--- Cassandra round-trip (paged scan of the singleton partition); the chronological
--- max is computed in JS via hourIdToMs(). The clustering order is DESC for operator
--- convenience when reading via cqlsh, but the APPLICATION MUST NOT rely on the
--- on-wire order — file_name has an unpadded hour component (YYYY-MM-DD-H, 0–23),
--- so a lexicographic LIMIT 1 against the clustering order returns the wrong row
--- (e.g. '…-9' beats '…-23' as a string). The application reads all rows and picks
--- the max chronologically. The DESC ordering is a cqlsh nicety only.
+-- New design: single partition (bucket='singleton'), clustering on hour_time (timestamp).
+-- Cassandra timestamps sort chronologically, so LIMIT 1 on the DESC clustering column
+-- returns the latest processed hour in a true O(1) key lookup — no JS max scan needed.
+-- hour_time is computed from file_name on write (hourIdToMs); file_name is stored as a
+-- regular column so the application can return the original string to callers.
 --
 -- Trade-off: hot-partition anti-pattern accepted because deployment is single-node Cassandra.
 -- Future multi-node topology would require repartitioning (e.g. bucket=YYYY).
@@ -24,7 +21,8 @@ DROP TABLE IF EXISTS jobflow.processed_files;
 
 CREATE TABLE jobflow.processed_files (
     bucket       text,
+    hour_time    timestamp,
     file_name    text,
     processed_at timestamp,
-    PRIMARY KEY (bucket, file_name)
-) WITH CLUSTERING ORDER BY (file_name DESC);
+    PRIMARY KEY (bucket, hour_time)
+) WITH CLUSTERING ORDER BY (hour_time DESC);

--- a/data-pipeline/schema/009_processed_files_single_partition.cql
+++ b/data-pipeline/schema/009_processed_files_single_partition.cql
@@ -1,0 +1,22 @@
+-- Restructure processed_files to single-partition design for O(1) catchup max lookup.
+-- The original table keyed on file_name alone, requiring N concurrent SELECT queries in
+-- --catchup mode (one per on-disk hour). With 3,426 on-disk files, this hit the
+-- cassandra-driver default pooling.maxRequestsPerConnection = 2048 limit.
+--
+-- New design: single partition (bucket='singleton') with CLUSTERING ORDER BY DESC.
+-- Catchup now reads MAX(file_name) in one query → filter by id > max.
+--
+-- Trade-off: hot-partition anti-pattern accepted because deployment is single-node Cassandra.
+-- Future multi-node topology would require repartitioning (e.g. bucket=YYYY).
+-- See ADR 0007 for full rationale.
+--
+-- Production processed_files is empty at migration time → drop+recreate with no data loss.
+
+DROP TABLE IF EXISTS jobflow.processed_files;
+
+CREATE TABLE jobflow.processed_files (
+    bucket       text,
+    file_name    text,
+    processed_at timestamp,
+    PRIMARY KEY (bucket, file_name)
+) WITH CLUSTERING ORDER BY (file_name DESC);

--- a/data-pipeline/schema/009_processed_files_single_partition.cql
+++ b/data-pipeline/schema/009_processed_files_single_partition.cql
@@ -1,16 +1,24 @@
--- Restructure processed_files to single-partition design for O(1) catchup max lookup.
+-- Restructure processed_files to single-partition design.
 -- The original table keyed on file_name alone, requiring N concurrent SELECT queries in
 -- --catchup mode (one per on-disk hour). With 3,426 on-disk files, this hit the
 -- cassandra-driver default pooling.maxRequestsPerConnection = 2048 limit.
 --
--- New design: single partition (bucket='singleton') with CLUSTERING ORDER BY DESC.
--- Catchup now reads MAX(file_name) in one query → filter by id > max.
+-- New design: single partition (bucket='singleton'). The catchup query is a single
+-- Cassandra round-trip (paged scan of the singleton partition); the chronological
+-- max is computed in JS via hourIdToMs(). The clustering order is DESC for operator
+-- convenience when reading via cqlsh, but the APPLICATION MUST NOT rely on the
+-- on-wire order — file_name has an unpadded hour component (YYYY-MM-DD-H, 0–23),
+-- so a lexicographic LIMIT 1 against the clustering order returns the wrong row
+-- (e.g. '…-9' beats '…-23' as a string). The application reads all rows and picks
+-- the max chronologically. The DESC ordering is a cqlsh nicety only.
 --
 -- Trade-off: hot-partition anti-pattern accepted because deployment is single-node Cassandra.
 -- Future multi-node topology would require repartitioning (e.g. bucket=YYYY).
 -- See ADR 0007 for full rationale.
 --
 -- Production processed_files is empty at migration time → drop+recreate with no data loss.
+-- IMPORTANT: re-running this migration on a populated table will wipe its rows.
+-- Operator precondition: `SELECT COUNT(*) FROM jobflow.processed_files;` must return 0.
 
 DROP TABLE IF EXISTS jobflow.processed_files;
 

--- a/docs/adr/0007-processed-files-single-partition.md
+++ b/docs/adr/0007-processed-files-single-partition.md
@@ -28,13 +28,21 @@ CREATE TABLE processed_files (
 ) WITH CLUSTERING ORDER BY (file_name DESC);
 ```
 
-Catchup query becomes a single round-trip:
+Catchup query becomes a single round-trip (paged scan of the singleton partition):
 
 ```cql
-SELECT file_name FROM processed_files WHERE bucket='singleton' LIMIT 1;
+SELECT file_name FROM processed_files WHERE bucket='singleton';
 ```
 
-Catchup logic becomes: `pending = ondisk.filter(id > max)` (lexicographic, works because `file_name` format is `YYYY-MM-DD-HH`).
+The chronological max is computed in JS via `hourIdToMs()`. Catchup logic becomes:
+`pending = ondisk.filter(id => hourIdToMs(id) > hourIdToMs(max))`.
+
+A `LIMIT 1` plus lexicographic ordering does **not** work because the canonical
+hour ID format is `YYYY-MM-DD-H` (hour unpadded, 0–23) — string compare yields
+`'2025-05-01-9' > '2025-05-01-10'`, which would silently skip 14 of every 24
+hours per day. Computing the max chronologically via `hourIdToMs` avoids this.
+Scanning the whole partition stays cheap because it is bounded (~9k rows/year of
+hourly ingest; ~26k after 3 years) and is a single paged round-trip.
 
 The `event_count` and `filtered_count` columns from the original schema are dropped — they were never read back, only written for ad-hoc observability.
 

--- a/docs/adr/0007-processed-files-single-partition.md
+++ b/docs/adr/0007-processed-files-single-partition.md
@@ -1,0 +1,64 @@
+# ADR 0007 — `processed_files` restructured to single-partition for O(1) catchup max lookup
+
+**Status:** Accepted  
+**Date:** 2026-05-24
+
+## Context
+
+On 2026-05-23, `ingester --catchup` crashed in production with:
+
+```
+NoHostAvailableError → BusyConnectionError: 2048 requests in-flight on a single connection
+```
+
+The crash was caused by `ingester.js` firing `Promise.all` of `writer.isFileProcessed(id)` over every on-disk hour ID (3,426 at the time), exceeding the cassandra-driver default `pooling.maxRequestsPerConnection = 2048`. The bug was latent — it worked through the January backfill (which used `--range`) and a smaller smoke test, but manifested once the on-disk archive grew past 2,048 files.
+
+The root insight: because the hourly ingester processes files strictly in chronological order and stops on first failure, `processed_files` is always a contiguous prefix `{H₀ … H_max}`. Catchup only needs `MAX(file_name)`, not per-file set membership.
+
+## Decision
+
+Restructure `processed_files` with a `(bucket, file_name)` composite primary key and `CLUSTERING ORDER BY (file_name DESC)`. All rows use `bucket = 'singleton'`.
+
+```cql
+CREATE TABLE processed_files (
+    bucket       text,
+    file_name    text,
+    processed_at timestamp,
+    PRIMARY KEY (bucket, file_name)
+) WITH CLUSTERING ORDER BY (file_name DESC);
+```
+
+Catchup query becomes a single round-trip:
+
+```cql
+SELECT file_name FROM processed_files WHERE bucket='singleton' LIMIT 1;
+```
+
+Catchup logic becomes: `pending = ondisk.filter(id > max)` (lexicographic, works because `file_name` format is `YYYY-MM-DD-HH`).
+
+The `event_count` and `filtered_count` columns from the original schema are dropped — they were never read back, only written for ad-hoc observability.
+
+## Consequences
+
+**Positive:**
+- Catchup startup is now O(1) regardless of on-disk archive size.
+- `BusyConnectionError` cannot recur from this code path.
+- Schema is simpler (two PK columns, one data column).
+
+**Negative / trade-offs:**
+- **Hot partition anti-pattern:** all rows land in the single `bucket='singleton'` partition. On a single-node Cassandra deployment this is acceptable — there is no intra-cluster imbalance. If the deployment ever becomes multi-node, this partition will become a hotspot and would need repartitioning (e.g. `bucket = YYYY` to spread across 12+ partitions per year).
+- **Schema migration is destructive:** changing the primary key requires `DROP TABLE + CREATE TABLE`. Safe here because `processed_files` was empty in production at migration time.
+- **Contiguity assumption:** `getMaxProcessedFile()` + `id > max` filtering is only correct if `processed_files` is a contiguous prefix. This invariant is maintained by the hourly ingester's sequential, break-on-first-failure processing. If a future change introduces non-sequential processing, this approach would need revisiting.
+
+## Alternatives considered
+
+1. **Raise `maxRequestsPerConnection`** — symptom fix; doesn't scale past the next doubling of the archive.
+2. **Serialize the per-file checks** — fixes the concurrency issue but adds O(N) sequential round-trips to catchup startup.
+3. **Truncate `processed_files` between catchup runs** — would break the hourly idempotency invariant (hourly mode relies on the table persisting across invocations).
+4. **`bucket = YYYY` partitioning** — correct for multi-node but unnecessary complexity for the current single-node deployment.
+
+## Related
+
+- ADR 0005 — `processed_files` is hourly-only (its "No schema change" claim is superseded by this ADR)
+- ADR 0003 — Backfill/Hourly relay-race (the `initialized` flag that keeps backfill out of `processed_files`)
+- Issue #238

--- a/docs/adr/0007-processed-files-single-partition.md
+++ b/docs/adr/0007-processed-files-single-partition.md
@@ -17,41 +17,38 @@ The root insight: because the hourly ingester processes files strictly in chrono
 
 ## Decision
 
-Restructure `processed_files` with a `(bucket, file_name)` composite primary key and `CLUSTERING ORDER BY (file_name DESC)`. All rows use `bucket = 'singleton'`.
+Restructure `processed_files` with `(bucket, hour_time)` as the primary key, where `hour_time` is a `timestamp` derived from `file_name` on write. All rows use `bucket = 'singleton'`. `file_name` is stored as a regular column.
 
 ```cql
 CREATE TABLE processed_files (
     bucket       text,
+    hour_time    timestamp,
     file_name    text,
     processed_at timestamp,
-    PRIMARY KEY (bucket, file_name)
-) WITH CLUSTERING ORDER BY (file_name DESC);
+    PRIMARY KEY (bucket, hour_time)
+) WITH CLUSTERING ORDER BY (hour_time DESC);
 ```
 
-Catchup query becomes a single round-trip (paged scan of the singleton partition):
+Catchup query is a true O(1) key lookup:
 
 ```cql
-SELECT file_name FROM processed_files WHERE bucket='singleton';
+SELECT file_name FROM processed_files WHERE bucket='singleton' LIMIT 1;
 ```
 
-The chronological max is computed in JS via `hourIdToMs()`. Catchup logic becomes:
-`pending = ondisk.filter(id => hourIdToMs(id) > hourIdToMs(max))`.
+Cassandra timestamps sort chronologically, so `LIMIT 1` on the `hour_time DESC` clustering column returns the latest processed hour directly — no JS iteration over the partition needed.
 
-A `LIMIT 1` plus lexicographic ordering does **not** work because the canonical
-hour ID format is `YYYY-MM-DD-H` (hour unpadded, 0–23) — string compare yields
-`'2025-05-01-9' > '2025-05-01-10'`, which would silently skip 14 of every 24
-hours per day. Computing the max chronologically via `hourIdToMs` avoids this.
-Scanning the whole partition stays cheap because it is bounded (~9k rows/year of
-hourly ingest; ~26k after 3 years) and is a single paged round-trip.
+On write, `markFileProcessed(fileName)` converts `file_name → hour_time` once via `hourIdToMs()`. The canonical hour ID format is `YYYY-MM-DD-H` (hour unpadded, 0–23); clustering on `file_name text` directly would sort lexicographically and break `LIMIT 1` (`'…-9' > '…-10'` as strings). A `timestamp` column avoids this entirely.
+
+Catchup filter: `pending = ondisk.filter(id => hourIdToMs(id) > hourIdToMs(max))`.
 
 The `event_count` and `filtered_count` columns from the original schema are dropped — they were never read back, only written for ad-hoc observability.
 
 ## Consequences
 
 **Positive:**
-- Catchup startup is now O(1) regardless of on-disk archive size.
+- Catchup startup is O(1): one `LIMIT 1` key lookup, no partition scan, no JS loop.
 - `BusyConnectionError` cannot recur from this code path.
-- Schema is simpler (two PK columns, one data column).
+- Timestamp clustering is semantically correct and self-documenting.
 
 **Negative / trade-offs:**
 - **Hot partition anti-pattern:** all rows land in the single `bucket='singleton'` partition. On a single-node Cassandra deployment this is acceptable — there is no intra-cluster imbalance. If the deployment ever becomes multi-node, this partition will become a hotspot and would need repartitioning (e.g. `bucket = YYYY` to spread across 12+ partitions per year).
@@ -64,6 +61,8 @@ The `event_count` and `filtered_count` columns from the original schema are drop
 2. **Serialize the per-file checks** — fixes the concurrency issue but adds O(N) sequential round-trips to catchup startup.
 3. **Truncate `processed_files` between catchup runs** — would break the hourly idempotency invariant (hourly mode relies on the table persisting across invocations).
 4. **`bucket = YYYY` partitioning** — correct for multi-node but unnecessary complexity for the current single-node deployment.
+5. **Zero-pad `file_name` on write, cluster on `file_name DESC`** — would make lexicographic order match chronological order and allow `LIMIT 1`. Rejected: requires a string transformation convention that isn't enforced by the type system; timestamp clustering expresses the intent directly and is enforced by Cassandra.
+6. **Partition scan + JS max** — was applied as an intermediate fix by the code reviewer. Correct but O(N) in partition size; superseded by the timestamp clustering approach.
 
 ## Related
 

--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -1,0 +1,26 @@
+# Knowledge Base Learnings
+
+Append-only log of what worked, what didn't, and what to adjust next time. One bullet per observation, dated. Newest at the top.
+
+Use this when:
+- A raw/ ingest required guesswork that a schema change would have prevented
+- A wiki page format turned out to be unhelpful when re-read in a later session
+- A wikilink convention created ambiguity
+- Reciprocal linking was forgotten and caused dead-ends
+- A page got stale because we didn't notice a code change
+
+Each entry: **what happened → what we'd change**. Skip generic platitudes.
+
+---
+
+## 2026-05-24
+
+- **`processed_files` schema change reveals that "No schema change" claims in ADRs age poorly.** ADR 0005 explicitly said "No schema change" and that claim became incorrect when issue #238 restructured the table. Future ADRs that make "no X" claims should include a "what would invalidate this" section so stale markers are easier to find. → Added superseded warning inline in [[adr-0005-processed-files-hourly-only]] rather than deleting it; linking pattern between ADRs is more durable than rewriting history.
+
+## 2026-05-23
+
+- **Wired the knowledge base into 8 daily skills/commands** so the patterns trigger without conscious effort: `grill-with-docs`, `write-a-prd`, `prd-to-issues`, `ship`, `gitflow`, `orchestrate-review`, `tdd`, `to-prd`. Each got a pre-load step (read `wiki/index.md` + grep), citation discipline (use `[[wikilinks]]` instead of re-explaining), and a capture step (save outputs to `raw/`, edit affected wiki pages, append learnings). `ship` and `gitflow` now have a mandatory "wiki update gate" between PR creation and code review — same shape as a tests-must-pass gate. `orchestrate-review` now instructs sub-agents to cite the `[[wikilink]]`/ADR being violated when flagging issues, and to post a "Knowledge-base proposals from this review" comment in Phase 3. → Couldn't wire `/verify` (not installed locally) or `/code-review` (plugin command — would be overwritten on plugin update). If those are wanted, the universal 4-line block from the earlier suggestion would have to be added by hand on each plugin upgrade.
+
+- **Bootstrapped the knowledge base.** Schema in `CLAUDE.md`, flat `wiki/`, hook on `UserPromptSubmit` checking `raw/.processed.json`. Seeded with pointers to `CONTEXT.md`, `MEMORY.md`, ADRs, and CassandraPlan rather than duplicating them. → Next ingest will tell us whether the manifest+hook combo actually nudges processing, or whether it needs to be more aggressive.
+- **Mistake: left ADR pages as unresolved wikilinks.** First bootstrap pass referenced ADRs in `index.md` as `[[adr-NNNN-...]]` but never created the mirror pages. The schema allows unresolved links, but the user expected `docs/` content to be *covered*, not just *pointed at*. → Next time, when seeding from a known-finite source (the `docs/` folder), enumerate everything in it first and create the wiki pages in the same pass — don't leave finite, known-good sources as TODOs.
+- **Mistake: referenced the wrong CassandraPlan.** Initial seed pointed at `/CassandraPlan.md` (root, older v1) instead of `docs/CassandraPlan.md` (v2, canonical, supersedes v1). The v2 explicitly says `Supersedes: v1`. → When a file appears in two locations, read both headers before deciding which is canonical; don't assume the root copy wins.

--- a/knowledge/wiki/adr-0005-processed-files-hourly-only.md
+++ b/knowledge/wiki/adr-0005-processed-files-hourly-only.md
@@ -1,0 +1,47 @@
+---
+title: ADR 0005 — `processed_files` is hourly-only
+slug: adr-0005-processed-files-hourly-only
+type: decision
+tags: [cassandra, pipeline, ingestion, idempotency]
+sources:
+  - docs/adr/0005-processed-files-hourly-only.md
+related: [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[backfill-run]] [[ingestion-pipeline]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0007-processed-files-single-partition]]
+updated: 2026-05-24
+status: stable
+adr_status: proposed
+---
+
+# ADR 0005 — `processed_files` is hourly-only; Backfill uses `backfill_progress`
+
+> Canonical text: `docs/adr/0005-processed-files-hourly-only.md`.
+
+> ⚠️ **Schema note (2026-05-24):** The "No schema change" claim below is superseded. [[adr-0007-processed-files-single-partition]] restructured `processed_files` to `(bucket, file_name)` PK with `CLUSTERING ORDER BY (file_name DESC)` to fix an O(N) concurrent-SELECT crash in `--catchup`. ADR 0005's core decision — backfill does not use `processed_files` — is unchanged.
+
+## TL;DR
+
+`processed_files` is **only** read/written when the Ingester runs in `--mode hourly`. In `--mode backfill` the table is untouched. Backfill crash recovery is per-date via `backfill_progress` instead.
+
+## The bug this prevents
+
+`processed_files` keys on **file name alone**, with no notion of "done for which target set." That caused this loss scenario:
+
+1. Backfill Run starts at midnight targeting Company X.
+2. Company Scout adds Company Y at 02:30 (`initialized = false`).
+3. Backfill keeps adding rows to `processed_files` ("file done") — but only Company X's events were written.
+4. Next night's Backfill targets Company Y, but every file looks "done" already → **Company Y's historical events are never written**.
+
+## Why this approach over alternatives
+
+- **Per-(file, target-set) keying** — correct but expensive (24 × dates × runs rows + hash comparisons).
+- **Truncate `processed_files` between runs** — breaks the hourly mode, which relies on the table across invocations.
+- **Stop using it for Backfill entirely** ← chosen. Backfill resumes at the *date* granularity from `backfill_progress`.
+
+## Knock-on effects
+
+- Each Backfill Run re-reads the full local archive for its `target_companies`. Wasted CPU + disk for already-initialised Companies, but their `company_events` writes are upserts → no duplicates. ~470 GB compressed per year; acceptable cost.
+- Backfill crash recovery has coarser granularity: a mid-date crash re-reads 24 hourly files on resume. Worst case ~30 min – 2 hrs of wasted work per crash.
+- Ingester behaviour now branches on `--mode` for `processed_files` reads/writes. Documented in [[ingestion-pipeline|InjestionPlan §5.6]].
+
+## See also
+- [[adr-0003-backfill-hourly-relay-race]] — the `initialized` flag that ADR 0005 leans on
+- [[backfill-run]] — the unit of work that records into `backfill_progress`

--- a/knowledge/wiki/adr-0007-processed-files-single-partition.md
+++ b/knowledge/wiki/adr-0007-processed-files-single-partition.md
@@ -17,15 +17,15 @@ adr_status: accepted
 
 ## TL;DR
 
-`processed_files` was restructured from `(file_name) PRIMARY KEY` to `(bucket, file_name) PRIMARY KEY`. All rows use `bucket = 'singleton'`. Catchup now scans the singleton partition in one paged round-trip and computes the chronological max in JS via `hourIdToMs()`, then filters on-disk IDs by `hourIdToMs(id) > hourIdToMs(max)`. This eliminates the N-concurrent-SELECT pattern that crashed production (3,426 in-flight requests exceeded the cassandra-driver's 2,048 limit).
+`processed_files` was restructured to `(bucket, hour_time timestamp)` PK with `CLUSTERING ORDER BY (hour_time DESC)`. All rows use `bucket = 'singleton'`; `file_name` is stored as a regular column. Catchup is now a true O(1) `LIMIT 1` key lookup — Cassandra timestamps sort chronologically so no JS max scan is needed. This eliminates the N-concurrent-SELECT pattern that crashed production (3,426 in-flight requests exceeded the cassandra-driver's 2,048 limit).
 
 ## The crash this fixes
 
 `ingester --catchup` fires `Promise.all(allOnDisk.map(id => writer.isFileProcessed(id)))` → 3,426 concurrent Cassandra SELECTs → `BusyConnectionError`. Scale-only bug (worked at smaller archive sizes).
 
-## Why single-partition is safe here
+## Why timestamp clustering, not string clustering
 
-The hourly ingester processes files strictly in chronological order and breaks on first failure. Therefore `processed_files` is always a contiguous prefix `{H₀ … H_max}`. Catchup only needs the max — not per-file membership. `hourIdToMs(id) > hourIdToMs(max)` filtering (chronological, not lexicographic — the canonical hour ID is `YYYY-MM-DD-H` with the hour unpadded, so string compare is wrong) is equivalent to "not yet processed."
+The canonical hour ID format is `YYYY-MM-DD-H` (hour unpadded, 0–23). Clustering on `file_name text DESC` and using `LIMIT 1` would fail because `'…-9' > '…-10'` as strings — once hour 9 of any day is processed, hours 10–23 of every later day would be silently skipped. A `timestamp` clustering column sorts chronologically by definition; `LIMIT 1` is always correct. `markFileProcessed` converts `file_name → hour_time` via `hourIdToMs()` on write.
 
 ## Hot-partition trade-off
 
@@ -33,9 +33,9 @@ All rows land in `bucket='singleton'`. On the current single-node Cassandra depl
 
 ## What changed in code
 
-- `CassandraWriter.isFileProcessed()` → removed; replaced by `getMaxProcessedFile()` (single SELECT scans singleton partition, returns `string | null` — chronological max computed in JS)
-- `CassandraWriter.markFileProcessed(fileName)` → writes with `bucket='singleton'`; `event_count`/`filtered_count` columns dropped
-- `ingester.js --catchup`: replaces `Promise.all` with single `getMaxProcessedFile()` + `allOnDisk.filter(id => hourIdToMs(id) > hourIdToMs(max))`
+- `CassandraWriter.isFileProcessed()` → removed; replaced by `getMaxProcessedFile()` (one `LIMIT 1` query, returns `string | null`)
+- `CassandraWriter.markFileProcessed(fileName)` → computes `hour_time = new Date(hourIdToMs(fileName))` and writes `(bucket, hour_time, file_name, processed_at)`; `event_count`/`filtered_count` columns dropped
+- `ingester.js --catchup`: single `getMaxProcessedFile()` call then `allOnDisk.filter(id => hourIdToMs(id) > hourIdToMs(max))`
 - Schema migration: `data-pipeline/schema/009_processed_files_single_partition.cql`
 
 ## Supersedes

--- a/knowledge/wiki/adr-0007-processed-files-single-partition.md
+++ b/knowledge/wiki/adr-0007-processed-files-single-partition.md
@@ -17,7 +17,7 @@ adr_status: accepted
 
 ## TL;DR
 
-`processed_files` was restructured from `(file_name) PRIMARY KEY` to `(bucket, file_name) PRIMARY KEY` with `CLUSTERING ORDER BY (file_name DESC)`. All rows use `bucket = 'singleton'`. Catchup now reads `MAX(file_name)` in one query and filters on-disk IDs by `id > max`, eliminating the N-concurrent-SELECT pattern that crashed production (3,426 in-flight requests exceeded the cassandra-driver's 2,048 limit).
+`processed_files` was restructured from `(file_name) PRIMARY KEY` to `(bucket, file_name) PRIMARY KEY`. All rows use `bucket = 'singleton'`. Catchup now scans the singleton partition in one paged round-trip and computes the chronological max in JS via `hourIdToMs()`, then filters on-disk IDs by `hourIdToMs(id) > hourIdToMs(max)`. This eliminates the N-concurrent-SELECT pattern that crashed production (3,426 in-flight requests exceeded the cassandra-driver's 2,048 limit).
 
 ## The crash this fixes
 
@@ -25,7 +25,7 @@ adr_status: accepted
 
 ## Why single-partition is safe here
 
-The hourly ingester processes files strictly in chronological order and breaks on first failure. Therefore `processed_files` is always a contiguous prefix `{H₀ … H_max}`. Catchup only needs the max — not per-file membership. `id > max` filtering (lexicographic on `YYYY-MM-DD-HH`) is equivalent to "not yet processed."
+The hourly ingester processes files strictly in chronological order and breaks on first failure. Therefore `processed_files` is always a contiguous prefix `{H₀ … H_max}`. Catchup only needs the max — not per-file membership. `hourIdToMs(id) > hourIdToMs(max)` filtering (chronological, not lexicographic — the canonical hour ID is `YYYY-MM-DD-H` with the hour unpadded, so string compare is wrong) is equivalent to "not yet processed."
 
 ## Hot-partition trade-off
 
@@ -33,9 +33,9 @@ All rows land in `bucket='singleton'`. On the current single-node Cassandra depl
 
 ## What changed in code
 
-- `CassandraWriter.isFileProcessed()` → removed; replaced by `getMaxProcessedFile()` (one SELECT, returns `string | null`)
+- `CassandraWriter.isFileProcessed()` → removed; replaced by `getMaxProcessedFile()` (single SELECT scans singleton partition, returns `string | null` — chronological max computed in JS)
 - `CassandraWriter.markFileProcessed(fileName)` → writes with `bucket='singleton'`; `event_count`/`filtered_count` columns dropped
-- `ingester.js --catchup`: replaces `Promise.all` with single `getMaxProcessedFile()` + `allOnDisk.filter(id => id > max)`
+- `ingester.js --catchup`: replaces `Promise.all` with single `getMaxProcessedFile()` + `allOnDisk.filter(id => hourIdToMs(id) > hourIdToMs(max))`
 - Schema migration: `data-pipeline/schema/009_processed_files_single_partition.cql`
 
 ## Supersedes

--- a/knowledge/wiki/adr-0007-processed-files-single-partition.md
+++ b/knowledge/wiki/adr-0007-processed-files-single-partition.md
@@ -1,0 +1,43 @@
+---
+title: ADR 0007 — processed_files single-partition for O(1) catchup
+slug: adr-0007-processed-files-single-partition
+type: decision
+tags: [cassandra, pipeline, ingestion, idempotency, performance]
+sources:
+  - docs/adr/0007-processed-files-single-partition.md
+related: [[adr-0005-processed-files-hourly-only]] [[adr-0003-backfill-hourly-relay-race]] [[ingestion-pipeline]] [[cassandra-analytics-pipeline]]
+updated: 2026-05-24
+status: stable
+adr_status: accepted
+---
+
+# ADR 0007 — `processed_files` restructured to single-partition for O(1) catchup max lookup
+
+> Canonical text: `docs/adr/0007-processed-files-single-partition.md`.
+
+## TL;DR
+
+`processed_files` was restructured from `(file_name) PRIMARY KEY` to `(bucket, file_name) PRIMARY KEY` with `CLUSTERING ORDER BY (file_name DESC)`. All rows use `bucket = 'singleton'`. Catchup now reads `MAX(file_name)` in one query and filters on-disk IDs by `id > max`, eliminating the N-concurrent-SELECT pattern that crashed production (3,426 in-flight requests exceeded the cassandra-driver's 2,048 limit).
+
+## The crash this fixes
+
+`ingester --catchup` fires `Promise.all(allOnDisk.map(id => writer.isFileProcessed(id)))` → 3,426 concurrent Cassandra SELECTs → `BusyConnectionError`. Scale-only bug (worked at smaller archive sizes).
+
+## Why single-partition is safe here
+
+The hourly ingester processes files strictly in chronological order and breaks on first failure. Therefore `processed_files` is always a contiguous prefix `{H₀ … H_max}`. Catchup only needs the max — not per-file membership. `id > max` filtering (lexicographic on `YYYY-MM-DD-HH`) is equivalent to "not yet processed."
+
+## Hot-partition trade-off
+
+All rows land in `bucket='singleton'`. On the current single-node Cassandra deployment this causes no imbalance. **If the deployment becomes multi-node**, this partition will be a hotspot and needs repartitioning (e.g. `bucket = YYYY`). This is a known future migration path, accepted per current topology.
+
+## What changed in code
+
+- `CassandraWriter.isFileProcessed()` → removed; replaced by `getMaxProcessedFile()` (one SELECT, returns `string | null`)
+- `CassandraWriter.markFileProcessed(fileName)` → writes with `bucket='singleton'`; `event_count`/`filtered_count` columns dropped
+- `ingester.js --catchup`: replaces `Promise.all` with single `getMaxProcessedFile()` + `allOnDisk.filter(id => id > max)`
+- Schema migration: `data-pipeline/schema/009_processed_files_single_partition.cql`
+
+## Supersedes
+
+[[adr-0005-processed-files-hourly-only]] — its "No schema change" claim is no longer accurate. ADR 0005's core decision (backfill does not use `processed_files`) is unchanged.

--- a/knowledge/wiki/index.md
+++ b/knowledge/wiki/index.md
@@ -1,0 +1,82 @@
+---
+title: Wiki Index
+slug: index
+type: reference
+updated: 2026-05-24
+---
+
+# JobFlow Wiki Index
+
+Entry point for the knowledge base. Pages are flat; this file groups them by `type` for human navigation. **Claude:** grep `wiki/` directly when looking for specific terms — the index is a cheatsheet, not the source of truth.
+
+> Schema: see [[../CLAUDE.md|CLAUDE.md]]. Authoritative sources: `/CONTEXT.md`, `/docs/adr/`, project memory.
+
+## Concepts (domain nouns)
+
+Mirror `CONTEXT.md` terms. Each page adds *system context* the glossary cannot carry.
+
+- [[application]] — the central entity; one job pursuit at a Company
+- [[stage]] — a user-defined step in a hiring pipeline
+- [[applied-stage]] — the Stage flagged as the Email Agent's auto-create target
+- [[rejection-stage]] — the Stage flagged as the Email Agent's rejection-routing target
+- [[application-receipt]] — email acknowledgment that triggers auto-Application creation
+- [[company]] — the employer named on an Application (not stored as its own entity)
+- [[first-sighting]] — the first time a Company appears anywhere; triggers the Scout
+- [[org]] — a GitHub organization the Company Scout resolved to a Company
+- [[tracked-event]] — a row in `company_events`; one piece of public GH activity
+- [[active-github-presence]] — Company Scout's classification of "alive" orgs
+- [[activity]] — a row in `card_activities` (system event or user note)
+- [[note]] — user-authored `card_activities` row
+- [[timeline]] — chronological Activities + Notes for one Application
+- [[notification]] — persistent in-app message from automation
+- [[task]] — user-created action item, optionally linked to an Application
+
+## Systems / Subsystems
+
+- [[email-agent]] — reads inbox, routes/creates Applications, produces Notifications
+- [[company-scout]] — runs on First Sighting; resolves Orgs; classifies GH presence
+- [[cassandra-analytics-pipeline]] — Cassandra ingestion (Backfill + Hourly Ingest)
+- [[ingestion-pipeline]] — Fetcher → Ingester → Cassandra; subsystem of the above
+- [[backfill]] — nightly catchup process for uninitialised (Company, Org) rows
+- [[hourly-ingest]] — frequent ingest for initialised (Company, Org) rows
+- [[kanban-board]] — frontend React board rendering Stages & Applications
+- [[gmail-integration]] — OAuth + token storage for the Email Agent
+
+### Canonical design docs (linked, not duplicated)
+
+- `docs/CassandraPlan.md` — JobFlow Analytics System Design (v2). Repo-root `/CassandraPlan.md` is the older v1.
+- `docs/InjestionPlan.md` — Ingestion pipeline consolidated plan.
+- `/ONBOARDING.md` — repo overview for new contributors.
+- `/CONTEXT.md` — domain glossary; canonical for every concept page.
+
+## Workflows
+
+- [[workflow-feature-development]] — 6-step branch → implement → commit → PR → review → human merge
+- [[workflow-grill-with-docs]] — stress-test plans against `CONTEXT.md` & ADRs
+- [[workflow-prd-to-issues]] — break PRD into vertical-slice GitHub issues
+- [[workflow-ship]] — one-shot feature delivery from a GitHub issue
+- [[workflow-code-review]] — multi-agent orchestrated review (NOT `senior-code-reviewer`)
+
+## Decisions (wiki mirrors of ADRs)
+
+- [[adr-0001-applied-stage-flag]] → `/docs/adr/0001-applied-stage-flag.md`
+- [[adr-0002-e2e-first-testing-strategy]] → `/docs/adr/0002-e2e-first-testing-strategy.md`
+- [[adr-0003-backfill-hourly-relay-race]] → `/docs/adr/0003-backfill-hourly-relay-race.md`
+- [[adr-0004-microservices-shaped-cli-contract]] → `/docs/adr/0004-microservices-shaped-cli-contract.md`
+- [[adr-0005-processed-files-hourly-only]] → `/docs/adr/0005-processed-files-hourly-only.md`
+- [[adr-0007-processed-files-single-partition]] → `/docs/adr/0007-processed-files-single-partition.md`
+
+## References (external systems & infrastructure)
+
+- [[infra-render]] — Render deploy; spins down after 15min — see memory
+- [[infra-neon]] — Postgres on Neon; uses pooler — see memory
+- [[infra-linux-deployment]] — Xubuntu box at tomer@192.168.10.12 — see memory
+- [[gh-archive]] — source of public GitHub events the pipeline ingests
+
+## People
+
+- [[tomer]] — collaboration preferences, role — see `memory/user_preferences.md`
+
+## Open questions
+
+(none yet — `q-<slug>` pages go here as they arise)

--- a/knowledge/wiki/ingestion-pipeline.md
+++ b/knowledge/wiki/ingestion-pipeline.md
@@ -32,7 +32,7 @@ The data-acquisition + ingestion subsystem of the [[cassandra-analytics-pipeline
 
 ## Where idempotency lives
 
-- **Hourly** uses `processed_files` (single-partition shape: `(bucket='singleton', file_name)` PK, `CLUSTERING ORDER BY (file_name DESC)`) → see [[adr-0007-processed-files-single-partition]] (supersedes schema section of [[adr-0005-processed-files-hourly-only]]).
+- **Hourly** uses `processed_files` (single-partition shape: `(bucket='singleton', file_name)` PK; chronological max computed in JS via `hourIdToMs` because `file_name`'s hour component is unpadded — see below) → see [[adr-0007-processed-files-single-partition]] (supersedes schema section of [[adr-0005-processed-files-hourly-only]]).
 - **Backfill** uses `backfill_progress` (per-date) → re-reads 24 files per resumed date.
 - Both rely on Cassandra full-key upserts on `company_events` → no duplicate rows even on overlapping writes.
 
@@ -42,9 +42,9 @@ The `--verb catchup` ingester verb is used by the hourly orchestrator after a ga
 
 **Old design (crashed production):** `Promise.all(allOnDisk.map(id => isFileProcessed(id)))` — N concurrent SELECTs. Crashed at 3,426 files (`BusyConnectionError: 2048 requests in-flight`).
 
-**New design (O(1)):**
-1. `getMaxProcessedFile()` → `SELECT file_name FROM processed_files WHERE bucket='singleton' LIMIT 1` — returns the highest file name ever processed (or `null` if empty).
-2. Filter: `pending = allOnDisk.filter(id => id > max)` — lexicographic compare works because `file_name` format is `YYYY-MM-DD-HH`.
+**New design (one round-trip):**
+1. `getMaxProcessedFile()` → `SELECT file_name FROM processed_files WHERE bucket='singleton'` — single paged scan of the singleton partition; chronological max computed in JS via `hourIdToMs()`. Returns `null` if empty.
+2. Filter: `pending = allOnDisk.filter(id => hourIdToMs(id) > hourIdToMs(max))` — must be chronological compare, not lexicographic. The canonical `file_name` format is `YYYY-MM-DD-H` (hour unpadded, 0–23), so string compare would silently skip hours 10–23 of each day once hour 9 is processed.
 3. The pre-filter means `processHour()` skips the per-file idempotency check for catchup (`cmd.verb !== 'catchup'` guard).
 
 ## Argument hygiene

--- a/knowledge/wiki/ingestion-pipeline.md
+++ b/knowledge/wiki/ingestion-pipeline.md
@@ -32,7 +32,7 @@ The data-acquisition + ingestion subsystem of the [[cassandra-analytics-pipeline
 
 ## Where idempotency lives
 
-- **Hourly** uses `processed_files` (single-partition shape: `(bucket='singleton', file_name)` PK; chronological max computed in JS via `hourIdToMs` because `file_name`'s hour component is unpadded — see below) → see [[adr-0007-processed-files-single-partition]] (supersedes schema section of [[adr-0005-processed-files-hourly-only]]).
+- **Hourly** uses `processed_files` (single-partition shape: `(bucket='singleton', hour_time timestamp)` PK, `CLUSTERING ORDER BY (hour_time DESC)`, `file_name` as regular column; `LIMIT 1` is a true O(1) key lookup because timestamps sort chronologically) → see [[adr-0007-processed-files-single-partition]] (supersedes schema section of [[adr-0005-processed-files-hourly-only]]).
 - **Backfill** uses `backfill_progress` (per-date) → re-reads 24 files per resumed date.
 - Both rely on Cassandra full-key upserts on `company_events` → no duplicate rows even on overlapping writes.
 
@@ -42,9 +42,9 @@ The `--verb catchup` ingester verb is used by the hourly orchestrator after a ga
 
 **Old design (crashed production):** `Promise.all(allOnDisk.map(id => isFileProcessed(id)))` — N concurrent SELECTs. Crashed at 3,426 files (`BusyConnectionError: 2048 requests in-flight`).
 
-**New design (one round-trip):**
-1. `getMaxProcessedFile()` → `SELECT file_name FROM processed_files WHERE bucket='singleton'` — single paged scan of the singleton partition; chronological max computed in JS via `hourIdToMs()`. Returns `null` if empty.
-2. Filter: `pending = allOnDisk.filter(id => hourIdToMs(id) > hourIdToMs(max))` — must be chronological compare, not lexicographic. The canonical `file_name` format is `YYYY-MM-DD-H` (hour unpadded, 0–23), so string compare would silently skip hours 10–23 of each day once hour 9 is processed.
+**New design (O(1)):**
+1. `getMaxProcessedFile()` → `SELECT file_name FROM processed_files WHERE bucket='singleton' LIMIT 1` — single key lookup on the `hour_time DESC` clustering column. Returns `null` if empty.
+2. Filter: `pending = allOnDisk.filter(id => hourIdToMs(id) > hourIdToMs(max))` — chronological compare via `hourIdToMs()`. The canonical `file_name` format is `YYYY-MM-DD-H` (hour unpadded, 0–23), so a plain string compare would silently skip hours 10–23 of each day once hour 9 is processed.
 3. The pre-filter means `processHour()` skips the per-file idempotency check for catchup (`cmd.verb !== 'catchup'` guard).
 
 ## Argument hygiene

--- a/knowledge/wiki/ingestion-pipeline.md
+++ b/knowledge/wiki/ingestion-pipeline.md
@@ -1,0 +1,66 @@
+---
+title: Ingestion Pipeline (Fetcher → Ingester → Cassandra)
+slug: ingestion-pipeline
+type: system
+tags: [pipeline, ingestion, gh-archive, cassandra]
+sources:
+  - docs/InjestionPlan.md
+  - docs/CassandraPlan.md
+  - data-pipeline/fetcher/
+  - data-pipeline/ingester/
+  - data-pipeline/orchestrators/
+related: [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[gh-archive]] [[tracked-event]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0004-microservices-shaped-cli-contract]] [[adr-0005-processed-files-hourly-only]] [[adr-0007-processed-files-single-partition]] [[infra-linux-deployment]]
+updated: 2026-05-24
+status: stable
+---
+
+# Ingestion Pipeline
+
+The data-acquisition + ingestion subsystem of the [[cassandra-analytics-pipeline]]. Canonical design: `docs/InjestionPlan.md`. System context: `docs/CassandraPlan.md` (v2 — supersedes `/CassandraPlan.md` at repo root).
+
+## Pieces
+
+- **Fetcher** — Node.js. Downloads GH Archive `.json.gz` files, atomic-writes to `GHARCHIVE_DIR` on the HDD (`/mnt/hdd/gharchive/YYYY/MM/DD/HH.json.gz`).
+- **Ingester** — Node.js. Main thread reads a file; worker pool parses + filters by `target_companies`; main thread writes to Cassandra. Branches on `--mode hourly | backfill` (see [[adr-0004-microservices-shaped-cli-contract]]).
+- **Orchestrators** — `data-pipeline/orchestrators/hourly.js` and `data-pipeline/orchestrators/backfill.js`. Spawn the Ingester with the appropriate `--mode` and per-job args.
+
+## Operational constraints
+
+- Hourly job and Backfill must **never** run simultaneously — enforced by a `flock`-based cron lock + the per-row `initialized` filter (see [[adr-0003-backfill-hourly-relay-race]]).
+- ~1-hour ingest latency target relative to GH Archive publish time.
+- ~470 GB/year compressed archive, kept indefinitely on the 2 TB HDD.
+
+## Where idempotency lives
+
+- **Hourly** uses `processed_files` (single-partition shape: `(bucket='singleton', file_name)` PK, `CLUSTERING ORDER BY (file_name DESC)`) → see [[adr-0007-processed-files-single-partition]] (supersedes schema section of [[adr-0005-processed-files-hourly-only]]).
+- **Backfill** uses `backfill_progress` (per-date) → re-reads 24 files per resumed date.
+- Both rely on Cassandra full-key upserts on `company_events` → no duplicate rows even on overlapping writes.
+
+## Catchup path (`--verb catchup`)
+
+The `--verb catchup` ingester verb is used by the hourly orchestrator after a gap (e.g. the service was down). It must resume without re-processing already-done hours.
+
+**Old design (crashed production):** `Promise.all(allOnDisk.map(id => isFileProcessed(id)))` — N concurrent SELECTs. Crashed at 3,426 files (`BusyConnectionError: 2048 requests in-flight`).
+
+**New design (O(1)):**
+1. `getMaxProcessedFile()` → `SELECT file_name FROM processed_files WHERE bucket='singleton' LIMIT 1` — returns the highest file name ever processed (or `null` if empty).
+2. Filter: `pending = allOnDisk.filter(id => id > max)` — lexicographic compare works because `file_name` format is `YYYY-MM-DD-HH`.
+3. The pre-filter means `processHour()` skips the per-file idempotency check for catchup (`cmd.verb !== 'catchup'` guard).
+
+## Argument hygiene
+
+Every per-job parameter is a CLI arg (URL-encoded for tokens with special chars — see `fix/hourly-target-companies-url-encoding`). Every service-level setting (Cassandra contact points, archive root, log level) is an env var. See [[adr-0004-microservices-shaped-cli-contract]].
+
+## Surprises / gotchas
+
+- `--target-companies` tokens must be URL-encoded by the orchestrator before being passed to the Ingester. Recent fixes (`727c6c9`, `ab64e1c`, `1fe9bb9`) hardened the operator-diagnostic path for `decodeURIComponent` failures.
+- The repo root has a `CassandraPlan.md` that is **older** than `docs/CassandraPlan.md`. The `docs/` copy is v2 and the canonical one.
+- "Catchup" is the **hourly fetcher's** mode (resumption after a gap). Don't confuse with [[backfill]] which is the nightly all-rows sweep.
+
+## Source pointers
+
+- Plan: `docs/InjestionPlan.md`
+- System design: `docs/CassandraPlan.md` (§5–§6 of the main RFC superseded by `InjestionPlan.md`)
+- Code: `data-pipeline/fetcher/`, `data-pipeline/ingester/`, `data-pipeline/orchestrators/{hourly,backfill}.js`
+- Schema migrations: `data-pipeline/schema/` (`processed_files`, `backfill_progress`, `backfill_runs`, `companies`)
+- Runtime host: see [[infra-linux-deployment]]


### PR DESCRIPTION
## Summary
- Replaces the N-concurrent-SELECT `isFileProcessed()` pattern in `--verb catchup` with a single `getMaxProcessedFile()` call, eliminating the `BusyConnectionError` that crashed production at 3,426 on-disk files
- Restructures `processed_files` schema to `(bucket='singleton', file_name)` composite PK with `CLUSTERING ORDER BY (file_name DESC)` so `MAX(file_name)` is a single O(1) round-trip
- Adds ADR 0007 documenting the hot-partition trade-off (acceptable for single-node Cassandra; future multi-node would need repartitioning)

## Acceptance criteria
- [x] Migration added under `data-pipeline/schema/` recreating `processed_files` with `(bucket, file_name)` PK and `CLUSTERING ORDER BY (file_name DESC)`
- [x] `cassandra-writer.js`: new `getMaxProcessedFile()` method returning `string | null`; `markFileProcessed(id)` writes with `bucket='singleton'`; `isFileProcessed(id)` removed
- [x] `ingester.js --catchup` no longer calls `Promise.all` of per-file checks; uses `getMaxProcessedFile()` once and filters on-disk IDs by `> max`
- [ ] Manual smoke test transcript posted on the PR (see below — requires production Cassandra access)
- [x] `knowledge/wiki/adr-0005-processed-files-hourly-only.md` updated: "No schema change" claim marked superseded
- [x] `knowledge/wiki/ingestion-pipeline.md` updated to describe new single-partition shape and `getMaxProcessedFile` catchup path
- [x] ADR 0007 created in both `knowledge/wiki/` and `docs/adr/`

## Smoke test

The smoke test transcript (criterion 4) requires running the ingester against a live Cassandra + populated GHARCHIVE_DIR. This must be run on the Linux deployment host. The three scenarios to capture:

1. Empty `processed_files` → catchup processes all on-disk hours in order
2. Populated `processed_files` → catchup processes only hours `> max`
3. Catchup over 3,000+ on-disk hours completes without `BusyConnectionError`

To run migration 009 on the host:
```bash
cqlsh -e "$(cat data-pipeline/schema/009_processed_files_single_partition.cql)"
```

## Related
Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)