### PR TITLE
docs: Company Scout re-grill — OrgScorer + HTTPS shim + multi-Org

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,11 +37,11 @@ An email sent by a company to acknowledge that they received a job application. 
 _Avoid_: Application confirmation, Acknowledgement email, Receipt email
 
 **Company Scout**:
-An automated process that runs on a Company's First Sighting. It resolves the Company to every public GitHub organization that belongs to it (a Company may legitimately own multiple Orgs — e.g. `wix`, `wix-incubator`) and classifies whether the Company has an Active GitHub Presence. It writes the resolved Orgs to the JobFlow Analytics system's `companies` table (one row per Company–Org pair); it produces no Notification and no user-facing change. A sibling of the Email Agent — an automated process acting on Applications — but triggered by Company novelty rather than by email.
+An automated process that runs on a Company's First Sighting. It enumerates candidate public GitHub organizations for the Company, scores each candidate against a weighted rubric, and writes those that pass the acceptance threshold and have an Active GitHub Presence to the JobFlow Analytics system's `companies` table — one row per (Company, Org) pair (a Company may legitimately own multiple Orgs, e.g. `wix`, `wix-incubator`). It produces no Notification and no user-facing change. A sibling of the Email Agent — an automated process acting on Applications — but triggered by Company novelty rather than by email.
 _Avoid_: Company Profiler, GitHub Checker, Company Agent
 
 **Active GitHub Presence**:
-The classification the Company Scout assigns to a Company: at least one of the Company's resolved GitHub organizations has at least one public repository that is not a fork, not archived, and was pushed to within the last year. A Company with no resolvable organizations, or whose repositories across all resolved Orgs are all older, forks, or archived, does not have an Active GitHub Presence.
+A per-Org classification the Company Scout assigns to each resolved GitHub organization: the Org has an Active GitHub Presence if it has at least one public repository that is not a fork, not archived, and was pushed to within the last year. Only Orgs with an Active GitHub Presence are written to the JobFlow Analytics system. By extension, a Company has an Active GitHub Presence if at least one of its resolved Orgs does.
 _Avoid_: Active repos, Live org
 
 **Org**:
@@ -96,7 +96,8 @@ _Avoid_: Todo (internal/DB term), Checklist item
 - The **Email Agent** produces **Notifications** to inform the user of every automated action it takes
 - A **Task** may optionally be linked to an **Application**; a **Task** without a link is standalone
 - The **First Sighting** of a **Company** on a new **Application** triggers the **Company Scout**
-- The **Company Scout** classifies a **Company** as having an **Active GitHub Presence** or not, and reports the ones that do to the JobFlow Analytics system
+- The **Company Scout** resolves a **Company** to zero or more candidate **Orgs**, scores each candidate, and admits those above the acceptance threshold
+- The **Company Scout** classifies each admitted **Org** as having an **Active GitHub Presence** or not, and writes only the active ones to the JobFlow Analytics system's `companies` table — one row per (Company, Org) pair
 
 ## Example dialogue
 

--- a/docs/adr/0009-org-scorer-weighted-scoring.md
+++ b/docs/adr/0009-org-scorer-weighted-scoring.md
@@ -1,0 +1,67 @@
+# ADR 0009 — Org acceptance via weighted scoring (OrgScorer), not a binary gate
+
+**Status:** Accepted
+**Date:** 2026-05-24
+
+## Context
+
+The Company Scout (see `/CONTEXT.md` → **Company Scout**, `knowledge/wiki/company-scout.md`) must decide, for each candidate GitHub organization, whether to write a `(Company, Org)` row into `jobflow.companies`. Wrong Orgs pollute the analytics dataset; missed Orgs reduce ingest coverage. The decision is fully automated — no human in the loop.
+
+Three signals were available during the grill (2026-05-24):
+
+1. **Slug similarity** between the org login and the normalized Company name. Reliable for exact matches; produces real-world false positives like `Riverside-Software` for "Riverside" (riverside.fm), `faye` for "Faye" (insurance), `rise` for "Rise".
+2. **Org website (`blog`) domain matched against the Application's careers/application URL domain.** Initially attractive. Two failure modes surfaced:
+   - **URL trust:** the Application URL is most often on an ATS platform (Greenhouse, Lever, Workday, …) or a job board, not on the company's own site. The domain on the card is not the company's domain.
+   - **Brand renames:** Meta's GitHub org is `facebook` with website `opensource.fb.com`; the company name is "Meta" and careers URLs are on `metacareers.com`. Every signal disagrees.
+3. **Org display name** (`org.name`, distinct from `org.login`). Catches Meta → `facebook` (display name is "Meta") but admits any unrelated org whose display name happens to coincide with a Company string.
+
+A binary gate (any one signal passes → accept) could only choose between precision and recall — and the user's intent was both: **lots of events** ingested *and* false positives kept out. A binary AND-gate (all signals must agree) becomes unsatisfiable when Application URLs aren't trustworthy and brand renames disagree on the rename pair.
+
+## Decision
+
+A **weighted scoring module — `OrgScorer`** — replaces the binary confidence gate.
+
+- One pure function: `scoreOrgCandidate(company, candidate, urls?)` returns a non-negative number.
+- One constant: `ORG_ACCEPT_THRESHOLD` (start: **80**).
+- Weight constants at the top of the same file, all editable in one place.
+- Multiple weak signals can sum to acceptance; a strong contrary signal (e.g. an ATS slug that disagrees with the org login) is encoded as a **negative** weight, providing genuine evidence against rather than just absence-of-evidence.
+
+Starting rubric (per candidate Org):
+
+| Signal | Points |
+|---|---|
+| Exact slug match (`normalize(company) == normalize(org.login)`) | +50 |
+| Strong slug similarity (substring + length-ratio ≥ 0.7) | +30 |
+| Moderate slug similarity (substring + length-ratio ≥ 0.5) | +15 |
+| Exact display-name match (`normalize(company) == normalize(org.name)`) | +50 |
+| Moderate display-name similarity (substring + length-ratio ≥ 0.5) | +15 |
+| ATS slug agrees with org login (when application URL is on an ATS platform) | +40 |
+| **ATS slug present but disagrees** with org login | **−50** |
+| Anchor-prefix sibling (sibling pass: org login starts with `<verified-anchor>-`) | +50 |
+| Real-org credibility — org has ≥5 public non-fork repos | +10 |
+| Real-org credibility — org has ≥100 followers | +10 |
+| **Pass threshold** | **≥ 80** |
+
+The threshold is a **single dial** — lower it for more events, raise it for fewer false positives — without touching any other code.
+
+## Consequences
+
+- The Scout can accept multiple Orgs per Company (Wix → `wix`, `wix-incubator`, …), realising the multi-Org capability the `companies` table schema and ADR 0003 already assume.
+- A 20-Org per-Company safety cap is enforced separately; more than 20 candidates passing the threshold indicates a malfunctioning scorer and aborts that Company.
+- Meta-style brand renames remain a known miss (`facebook` org reaches only 70 points under the starting weights). Accepted: the cost of catching them is loosening the display-name signal further, which would admit unrelated orgs.
+- Slug-only false positives (`Riverside-Software`, `faye`, `rise`) score below the threshold under the starting weights (≤50) and are rejected — eliminating the regressions from the single-shot resolver.
+- **Calibration is manual, not automated.** Per the per-feature decision to ship no tests for the Scout, the starting weights are tuned once during implementation against the existing ~74-Company dataset and then frozen unless drift is observed. This is the single largest risk in this decision.
+
+## Alternatives considered
+
+- **Binary AND-gate (all signals must agree).** Unsatisfiable for the Meta case and for any Application without trustworthy URL data. Rejected.
+- **Binary OR-gate (any signal passes).** What the single-shot resolver effectively used; produces the documented false positives. Rejected.
+- **Search-driven enumeration with name-only gate.** Highest recall but unbounded false-positive surface (`Comet` → admits `comet-ml`, `cometchat`, `dlsucomet`). Rejected.
+- **Hybrid confidence score with manual disambiguation queue.** Adds a human-in-the-loop tier; violates the "fully automated" decision locked early in the grill. Rejected.
+- **External alias map (Wikipedia/Wikidata, hand-curated list).** Would solve Meta → `facebook` cleanly; adds an external dependency and curation burden. Out of scope; revisit if the gap bites.
+
+## See also
+
+- `knowledge/wiki/company-scout.md` — full system context
+- ADR 0010 — HTTPS shim write path (the consumer of OrgScorer's accept decisions)
+- ADR 0003 — Backfill & Hourly Ingest hand off via per-row `initialized` (the invariant the accepted rows feed)

--- a/docs/adr/0010-https-shim-write-path.md
+++ b/docs/adr/0010-https-shim-write-path.md
@@ -1,0 +1,79 @@
+# ADR 0010 — Company Scout writes to Cassandra via a tiny HTTPS shim, not direct CQL
+
+**Status:** Accepted
+**Date:** 2026-05-24
+
+## Context
+
+The Company Scout (see `/CONTEXT.md` → **Company Scout**, `knowledge/wiki/company-scout.md`) writes one row per accepted `(Company, Org)` pair into `jobflow.companies` on the analytics-pipeline Cassandra cluster. The two systems live in genuinely different network zones:
+
+- **JobFlow web app** runs on **Render** (public cloud) and connects to Neon Postgres.
+- **Analytics pipeline + Cassandra** run on the Xubuntu box at `tomer@192.168.10.12` (see `knowledge/wiki/infra-linux-deployment.md` / project memory).
+
+Render cannot reach a private home-LAN address; the home box will be exposed to the internet for this purpose. The write volume is intentionally tiny — a single batch per Company First Sighting, with no scaling concerns in v1.
+
+Additional constraints from the grill (2026-05-24):
+
+- The `companies` table carries an `initialized boolean` flag (ADR 0003) that **must** be `false` on every Scout-written row, or the row regresses Backfill state silently. The producer must not be allowed to "forget" this.
+- The Scout's run-once-per-Company semantics combined with no retry mean the write surface is small, but a corrupted write would silently break the Backfill/Hourly relay race for that row.
+
+## Decision
+
+JobFlow writes via a **tiny HTTPS shim** running on the Xubuntu box, alongside Cassandra. JobFlow does not import `cassandra-driver` and does not speak CQL.
+
+**Wire contract:**
+
+```
+POST /companies
+Authorization: Bearer <COMPANY_REGISTRY_TOKEN>
+Content-Type: application/json
+
+{
+  "company": "wix",
+  "active_orgs": [
+    { "org_name": "wix",           "last_repo_push": "2026-05-20T..." },
+    { "org_name": "wix-incubator", "last_repo_push": "2026-04-18T..." }
+  ]
+}
+
+→ 200 OK
+{
+  "company": "wix",
+  "results": [
+    { "org_name": "wix",           "status": "registered" },
+    { "org_name": "wix-incubator", "status": "already_exists" }
+  ]
+}
+```
+
+- One POST per Company (batch of all admitted active Orgs).
+- The shim loops over `active_orgs` and issues `INSERT … IF NOT EXISTS` per Org — a Cassandra Lightweight Transaction. Atomic check-and-insert; no read-before-write race.
+- The shim is the sole writer of `initialized = false` and the only code that touches the `companies` table on this path. The invariant is enforced in one place.
+- HTTPS via a reverse-proxy (Caddy/nginx) terminating Let's Encrypt; Cassandra's native port stays bound to localhost.
+- Auth via a shared bearer token rotated by changing one env var on each side.
+- The shim itself is a separate deliverable in the `data-pipeline/` repo, ~30 lines of Node.
+
+JobFlow's `CompanyRegistry` interface has two implementations:
+
+- `HttpShimCompanyRegistry` (production): POSTs to `COMPANY_REGISTRY_URL` with the bearer token.
+- `LoggingCompanyRegistry` (dev fallback when `COMPANY_REGISTRY_URL` is unset): emits a structured log line of what *would* have been registered.
+
+## Consequences
+
+- JobFlow has **no Cassandra driver dependency** and no CQL anywhere — one HTTP call from one place.
+- The shim centralizes the `initialized = false` invariant; future JobFlow contributors physically cannot forget it.
+- The shim's per-Org `INSERT … IF NOT EXISTS` makes JobFlow's POSTs idempotent — duplicate sends (rare, but possible across network glitches or a deliberate re-trigger later) cause no harm and produce `already_exists` in the response so the caller can log accordingly.
+- The shim is one more service to keep running (`systemd` unit on the Linux box). Operational footprint: small but nonzero.
+- **A shim outage during a Company's First Sighting permanently loses that registration** for the current scope (no retry; the First Sighting flag in `cards.company_name` is already consumed). Documented in `knowledge/wiki/company-scout.md` Open Questions; a manual re-trigger admin endpoint is the natural future fix.
+- The `data-pipeline/` repo grows by a small service and its own deploy story (cron / systemd). JobFlow ships only the client-side `HttpShimCompanyRegistry` and the env vars.
+
+## Alternatives considered
+
+- **Direct CQL over the internet.** JobFlow opens a CQL connection to `cassandra://your-home-ip:9042` using `cassandra-driver`. Native protocol on the public internet is a much larger attack surface than HTTPS; brings a multi-MB native client into JobFlow for what is otherwise one HTTP POST; spreads the `initialized = false` invariant across producer code. Rejected.
+- **Postgres outbox.** JobFlow inserts the intent into a `pending_company_writes` table on Neon; a daemon on the Xubuntu box polls and writes to Cassandra. Decouples networks; survives Cassandra/network downtime. Adds a JobFlow-side table (the user specifically wanted no JobFlow companies-related table); two new pieces of infra (table + daemon). Rejected as too much for the volume.
+
+## See also
+
+- `knowledge/wiki/company-scout.md` — full system context
+- ADR 0003 — Backfill & Hourly Ingest hand off via per-row `initialized` (the invariant the shim enforces)
+- ADR 0009 — OrgScorer weighted scoring (produces the accept decisions the shim writes)

--- a/knowledge/raw/2026-05-24-grill-company-scout.md
+++ b/knowledge/raw/2026-05-24-grill-company-scout.md
@@ -1,0 +1,75 @@
+---
+date: 2026-05-24
+topic: Company Scout — re-grill against the wiki
+participants: Tomer + Claude
+status: closed
+artifacts:
+  - CONTEXT.md (revised Company Scout, Active GitHub Presence, Relationships)
+  - knowledge/wiki/company-scout.md (created)
+  - docs/adr/0009-org-scorer-weighted-scoring.md (created)
+  - docs/adr/0010-https-shim-write-path.md (created)
+related-issues:
+  - PRD: #180
+  - slices: #181, #182, #183, #184 (to be revised post-grill)
+---
+
+# Company Scout — re-grill (2026-05-24)
+
+A re-grill of PRD #180. The original grill (earlier this session) **skipped the mandatory wiki pre-load step** in the `grill-with-docs` skill and produced a PRD that was misaligned with the project's real state — most notably it assumed one Org per Company, deferred the Cassandra write, and ignored the `initialized = false` invariant. Tomer flagged this and asked for a re-grill, properly grounded against the wiki and the updated `CONTEXT.md`.
+
+## What's locked across both grills
+
+Carried forward from the first grill (not re-asked):
+
+- Trigger: **First Sighting** on both Application-creation paths (manual route + `gmailSync`), inside `cardService.createCard` as the single shared call site — not `pgSubscriber`, not two call sites. Global normalized dedup against `cards.company_name`.
+- Background fire-after-commit, not awaited, no retry on crash.
+- `GITHUB_TOKEN` env var — optional in dev, required in production.
+- A clear comment in the new module about the `gmailSync`-rollback transaction-boundary edge case.
+- No automated tests for the Scout feature.
+- "Active GitHub Presence" rule: ≥1 public, non-fork, non-archived repo pushed within rolling 365 days.
+
+## What changed in this re-grill
+
+### Multi-Org per Company
+A Company has **many** `(Company, Org)` rows, not one. `CONTEXT.md`, `CassandraPlan.md` §4.4, and ADR 0003 all assume this — the original grill missed it.
+
+### "Active" is a per-Org classification, not a per-Company gate
+Tomer's answer: **only active Orgs are written.** That makes the `Active GitHub Presence` classification *per-Org*; a Company has APGP iff at least one of its Orgs does. `CONTEXT.md` revised accordingly.
+
+### Cassandra write is NOT deferred
+The analytics pipeline at `/data-pipeline/` is real, the `companies` table exists, and Backfill + Hourly Ingest depend on Scout-written rows landing with `initialized = false` (ADR 0003). v1 must actually write to Cassandra — not log.
+
+### Org resolution: weighted scoring instead of binary gate
+A binary gate forces a precision/recall choice — Tomer wanted **both** good quality *and* lots of events. With URL trust dropped (Application URLs are most often ATS or third-party, so domain match is unreliable) and Meta-style brand renames disagreeing across every signal, no binary AND-gate is satisfiable.
+
+**Decision:** an `OrgScorer` deep module — `scoreOrgCandidate(company, candidate, urls?) → number`, threshold `ORG_ACCEPT_THRESHOLD = 80`, weight constants in one file. Captured in **ADR 0009**.
+
+Stress-tested against the original ~74-Company dataset:
+- `Wix → wix`: 85 ✓
+- `Wix → wix-incubator` (sibling): 85 ✓ (with anchor-prefix bonus)
+- `Comet → comet-ml`: 100 ✓; `cometchat`: 50 ✗; `dlsucomet`: ✗
+- `Riverside → Riverside-Software`: 50 ✗ (today's known false positive)
+- `Meta → facebook`: 70 ✗ (accepted miss — brand renames are an honest gap of fully automated guessing)
+
+Calibration: manual, one-time during implementation. The no-tests decision (carried over) means there's no automated regression to catch drift.
+
+### Write path: tiny HTTPS shim, not direct CQL
+JobFlow lives on Render; Cassandra lives on the home Linux box at `192.168.10.12`. The box will be exposed to the internet. Three options were weighed: direct CQL, HTTPS shim, Postgres outbox.
+
+**Decision:** ~30-line Node HTTPS shim alongside Cassandra. One endpoint `POST /companies` with bearer-token auth; loops over `active_orgs` and issues `INSERT … IF NOT EXISTS` per Org (LWT — atomic check-and-insert). The shim is the **sole** writer of `initialized = false`, enforcing the ADR 0003 invariant in one place. Captured in **ADR 0010**.
+
+JobFlow side: `CompanyRegistry` interface with `HttpShimCompanyRegistry` (prod) and `LoggingCompanyRegistry` (dev fallback when `COMPANY_REGISTRY_URL` unset). Per-Company batch POST; per-Org response statuses (`registered` / `already_exists`) logged on JobFlow side.
+
+Tomer added: the shim must check existence and refuse silently (`already_exists`) on duplicates. Clarified as **idempotency by composite PK** (the same `(Company, Org)` row), not a global one-Org-one-Company invariant.
+
+### Re-run scenarios — accepted as-is
+- **A.** Shim down during a First Sighting → Company is silently un-registered forever. Accepted; no retry; no admin endpoint in v1.
+- **B.** Company adds new Orgs months later → Scout doesn't re-evaluate; new Orgs never registered. Accepted; consistent with "fire once on First Sighting".
+- **C.** All cards for a Company deleted then re-created → Scout fires again; shim's `IF NOT EXISTS` makes this safe. Documented; no code change.
+
+## Things to clean up after the grill
+
+- PRD #180 needs revision: replace the "Cassandra write deferred / LoggingCompanyRegistry is v1" framing with the HTTPS-shim reality; replace single-Org resolution with multi-Org + `OrgScorer`; add `COMPANY_REGISTRY_URL` / `COMPANY_REGISTRY_TOKEN` env vars.
+- Slices #182 (resolver) and #183 (registry hand-off) need substantial rewrites; slice #181 (skeleton + trigger + env) needs only small edits; slice #184 (search fallback) likely folds into the new resolver slice.
+- The shim itself is a **separate deliverable** in `data-pipeline/`, not part of the JobFlow PRD. A parallel issue/PRD covers it.
+- The `companies.active` column is effectively always `true` under the locked design (only active Orgs are written). Schema unchanged; flagged for future cleanup.

--- a/knowledge/wiki/company-scout.md
+++ b/knowledge/wiki/company-scout.md
@@ -1,0 +1,73 @@
+---
+title: Company Scout
+slug: company-scout
+type: system
+tags: [automation, github, scoring, analytics-producer]
+sources:
+  - CONTEXT.md#company-scout
+  - docs/adr/0009-org-scorer-weighted-scoring.md
+  - docs/adr/0010-https-shim-write-path.md
+  - docs/CassandraPlan.md
+related: [[application]] [[company]] [[first-sighting]] [[org]] [[active-github-presence]] [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[email-agent]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0009-org-scorer-weighted-scoring]] [[adr-0010-https-shim-write-path]]
+updated: 2026-05-24
+status: stable
+---
+
+# Company Scout
+
+> Canonical definition: see `/CONTEXT.md` → **Company Scout**.
+
+The producer side of the [[cassandra-analytics-pipeline]]. Triggered by the [[first-sighting]] of a [[company]] on a new [[application]], it enumerates candidate GitHub [[org|Orgs]], scores each against a weighted rubric (see [[adr-0009-org-scorer-weighted-scoring]]), and writes the active accepted Orgs into the analytics pipeline's `companies` Cassandra table via a small HTTPS shim (see [[adr-0010-https-shim-write-path]]).
+
+## Why it exists
+
+The analytics pipeline can't profile a Company until its `(Company, Org)` rows exist in `jobflow.companies`. Before the Scout, that table was hand-curated to a fixed list of ~5 target companies and was never updated. The Scout closes that gap: every Company you actually start tracking becomes a candidate for analytics, with no manual step.
+
+## How it relates
+
+- Triggered by [[first-sighting]] of a [[company]] on an [[application]] (both the manual create path and the [[email-agent]]'s auto-create path)
+- Lives inside `cardService.createCard` as the single shared call site — fired detached after the card insert
+- Calls the **OrgScorer** module (see [[adr-0009-org-scorer-weighted-scoring]]) to decide which candidate Orgs to accept
+- Writes accepted, active Orgs to the analytics pipeline's `companies` table via the HTTPS shim (see [[adr-0010-https-shim-write-path]])
+- Produces zero JobFlow-side rows — no new tables, no new columns, no [[notification|Notifications]]
+
+## Decision flow per First Sighting
+
+1. **Enumerate candidates** — slug-probe variants of the Company name + GitHub org search; once an anchor is admitted, prefix-sweep for `<anchor>-*` siblings.
+2. **Score each candidate** — `scoreOrgCandidate(company, candidate, urls?)` returns a number 0…N using a weighted rubric (exact slug match, display-name match, ATS-slug agreement, anchor-prefix bonus, real-org credibility). Candidates below `ORG_ACCEPT_THRESHOLD` (currently 80) are rejected.
+3. **Classify each admitted Org** — listOrgRepos → [[active-github-presence]] check (≥1 public, non-fork, non-archived repo pushed within 365 days).
+4. **POST per-Company batch** — `POST /companies { company, active_orgs: [...] }` to the shim with `Authorization: Bearer <COMPANY_REGISTRY_TOKEN>`. Shim does `INSERT … IF NOT EXISTS` per Org (sets `initialized = false` so [[backfill]] picks it up — ADR 0003 invariant).
+5. **Log per-Org outcome** — `registered` or `already_exists` from the shim's response.
+
+## Key invariants
+
+- Fires **exactly once per Company name**, the first time it appears on any [[application]] across all users (normalized: lowercase + trim).
+- Rows reach Cassandra **only** via the HTTPS shim; JobFlow never speaks CQL.
+- The shim is the sole writer of `initialized = false` — that invariant lives in one place (see [[adr-0010-https-shim-write-path]] and [[adr-0003-backfill-hourly-relay-race]]).
+- Card creation latency is unaffected — `runCompanyCheck` is fired detached and never awaited.
+- No retry; no scheduled re-evaluation; the Scout never runs twice for the same Company while a card with that name exists.
+
+## Surprises / gotchas
+
+- **gmailSync transaction-boundary edge case.** `createCard` is called inside `gmailSync`'s per-email transaction; the detached check may start before that transaction commits. On a rollback (rare error path), the Scout has run for a card that no longer exists — costing a stray log line and (potentially) an idempotent `companies` row. The new module carries a comment explaining why this is accepted, so it doesn't get "fixed" into a regression.
+- **No-retry consequences.**
+  - Shim down during a Company's First Sighting → that Company is silently un-registered forever (until manual intervention, which doesn't exist).
+  - Company adds a new Org months later → Scout doesn't re-evaluate; the new Org is never registered.
+  - All cards for a Company are deleted then a new one is added → Scout fires again; previously-registered Orgs return `already_exists` from the shim (safe).
+- **`active` column in `companies` is effectively always `true` in v1.** Only active Orgs are written, so the column never carries a `false` value through this path. The schema retains it for future flexibility; no v1 change.
+- **The OrgScorer is uncalibrated until implementation.** The 80-point threshold is a starting point; calibration against the existing ~74-Company dataset happens once during implementation and is then frozen unless drift is observed.
+
+## Open questions
+
+- A manual re-trigger admin endpoint (`POST /admin/company-scout/run-for-company?name=X`) would fix the "shim was down" and "Company added Orgs later" gaps in one shot. Not in scope for v1; revisit if the gaps bite in practice.
+- Should the OrgScorer threshold and weights be env-tunable rather than file constants? Default = file constants for simplicity; revisit if retuning becomes frequent.
+
+## Source pointers
+
+- Trigger site: `backend/src/services/cardService.ts` (in `createCard`)
+- Scout orchestrator: `backend/src/services/companyScout/` (planned)
+- OrgScorer module: `backend/src/services/companyScout/orgScorer.ts` (planned)
+- HTTPS shim: separate deliverable in `data-pipeline/` repo (not in JobFlow)
+- Cassandra schema: `data-pipeline/schema/004_companies.cql` + `005_alter_companies_initialized.cql`
+- Canonical pipeline design: `docs/CassandraPlan.md` §4.4 (`companies` table)
+- Related ADRs: [[adr-0003-backfill-hourly-relay-race]], [[adr-0009-org-scorer-weighted-scoring]], [[adr-0010-https-shim-write-path]]


### PR DESCRIPTION
## Summary
- Outcomes from the 2026-05-24 re-grill of PRD #180 against the wiki and updated `CONTEXT.md`
- Revises `CONTEXT.md` (Company Scout, Active GitHub Presence, Relationships) to match the per-Org / multi-Org / real-Cassandra design
- Adds two ADRs (0009 — `OrgScorer` weighted scoring; 0010 — HTTPS shim write path) and a new wiki page (`company-scout.md`)
- Saves the full grill transcript under `knowledge/raw/` per the `grill-with-docs` skill instructions

## Changes
- `CONTEXT.md`: Company Scout entry tightened (scores candidates, writes only accepted active Orgs); Active GitHub Presence redefined as per-Org with Company-level APGP as derived; Relationships bullets split into score/admit + per-Org active classification
- `docs/adr/0009-org-scorer-weighted-scoring.md`: weighted-scoring rubric, 80-point threshold, alternatives (binary gate, hybrid, search-only) and why each was rejected, stress-tested against the existing ~74-Company dataset
- `docs/adr/0010-https-shim-write-path.md`: HTTPS shim chosen over direct CQL and Postgres outbox; `INSERT IF NOT EXISTS`; shim is the sole writer of `initialized = false` (enforces ADR 0003 in one place)
- `knowledge/wiki/company-scout.md`: full system context — decision flow per First Sighting, key invariants, the gmailSync transaction-boundary edge case, no-retry consequences (scenarios A/B/C), source pointers
- `knowledge/raw/2026-05-24-grill-company-scout.md`: grill transcript

No code changes.

## Follow-ups (separate PRs)
- PRD #180 revision to match this design (the Cassandra write is in scope; multi-Org via `OrgScorer`; new env vars)
- Slices #182 (resolver) and #183 (registry hand-off) rewritten; #181 minor edits; #184 likely folds into the new resolver slice
- The HTTPS shim is a separate deliverable in `data-pipeline/` — not part of JobFlow's PRD

## Test plan
- [ ] `CONTEXT.md` renders correctly on GitHub
- [ ] All ADR + wiki links resolve
- [ ] No code references to these decisions yet — that lands with the rewritten slices

Related: PRD #180; ADR 0003 (the `initialized` invariant ADR 0010 enforces); existing slices #181–#184 to be revised in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)