### PR TITLE
Company Scout slice 1: First-Sighting trigger + Scout skeleton + env vars + LoggingCompanyRegistry

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -21,11 +21,23 @@ const schema = z.object({
   LLM_PROVIDER:         z.enum(['anthropic', 'google']).default('google'),
   ANTHROPIC_API_KEY:    z.string().optional(),
   GOOGLE_AI_API_KEY:    z.string().optional(),
+
+  GITHUB_TOKEN:            z.string().optional(),
+  COMPANY_REGISTRY_URL:    z.string().url().optional(),
+  COMPANY_REGISTRY_TOKEN:  z.string().optional(),
 }).superRefine((v, ctx) => {
   if (v.NODE_ENV !== 'production') return;
 
   for (const k of ['GOOGLE_CLIENT_ID','GOOGLE_CLIENT_SECRET','GOOGLE_REDIRECT_URI','CRON_API_KEY'] as const) {
     if (!v[k]) ctx.addIssue({ code: 'custom', path: [k], message: `${k} is required in production` });
+  }
+
+  for (const k of ['GITHUB_TOKEN','COMPANY_REGISTRY_URL','COMPANY_REGISTRY_TOKEN'] as const) {
+    if (!v[k]) ctx.addIssue({ code: 'custom', path: [k], message: `${k} is required in production` });
+  }
+
+  if (v.COMPANY_REGISTRY_URL && !v.COMPANY_REGISTRY_TOKEN) {
+    ctx.addIssue({ code: 'custom', path: ['COMPANY_REGISTRY_TOKEN'], message: 'COMPANY_REGISTRY_TOKEN is required when COMPANY_REGISTRY_URL is set' });
   }
 
   for (const [k, defaultVal] of [

--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -2,6 +2,7 @@ import { Knex } from 'knex';
 import db from '../config/database';
 import { AppError } from '../middleware/errorHandler';
 import { shiftUp, shiftDown, withTransaction } from '../util/positions';
+import { runCompanyCheck } from './companyScout/companyScout';
 
 export interface CardFilters {
   stage?: string;
@@ -270,6 +271,16 @@ export const cardService = {
       position = (maxPos?.max ?? -1) + 1;
     }
 
+    // First Sighting check: global dedup across all users, case-insensitive,
+    // whitespace-trimmed. We use the base db instance (not runner/trx) so this
+    // read sees already-committed rows from other users — a trx-scoped read
+    // would miss cards committed outside this transaction.
+    const normalizedCompany = data.company_name.trim().toLowerCase();
+    const existingCompany = await db('cards')
+      .whereRaw('lower(trim(company_name)) = ?', [normalizedCompany])
+      .first();
+    const isFirstSighting = !existingCompany;
+
     // Caller may pre-resolve the icon URL (e.g. gmailSync resolves it outside
     // its per-email transaction to avoid holding a DB connection across the
     // Clearbit HTTP call). Detect presence with `in` so an explicit `null` is
@@ -308,6 +319,15 @@ export const cardService = {
       .returning('*');
 
     await logActivity(card.id, userId, 'created', undefined, undefined, undefined, undefined, runner);
+
+    if (isFirstSighting) {
+      // Fire detached — never await, never let a thrown error propagate.
+      // Card-creation latency must be unaffected by the Scout.
+      runCompanyCheck(data.company_name, {
+        applicationUrl: data.application_url,
+        careersUrl: data.careers_url,
+      }).catch(() => { /* intentionally suppressed — Scout errors must not fail card creation */ });
+    }
 
     // Return card with stage name
     const stage = await runner('stages').where({ id: card.stage_id }).first();

--- a/backend/src/services/companyScout/companyRegistry.ts
+++ b/backend/src/services/companyScout/companyRegistry.ts
@@ -15,12 +15,13 @@ export interface CompanyRegistry {
  * HttpShimCompanyRegistry (slice #184) is the production implementation.
  */
 export class LoggingCompanyRegistry implements CompanyRegistry {
-  async register(company: string, activeOrgs: ActiveOrg[]): Promise<void> {
+  register(company: string, activeOrgs: ActiveOrg[]): Promise<void> {
     logger.info('company_registry.would_register', {
       service: 'company-scout',
       company,
       active_org_count: activeOrgs.length,
       active_orgs: activeOrgs,
     });
+    return Promise.resolve();
   }
 }

--- a/backend/src/services/companyScout/companyRegistry.ts
+++ b/backend/src/services/companyScout/companyRegistry.ts
@@ -1,0 +1,26 @@
+import logger from '../../config/logger';
+
+export interface ActiveOrg {
+  org_name: string;
+  last_repo_push: string;
+}
+
+export interface CompanyRegistry {
+  register(company: string, activeOrgs: ActiveOrg[]): Promise<void>;
+}
+
+/**
+ * Dev fallback used when COMPANY_REGISTRY_URL is not configured. Logs a
+ * structured line describing what would have been POSTed to the HTTPS shim.
+ * HttpShimCompanyRegistry (slice #184) is the production implementation.
+ */
+export class LoggingCompanyRegistry implements CompanyRegistry {
+  async register(company: string, activeOrgs: ActiveOrg[]): Promise<void> {
+    logger.info('company_registry.would_register', {
+      service: 'company-scout',
+      company,
+      active_org_count: activeOrgs.length,
+      active_orgs: activeOrgs,
+    });
+  }
+}

--- a/backend/src/services/companyScout/companyScout.ts
+++ b/backend/src/services/companyScout/companyScout.ts
@@ -1,0 +1,50 @@
+import logger from '../../config/logger';
+import { LoggingCompanyRegistry, type CompanyRegistry } from './companyRegistry';
+
+// The registry singleton is resolved once at module load time.
+// HttpShimCompanyRegistry (slice #184) will be swapped in here when
+// COMPANY_REGISTRY_URL is configured; for now LoggingCompanyRegistry is the
+// only implementation.
+const registry: CompanyRegistry = new LoggingCompanyRegistry();
+
+/**
+ * Runs the Company Scout for a Company on its First Sighting.
+ *
+ * Slice 1 skeleton: logs the First Sighting and delegates to the registry
+ * with an empty activeOrgs array (placeholder — GitHub resolution lands in
+ * slice #182 / #183). HttpShimCompanyRegistry is deferred to slice #184.
+ *
+ * ---
+ * ACCEPTED EDGE CASE — gmailSync transaction-boundary race:
+ *
+ * `createCard` is called inside gmailSync's per-email transaction; this
+ * function is fired detached (not awaited) immediately after the INSERT
+ * returns but before that transaction has committed. On a rare rollback
+ * (e.g. the subsequent processed_emails audit INSERT fails), the card that
+ * triggered the First Sighting no longer exists — but the Scout has already
+ * run and may have written a `companies` row via the shim.
+ *
+ * This is intentionally accepted:
+ *   - The shim's `INSERT … IF NOT EXISTS` makes duplicate sends safe
+ *     (ADR 0010), and a stray `companies` row whose card vanished causes no
+ *     correctness harm — the Backfill will attempt GitHub resolution for a
+ *     company that happens to have no live card, producing at worst a low-
+ *     value analytics row.
+ *   - The alternative — awaiting inside the transaction, or adding a
+ *     post-commit hook — would couple Scout latency to card-creation latency
+ *     or require a more complex transaction API. Both costs outweigh the
+ *     rare-rollback risk.
+ *   - See also: knowledge/wiki/company-scout.md § "Surprises / gotchas"
+ */
+export async function runCompanyCheck(
+  companyName: string,
+  cardUrls?: { applicationUrl?: string; careersUrl?: string },
+): Promise<void> {
+  logger.info('company_scout.first_sighting', {
+    service: 'company-scout',
+    company: companyName,
+    card_urls: cardUrls,
+  });
+
+  await registry.register(companyName, []);
+}

--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -13,6 +13,10 @@ Each entry: **what happened → what we'd change**. Skip generic platitudes.
 
 ---
 
+## 2026-05-24 (PR #244 — Company Scout slice 1)
+
+- **Global dedup in `createCard` must use the base `db` instance, not the caller's `trx`.** The First Sighting check queries `cards.company_name` globally across all users; using `runner` (which may be a `trx`) would scope the read to uncommitted rows inside the current transaction, making concurrent creates race past the dedup. → Always use `db` (not `runner`/`trx`) for reads that need committed global state even when the surrounding write uses a transaction.
+
 ## 2026-05-24 (PR #242 — fetcher p-limit bump)
 
 - **File size varies ~3× across different months of GH Archive.** Jan 2025 files averaged ~77 MB/hour vs ~25 MB for May 2026 — GitHub event volume grew significantly. When benchmarking fetcher throughput, files/sec is a misleading metric across different date ranges; MB/s is the correct comparison. The p-limit(3→6) bump yielded ~2.2× MB/s improvement (71 vs 33 MB/s) on the Xubuntu box, clearing the >1.3× approval threshold.

--- a/knowledge/wiki/company-scout.md
+++ b/knowledge/wiki/company-scout.md
@@ -11,6 +11,7 @@ sources:
 related: [[application]] [[company]] [[first-sighting]] [[org]] [[active-github-presence]] [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[email-agent]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0009-org-scorer-weighted-scoring]] [[adr-0010-https-shim-write-path]]
 updated: 2026-05-24
 status: stable
+shipped: "#181 (slice 1)"
 ---
 
 # Company Scout
@@ -65,8 +66,8 @@ The analytics pipeline can't profile a Company until its `(Company, Org)` rows e
 ## Source pointers
 
 - Trigger site: `backend/src/services/cardService.ts` (in `createCard`)
-- Scout orchestrator: `backend/src/services/companyScout/` (planned)
-- OrgScorer module: `backend/src/services/companyScout/orgScorer.ts` (planned)
+- Scout orchestrator: `backend/src/services/companyScout/companyScout.ts` (skeleton — slice 1); `companyRegistry.ts` (LoggingCompanyRegistry — slice 1)
+- OrgScorer module: `backend/src/services/companyScout/orgScorer.ts` (planned — slice 2/3)
 - HTTPS shim: separate deliverable in `data-pipeline/` repo (not in JobFlow)
 - Cassandra schema: `data-pipeline/schema/004_companies.cql` + `005_alter_companies_initialized.cql`
 - Canonical pipeline design: `docs/CassandraPlan.md` §4.4 (`companies` table)


### PR DESCRIPTION
## Summary
- Adds `GITHUB_TOKEN`, `COMPANY_REGISTRY_URL`, and `COMPANY_REGISTRY_TOKEN` to the Zod env schema — optional in development, required in production; `COMPANY_REGISTRY_TOKEN` also required whenever `COMPANY_REGISTRY_URL` is set
- Adds `CompanyRegistry` interface and `LoggingCompanyRegistry` implementation (structured `info` log of what would be POSTed to the HTTPS shim); `HttpShimCompanyRegistry` deferred to slice #184
- Adds `companyScout.ts` with `runCompanyCheck` skeleton (logs First Sighting, calls `LoggingCompanyRegistry.register` with empty `activeOrgs`; contains an explanatory comment for the accepted `gmailSync`-rollback transaction-boundary edge case)
- Modifies `cardService.createCard` to perform a global case-insensitive whitespace-trimmed dedup against `cards.company_name` before the insert, then fire `runCompanyCheck` detached (not awaited, errors suppressed) after the insert on a First Sighting

## Acceptance criteria
- [x] `GITHUB_TOKEN`, `COMPANY_REGISTRY_URL`, and `COMPANY_REGISTRY_TOKEN` are in the env schema — all optional in development, required in production (startup fails in production if any is absent; `COMPANY_REGISTRY_TOKEN` required when `COMPANY_REGISTRY_URL` is set)
- [x] Creating an Application for a Company name never seen before (across all users) triggers the Scout exactly once, producing one structured log line from `LoggingCompanyRegistry`
- [x] Creating an Application for a Company name already present on any existing card produces no Scout log line
- [x] Dedup matching ignores case and surrounding whitespace (`Accessibe` and ` accessiBe ` are the same Company)
- [x] The check fires for both the manual create route and the `gmailSync` (Email Agent) path
- [x] `runCompanyCheck` is fired detached — card-creation response latency is unchanged
- [x] A thrown error inside `runCompanyCheck` never fails or delays card creation
- [x] `CompanyRegistry` interface and `LoggingCompanyRegistry` exist; `HttpShimCompanyRegistry` does **not** exist yet (it lands in slice #184)
- [x] The new module contains a comment explaining the accepted `gmailSync`-rollback edge case
- [x] Production deployment note: `GITHUB_TOKEN`, `COMPANY_REGISTRY_URL`, `COMPANY_REGISTRY_TOKEN` must be set in Render's environment before deploy (operator action; a dedicated GitHub machine user is intended)

## Related
Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)