### PR TITLE
docs: ingest Company Scout grill transcript (manifest + learnings)

### DIFF
--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -13,6 +13,11 @@ Each entry: **what happened → what we'd change**. Skip generic platitudes.
 
 ---
 
+## 2026-05-24 (PR #243 — Company Scout re-grill)
+
+- **The first grill produced a misaligned PRD because the wiki pre-load step was skipped.** The `grill-with-docs` skill explicitly instructs `Read knowledge/wiki/index.md` + grep for the topic *before asking the first question*. Skipping that step produced a PRD that assumed single-Org Companies, deferred the Cassandra write, and ignored the `initialized = false` invariant from ADR 0003 — all of which were resolved in the wiki and `CassandraPlan.md`. The user caught it; the entire grill had to be redone. → Treat the skill's pre-load step as load-bearing, not flavor text. If `knowledge/wiki/` exists, reading the index + topic-matched pages is the *first* tool call of the grill, not an optional warm-up.
+- **Multi-fact raw files map cleanly when the design itself was already structured.** This raw was a grill transcript with discrete decisions; each decision had an obvious target (per-Org classification → CONTEXT.md; OrgScorer rubric → ADR 0009; HTTPS shim → ADR 0010; system context → wiki/company-scout.md). The ingest was bookkeeping rather than authoring — material was written *during* the grill per the skill's "update CONTEXT.md inline" rule. → When a raw file is the transcript of a structured workflow, the workflow's own discipline does most of the ingest work; the post-hoc step is just recording outputs and appending this bullet.
+
 ## 2026-05-24 (PR #242 — fetcher p-limit bump)
 
 - **File size varies ~3× across different months of GH Archive.** Jan 2025 files averaged ~77 MB/hour vs ~25 MB for May 2026 — GitHub event volume grew significantly. When benchmarking fetcher throughput, files/sec is a misleading metric across different date ranges; MB/s is the correct comparison. The p-limit(3→6) bump yielded ~2.2× MB/s improvement (71 vs 33 MB/s) on the Xubuntu box, clearing the >1.3× approval threshold.

--- a/knowledge/raw/.processed.json
+++ b/knowledge/raw/.processed.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "files": {
+    "raw/2026-05-24-grill-company-scout.md": {
+      "sha256": "9a57e2dd31b0e58894ad1d84dd5f6dc4a2dd8ae1f73c00d7fc4bc2d4b38d797e",
+      "processed_at": "2026-05-24T00:00:00Z",
+      "outputs": {
+        "wiki": ["company-scout.md"],
+        "adr": ["docs/adr/0009-org-scorer-weighted-scoring.md", "docs/adr/0010-https-shim-write-path.md"],
+        "context_md": ["Company Scout (revised)", "Active GitHub Presence (revised per-Org)", "Relationships (Scout bullets split)"],
+        "memory": []
+      },
+      "notes": "Re-grill of PRD #180 against the wiki (the first grill skipped the wiki pre-load). All material captured inline during the grill and merged via PR #243; this manifest entry just records the bookkeeping."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Records `knowledge/raw/2026-05-24-grill-company-scout.md` as processed in `raw/.processed.json` (sha256 + outputs).
- Appends two learnings bullets reflecting on the re-grill (PR #243): the wiki pre-load step is load-bearing, and well-structured grills produce ingests that are mostly bookkeeping.

## Changes
- `knowledge/raw/.processed.json`: first manifest entry
- `knowledge/learnings.md`: new \`## 2026-05-24 (PR #243 — Company Scout re-grill)\` section at the top

No new wiki pages or ADRs — they were already merged via PR #243. No code.

## Test plan
- [ ] Manifest entry sha256 matches the raw file
- [ ] Outputs list correctly references existing files

Related: PR #243 (the grill outputs), PRD #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)