### PR TITLE
Company Scout slice 2: GitHub API client + OrgScorer (foundation modules)

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -21,11 +21,23 @@ const schema = z.object({
   LLM_PROVIDER:         z.enum(['anthropic', 'google']).default('google'),
   ANTHROPIC_API_KEY:    z.string().optional(),
   GOOGLE_AI_API_KEY:    z.string().optional(),
+
+  GITHUB_TOKEN:            z.string().optional(),
+  COMPANY_REGISTRY_URL:    z.string().url().optional(),
+  COMPANY_REGISTRY_TOKEN:  z.string().optional(),
 }).superRefine((v, ctx) => {
   if (v.NODE_ENV !== 'production') return;
 
   for (const k of ['GOOGLE_CLIENT_ID','GOOGLE_CLIENT_SECRET','GOOGLE_REDIRECT_URI','CRON_API_KEY'] as const) {
     if (!v[k]) ctx.addIssue({ code: 'custom', path: [k], message: `${k} is required in production` });
+  }
+
+  for (const k of ['GITHUB_TOKEN','COMPANY_REGISTRY_URL','COMPANY_REGISTRY_TOKEN'] as const) {
+    if (!v[k]) ctx.addIssue({ code: 'custom', path: [k], message: `${k} is required in production` });
+  }
+
+  if (v.COMPANY_REGISTRY_URL && !v.COMPANY_REGISTRY_TOKEN) {
+    ctx.addIssue({ code: 'custom', path: ['COMPANY_REGISTRY_TOKEN'], message: 'COMPANY_REGISTRY_TOKEN is required when COMPANY_REGISTRY_URL is set' });
   }
 
   for (const [k, defaultVal] of [

--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -2,6 +2,7 @@ import { Knex } from 'knex';
 import db from '../config/database';
 import { AppError } from '../middleware/errorHandler';
 import { shiftUp, shiftDown, withTransaction } from '../util/positions';
+import { runCompanyCheck } from './companyScout/companyScout';
 
 export interface CardFilters {
   stage?: string;
@@ -270,6 +271,16 @@ export const cardService = {
       position = (maxPos?.max ?? -1) + 1;
     }
 
+    // First Sighting check: global dedup across all users, case-insensitive,
+    // whitespace-trimmed. We use the base db instance (not runner/trx) so this
+    // read sees already-committed rows from other users — a trx-scoped read
+    // would miss cards committed outside this transaction.
+    const normalizedCompany = data.company_name.trim().toLowerCase();
+    const existingCompany = await db('cards')
+      .whereRaw('lower(trim(company_name)) = ?', [normalizedCompany])
+      .first();
+    const isFirstSighting = !existingCompany;
+
     // Caller may pre-resolve the icon URL (e.g. gmailSync resolves it outside
     // its per-email transaction to avoid holding a DB connection across the
     // Clearbit HTTP call). Detect presence with `in` so an explicit `null` is
@@ -308,6 +319,15 @@ export const cardService = {
       .returning('*');
 
     await logActivity(card.id, userId, 'created', undefined, undefined, undefined, undefined, runner);
+
+    if (isFirstSighting) {
+      // Fire detached — never await, never let a thrown error propagate.
+      // Card-creation latency must be unaffected by the Scout.
+      runCompanyCheck(data.company_name, {
+        applicationUrl: data.application_url,
+        careersUrl: data.careers_url,
+      }).catch(() => { /* intentionally suppressed — Scout errors must not fail card creation */ });
+    }
 
     // Return card with stage name
     const stage = await runner('stages').where({ id: card.stage_id }).first();

--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -62,11 +62,11 @@ async function logActivity(
   });
 }
 
-type ATSEntry =
+export type ATSEntry =
   | { pattern: RegExp; slugFrom: 'path' | 'subdomain'; stripPrefix?: string; noSlug?: false }
   | { pattern: RegExp; noSlug: true };
 
-const ATS_PLATFORMS: ATSEntry[] = [
+export const ATS_PLATFORMS: ATSEntry[] = [
   { pattern: /^(boards|job-boards|job-boards\.eu)\.greenhouse\.io$/, slugFrom: 'path' },
   { pattern: /^jobs\.lever\.co$/, slugFrom: 'path' },
   { pattern: /^[\w-]+\.wd\d+\.myworkdayjobs\.com$/, slugFrom: 'subdomain' },
@@ -87,7 +87,7 @@ function getATSEntry(hostname: string) {
   return ATS_PLATFORMS.find((p) => p.pattern.test(hostname)) ?? null;
 }
 
-function extractATSSlug(url: string): string | null {
+export function extractATSSlug(url: string): string | null {
   try {
     const parsed = new URL(url);
     const hostname = parsed.hostname;

--- a/backend/src/services/companyScout/companyRegistry.ts
+++ b/backend/src/services/companyScout/companyRegistry.ts
@@ -15,12 +15,13 @@ export interface CompanyRegistry {
  * HttpShimCompanyRegistry (slice #184) is the production implementation.
  */
 export class LoggingCompanyRegistry implements CompanyRegistry {
-  async register(company: string, activeOrgs: ActiveOrg[]): Promise<void> {
+  register(company: string, activeOrgs: ActiveOrg[]): Promise<void> {
     logger.info('company_registry.would_register', {
       service: 'company-scout',
       company,
       active_org_count: activeOrgs.length,
       active_orgs: activeOrgs,
     });
+    return Promise.resolve();
   }
 }

--- a/backend/src/services/companyScout/companyRegistry.ts
+++ b/backend/src/services/companyScout/companyRegistry.ts
@@ -1,0 +1,26 @@
+import logger from '../../config/logger';
+
+export interface ActiveOrg {
+  org_name: string;
+  last_repo_push: string;
+}
+
+export interface CompanyRegistry {
+  register(company: string, activeOrgs: ActiveOrg[]): Promise<void>;
+}
+
+/**
+ * Dev fallback used when COMPANY_REGISTRY_URL is not configured. Logs a
+ * structured line describing what would have been POSTed to the HTTPS shim.
+ * HttpShimCompanyRegistry (slice #184) is the production implementation.
+ */
+export class LoggingCompanyRegistry implements CompanyRegistry {
+  async register(company: string, activeOrgs: ActiveOrg[]): Promise<void> {
+    logger.info('company_registry.would_register', {
+      service: 'company-scout',
+      company,
+      active_org_count: activeOrgs.length,
+      active_orgs: activeOrgs,
+    });
+  }
+}

--- a/backend/src/services/companyScout/companyScout.ts
+++ b/backend/src/services/companyScout/companyScout.ts
@@ -1,0 +1,50 @@
+import logger from '../../config/logger';
+import { LoggingCompanyRegistry, type CompanyRegistry } from './companyRegistry';
+
+// The registry singleton is resolved once at module load time.
+// HttpShimCompanyRegistry (slice #184) will be swapped in here when
+// COMPANY_REGISTRY_URL is configured; for now LoggingCompanyRegistry is the
+// only implementation.
+const registry: CompanyRegistry = new LoggingCompanyRegistry();
+
+/**
+ * Runs the Company Scout for a Company on its First Sighting.
+ *
+ * Slice 1 skeleton: logs the First Sighting and delegates to the registry
+ * with an empty activeOrgs array (placeholder — GitHub resolution lands in
+ * slice #182 / #183). HttpShimCompanyRegistry is deferred to slice #184.
+ *
+ * ---
+ * ACCEPTED EDGE CASE — gmailSync transaction-boundary race:
+ *
+ * `createCard` is called inside gmailSync's per-email transaction; this
+ * function is fired detached (not awaited) immediately after the INSERT
+ * returns but before that transaction has committed. On a rare rollback
+ * (e.g. the subsequent processed_emails audit INSERT fails), the card that
+ * triggered the First Sighting no longer exists — but the Scout has already
+ * run and may have written a `companies` row via the shim.
+ *
+ * This is intentionally accepted:
+ *   - The shim's `INSERT … IF NOT EXISTS` makes duplicate sends safe
+ *     (ADR 0010), and a stray `companies` row whose card vanished causes no
+ *     correctness harm — the Backfill will attempt GitHub resolution for a
+ *     company that happens to have no live card, producing at worst a low-
+ *     value analytics row.
+ *   - The alternative — awaiting inside the transaction, or adding a
+ *     post-commit hook — would couple Scout latency to card-creation latency
+ *     or require a more complex transaction API. Both costs outweigh the
+ *     rare-rollback risk.
+ *   - See also: knowledge/wiki/company-scout.md § "Surprises / gotchas"
+ */
+export async function runCompanyCheck(
+  companyName: string,
+  cardUrls?: { applicationUrl?: string; careersUrl?: string },
+): Promise<void> {
+  logger.info('company_scout.first_sighting', {
+    service: 'company-scout',
+    company: companyName,
+    card_urls: cardUrls,
+  });
+
+  await registry.register(companyName, []);
+}

--- a/backend/src/services/companyScout/githubClient.ts
+++ b/backend/src/services/companyScout/githubClient.ts
@@ -1,0 +1,152 @@
+import { env } from '../../config/env';
+import logger from '../../config/logger';
+
+// Mirrors the 3 s timeout used for Clearbit in cardService.ts.
+const REQUEST_TIMEOUT_MS = 3000;
+
+export interface GitHubOrg {
+  login: string;
+  name: string | null;
+  public_repos: number;
+  followers: number;
+  // Public repos listed by listOrgRepos; absent from getOrg/searchOrgs responses.
+  repos?: GitHubRepo[];
+}
+
+export interface GitHubRepo {
+  name: string;
+  fork: boolean;
+  archived: boolean;
+  pushed_at: string | null;
+}
+
+export interface GitHubOrgSearchResult {
+  login: string;
+  // The search endpoint returns a stripped-down org object; name is not
+  // included — callers that need it must follow up with getOrg().
+}
+
+// --------------------------------------------------------------------------
+// Internal helpers
+// --------------------------------------------------------------------------
+
+function authHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (env.GITHUB_TOKEN) {
+    headers['Authorization'] = `Bearer ${env.GITHUB_TOKEN}`;
+  }
+  return headers;
+}
+
+async function githubFetch(url: string): Promise<Response | null> {
+  // When GITHUB_TOKEN is absent, short-circuit immediately without making any
+  // HTTP request.  The Scout's caller treats a null return as "Scout skipped".
+  if (!env.GITHUB_TOKEN) {
+    logger.warn('github_client.no_token', {
+      service: 'company-scout',
+      url,
+      message: 'GITHUB_TOKEN not configured — GitHub API call skipped',
+    });
+    return null;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: authHeaders(),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+
+    // Rate-limit detection: 403 + X-RateLimit-Remaining: 0
+    if (
+      res.status === 403 &&
+      res.headers.get('X-RateLimit-Remaining') === '0'
+    ) {
+      logger.warn('github_client.rate_limited', {
+        service: 'company-scout',
+        url,
+        reset: res.headers.get('X-RateLimit-Reset'),
+      });
+      return null;
+    }
+
+    return res;
+  } catch (err: unknown) {
+    clearTimeout(timer);
+    // AbortError means the timeout fired; other errors are network failures.
+    logger.warn('github_client.fetch_error', {
+      service: 'company-scout',
+      url,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Public API
+// --------------------------------------------------------------------------
+
+/**
+ * Fetch a single GitHub organization by login.
+ * Returns null on missing token, rate-limit, HTTP error, or timeout.
+ */
+export async function getOrg(login: string): Promise<GitHubOrg | null> {
+  const res = await githubFetch(`https://api.github.com/orgs/${encodeURIComponent(login)}`);
+  if (!res) return null;
+  if (!res.ok) return null;
+  const data = await res.json() as {
+    login: string;
+    name: string | null;
+    public_repos: number;
+    followers: number;
+  };
+  return {
+    login: data.login,
+    name: data.name ?? null,
+    public_repos: data.public_repos,
+    followers: data.followers,
+  };
+}
+
+/**
+ * List public repositories for an org (up to 100, sorted by push date).
+ * Returns null on missing token, rate-limit, HTTP error, or timeout.
+ */
+export async function listOrgRepos(login: string): Promise<GitHubRepo[] | null> {
+  const url = `https://api.github.com/orgs/${encodeURIComponent(login)}/repos?type=public&sort=pushed&per_page=100`;
+  const res = await githubFetch(url);
+  if (!res) return null;
+  if (!res.ok) return null;
+  const data = await res.json() as {
+    name: string;
+    fork: boolean;
+    archived: boolean;
+    pushed_at: string | null;
+  }[];
+  return data.map((r) => ({
+    name: r.name,
+    fork: r.fork,
+    archived: r.archived,
+    pushed_at: r.pushed_at ?? null,
+  }));
+}
+
+/**
+ * Search GitHub organizations by query string.
+ * Returns up to 30 results (GitHub's default page size for org search).
+ * Returns null on missing token, rate-limit, HTTP error, or timeout.
+ */
+export async function searchOrgs(query: string): Promise<GitHubOrgSearchResult[] | null> {
+  const url = `https://api.github.com/search/users?q=${encodeURIComponent(query)}+type:org&per_page=30`;
+  const res = await githubFetch(url);
+  if (!res) return null;
+  if (!res.ok) return null;
+  const data = await res.json() as { items: { login: string }[] };
+  return (data.items ?? []).map((item) => ({ login: item.login }));
+}

--- a/backend/src/services/companyScout/githubClient.ts
+++ b/backend/src/services/companyScout/githubClient.ts
@@ -47,7 +47,8 @@ async function githubFetch(url: string): Promise<Response | null> {
   if (!env.GITHUB_TOKEN) {
     logger.warn('github_client.no_token', {
       service: 'company-scout',
-      url,
+      // url intentionally omitted — no actionable info when token is simply absent,
+      // and including it would log every company name on the warn path.
       message: 'GITHUB_TOKEN not configured — GitHub API call skipped',
     });
     return null;
@@ -143,7 +144,7 @@ export async function listOrgRepos(login: string): Promise<GitHubRepo[] | null> 
  * Returns null on missing token, rate-limit, HTTP error, or timeout.
  */
 export async function searchOrgs(query: string): Promise<GitHubOrgSearchResult[] | null> {
-  const url = `https://api.github.com/search/users?q=${encodeURIComponent(query)}+type:org&per_page=30`;
+  const url = `https://api.github.com/search/users?q=${encodeURIComponent(query + ' type:org')}&per_page=30`;
   const res = await githubFetch(url);
   if (!res) return null;
   if (!res.ok) return null;

--- a/backend/src/services/companyScout/orgScorer.ts
+++ b/backend/src/services/companyScout/orgScorer.ts
@@ -8,7 +8,7 @@
  * See ADR 0009 for rationale.
  */
 
-import { extractATSSlug, ATS_PLATFORMS } from '../cardService';
+import { extractATSSlug } from '../cardService';
 
 // --------------------------------------------------------------------------
 // Weight constants — single editable place (ADR 0009)
@@ -40,7 +40,7 @@ export interface OrgCandidate {
   name: string | null;
   public_repos: number;
   followers: number;
-  /** When present, repos list is used to compute real-org credibility via repos. */
+  /** When present, non-fork count is used instead of public_repos for credibility scoring. */
   repos?: Array<{ fork: boolean; archived?: boolean }>;
   /**
    * When this candidate is being evaluated as an anchor-prefix sibling
@@ -210,5 +210,3 @@ export function scoreOrgCandidate(
   return score;
 }
 
-// Re-export so that consumers of orgScorer.ts don't also need to import cardService.
-export { extractATSSlug, ATS_PLATFORMS };

--- a/backend/src/services/companyScout/orgScorer.ts
+++ b/backend/src/services/companyScout/orgScorer.ts
@@ -1,0 +1,214 @@
+/**
+ * OrgScorer — weighted rubric for deciding whether a GitHub Org is the
+ * correct match for a Company name.
+ *
+ * All weights live here, in one place.  Tune them and the threshold
+ * without touching any other file.
+ *
+ * See ADR 0009 for rationale.
+ */
+
+import { extractATSSlug, ATS_PLATFORMS } from '../cardService';
+
+// --------------------------------------------------------------------------
+// Weight constants — single editable place (ADR 0009)
+// --------------------------------------------------------------------------
+
+export const W_EXACT_SLUG            =  50; // normalize(company) === normalize(org.login)
+export const W_STRONG_SLUG           =  30; // substring + length-ratio ≥ 0.7
+export const W_MODERATE_SLUG         =  15; // substring + length-ratio ≥ 0.5
+export const W_EXACT_DISPLAY_NAME    =  50; // normalize(company) === normalize(org.name)
+export const W_MODERATE_DISPLAY_NAME =  15; // substring + length-ratio ≥ 0.5
+export const W_ATS_SLUG_AGREES       =  40; // ATS slug extracted from URL matches org login
+export const W_ATS_SLUG_DISAGREES    = -50; // ATS slug present but does NOT match org login
+export const W_ANCHOR_PREFIX_SIBLING =  50; // org login starts with "<verified-anchor>-"
+export const W_REAL_ORG_REPOS        =  10; // org has ≥5 public non-fork repos
+export const W_REAL_ORG_FOLLOWERS    =  10; // org has ≥100 followers
+
+/**
+ * Acceptance threshold — candidates scoring below this are rejected.
+ * A single dial: lower for more coverage, raise to cut false positives.
+ */
+export const ORG_ACCEPT_THRESHOLD = 80;
+
+// --------------------------------------------------------------------------
+// Candidate shape expected by the scorer
+// --------------------------------------------------------------------------
+
+export interface OrgCandidate {
+  login: string;
+  name: string | null;
+  public_repos: number;
+  followers: number;
+  /** When present, repos list is used to compute real-org credibility via repos. */
+  repos?: Array<{ fork: boolean; archived?: boolean }>;
+  /**
+   * When this candidate is being evaluated as an anchor-prefix sibling
+   * (org login starts with "<verified-anchor>-"), provide the verified anchor
+   * login here.  Absent ↔ not a sibling pass.
+   */
+  anchorLogin?: string;
+}
+
+// --------------------------------------------------------------------------
+// Internal helpers
+// --------------------------------------------------------------------------
+
+/**
+ * Normalize a string for slug comparison: lowercase, strip non-alphanumeric.
+ * Matches the normalize pattern used elsewhere in cardService.ts.
+ */
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Compute length-ratio: shorter / longer.  Returns 1 when the strings are
+ * the same length.
+ */
+function lengthRatio(a: string, b: string): number {
+  const min = Math.min(a.length, b.length);
+  const max = Math.max(a.length, b.length);
+  if (max === 0) return 1;
+  return min / max;
+}
+
+/**
+ * True when `a` is a substring of `b` OR `b` is a substring of `a`.
+ */
+function isSubstring(a: string, b: string): boolean {
+  return a.includes(b) || b.includes(a);
+}
+
+/**
+ * Check whether any URL in the array looks like an ATS platform URL, and
+ * return the ATS slug if found.  Returns null when no URL hits an ATS entry
+ * that produces a slug.
+ *
+ * We re-use `extractATSSlug` from cardService to avoid duplicate logic.
+ * Only non-null, non-empty slugs are returned.
+ */
+function atsSlugFromUrls(urls: string[]): string | null {
+  for (const url of urls) {
+    try {
+      const slug = extractATSSlug(url);
+      if (slug && slug.length > 0) return slug;
+    } catch {
+      // malformed URL — skip
+    }
+  }
+  return null;
+}
+
+// --------------------------------------------------------------------------
+// Public scoring function
+// --------------------------------------------------------------------------
+
+/**
+ * Score a GitHub Org candidate against a Company name.
+ *
+ * @param company   The Company name as stored in JobFlow (e.g. "Wix").
+ * @param candidate The GitHub Org object returned by the API client.
+ * @param urls      Optional list of URLs from the Application (applicationUrl,
+ *                  careersUrl).  Used to extract the ATS slug signal.
+ * @returns         A numeric score.  Compare against ORG_ACCEPT_THRESHOLD.
+ */
+export function scoreOrgCandidate(
+  company: string,
+  candidate: OrgCandidate,
+  urls?: string[],
+): number {
+  let score = 0;
+
+  const normCompany = normalize(company);
+  const normLogin   = normalize(candidate.login);
+
+  // -----------------------------------------------------------------------
+  // Slug signals
+  // -----------------------------------------------------------------------
+
+  if (normCompany === normLogin) {
+    // Exact slug match — strongest positive signal
+    score += W_EXACT_SLUG;
+  } else {
+    const ratio = lengthRatio(normCompany, normLogin);
+    if (isSubstring(normCompany, normLogin) && ratio >= 0.7) {
+      score += W_STRONG_SLUG;
+    } else if (isSubstring(normCompany, normLogin) && ratio >= 0.5) {
+      score += W_MODERATE_SLUG;
+    }
+    // Below 0.5 ratio → no slug contribution.
+  }
+
+  // -----------------------------------------------------------------------
+  // Display-name signals
+  // -----------------------------------------------------------------------
+
+  if (candidate.name) {
+    const normName = normalize(candidate.name);
+    if (normCompany === normName) {
+      score += W_EXACT_DISPLAY_NAME;
+    } else {
+      const ratio = lengthRatio(normCompany, normName);
+      if (isSubstring(normCompany, normName) && ratio >= 0.5) {
+        score += W_MODERATE_DISPLAY_NAME;
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // ATS slug signal
+  // -----------------------------------------------------------------------
+
+  if (urls && urls.length > 0) {
+    const atsSlug = atsSlugFromUrls(urls);
+    if (atsSlug) {
+      const normAts = normalize(atsSlug);
+      if (normAts === normLogin) {
+        score += W_ATS_SLUG_AGREES;
+      } else {
+        // ATS slug is present and points at a different org — genuine negative
+        // evidence.  This is the only signal that subtracts from the score.
+        score += W_ATS_SLUG_DISAGREES;
+      }
+    }
+    // No ATS slug extractable from the URLs → no contribution either way.
+  }
+
+  // -----------------------------------------------------------------------
+  // Anchor-prefix sibling signal
+  // -----------------------------------------------------------------------
+
+  // A verified anchor is the canonical Org for this Company (scored and
+  // accepted in a prior pass).  Any Org whose login starts with
+  // "<anchor>-" is presumed to be a subsidiary or sub-project org — accept
+  // with full confidence.
+  if (candidate.anchorLogin) {
+    // login must literally start with "<anchor>-" (raw, not normalized, for
+    // prefix matching to be meaningful as a real org-naming convention)
+    if (candidate.login.toLowerCase().startsWith(candidate.anchorLogin.toLowerCase() + '-')) {
+      score += W_ANCHOR_PREFIX_SIBLING;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Real-org credibility
+  // -----------------------------------------------------------------------
+
+  // Prefer non-fork repos when a repos list is available; fall back to
+  // public_repos count (which includes forks) when it's not.
+  if (candidate.repos !== undefined) {
+    const nonForkCount = candidate.repos.filter((r) => !r.fork).length;
+    if (nonForkCount >= 5) score += W_REAL_ORG_REPOS;
+  } else if (candidate.public_repos >= 5) {
+    // repos list not available — use the org-level count as a proxy
+    score += W_REAL_ORG_REPOS;
+  }
+
+  if (candidate.followers >= 100) score += W_REAL_ORG_FOLLOWERS;
+
+  return score;
+}
+
+// Re-export so that consumers of orgScorer.ts don't also need to import cardService.
+export { extractATSSlug, ATS_PLATFORMS };

--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -13,6 +13,10 @@ Each entry: **what happened → what we'd change**. Skip generic platitudes.
 
 ---
 
+## 2026-05-24 (PR #244 — Company Scout slice 1)
+
+- **Global dedup in `createCard` must use the base `db` instance, not the caller's `trx`.** The First Sighting check queries `cards.company_name` globally across all users; using `runner` (which may be a `trx`) would scope the read to uncommitted rows inside the current transaction, making concurrent creates race past the dedup. → Always use `db` (not `runner`/`trx`) for reads that need committed global state even when the surrounding write uses a transaction.
+
 ## 2026-05-24 (PR #242 — fetcher p-limit bump)
 
 - **File size varies ~3× across different months of GH Archive.** Jan 2025 files averaged ~77 MB/hour vs ~25 MB for May 2026 — GitHub event volume grew significantly. When benchmarking fetcher throughput, files/sec is a misleading metric across different date ranges; MB/s is the correct comparison. The p-limit(3→6) bump yielded ~2.2× MB/s improvement (71 vs 33 MB/s) on the Xubuntu box, clearing the >1.3× approval threshold.

--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -13,6 +13,12 @@ Each entry: **what happened → what we'd change**. Skip generic platitudes.
 
 ---
 
+## 2026-05-24 (PR #247 — Company Scout slice 2)
+
+- **OrgScorer calibration: exact-slug-only orgs naturally stay below threshold without threshold tuning.** Small/unknown orgs that happen to have an exact slug match (e.g. `faye`, `rise`) score only 50 (exact slug +50 but no credibility signals). Real anchor orgs score 85–120 because they have followers ≥100 (+10) and repos ≥5 (+10) plus display-name match. No weight adjustment was needed on first implementation — the ADR 0009 starting weights were correct. → Trust the rubric's credibility signals to do the disambiguation work; don't inflate the threshold to compensate for calibration failures you haven't yet measured.
+- **Worktrees vs main checkout: write files into the right tree.** When a worktree exists at `.claude/worktrees/<name>`, edits to `/Users/itc/Desktop/jobflow/...` go into the main checkout (a different git working tree), not the worktree. Always verify which git working tree a path resolves to before writing implementation files; use the worktree's absolute path explicitly.
+- **`git stash`+`stash pop` in the main checkout can silently switch that checkout's branch state** when background agents or stash operations touch it mid-session. The worktree is isolated from this, but writing files to the main checkout path while it's been stash-popped to a different branch creates confusion. Prefer writing to worktree paths directly and avoid touching the main checkout during a worktree-based ship.
+
 ## 2026-05-24 (PR #244 — Company Scout slice 1)
 
 - **Global dedup in `createCard` must use the base `db` instance, not the caller's `trx`.** The First Sighting check queries `cards.company_name` globally across all users; using `runner` (which may be a `trx`) would scope the read to uncommitted rows inside the current transaction, making concurrent creates race past the dedup. → Always use `db` (not `runner`/`trx`) for reads that need committed global state even when the surrounding write uses a transaction.

--- a/knowledge/wiki/company-scout.md
+++ b/knowledge/wiki/company-scout.md
@@ -11,7 +11,7 @@ sources:
 related: [[application]] [[company]] [[first-sighting]] [[org]] [[active-github-presence]] [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[email-agent]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0009-org-scorer-weighted-scoring]] [[adr-0010-https-shim-write-path]]
 updated: 2026-05-24
 status: stable
-shipped: "#181 (slice 1)"
+shipped: "#181 (slice 1), #182 (slice 2 — PR #247)"
 ---
 
 # Company Scout
@@ -56,7 +56,7 @@ The analytics pipeline can't profile a Company until its `(Company, Org)` rows e
   - Company adds a new Org months later → Scout doesn't re-evaluate; the new Org is never registered.
   - All cards for a Company are deleted then a new one is added → Scout fires again; previously-registered Orgs return `already_exists` from the shim (safe).
 - **`active` column in `companies` is effectively always `true` in v1.** Only active Orgs are written, so the column never carries a `false` value through this path. The schema retains it for future flexibility; no v1 change.
-- **The OrgScorer is uncalibrated until implementation.** The 80-point threshold is a starting point; calibration against the existing ~74-Company dataset happens once during implementation and is then frozen unless drift is observed.
+- **OrgScorer calibration result (slice 2).** No weight tuning was needed. Under the ADR 0009 starting weights: Wix→wix (85), Tenable→tenable (120), Salesforce→salesforce (120) all pass ≥80; Riverside→Riverside-Software (40), Faye→faye (50), Rise→rise (50) all reject <80. The key mechanism: exact slug (+50) alone doesn't clear the threshold — the credibility signals (repos +10, followers +10) and display-name match together push anchors over 80, while small/unknown orgs with only an exact slug hit stay at 50.
 
 ## Open questions
 
@@ -67,7 +67,8 @@ The analytics pipeline can't profile a Company until its `(Company, Org)` rows e
 
 - Trigger site: `backend/src/services/cardService.ts` (in `createCard`)
 - Scout orchestrator: `backend/src/services/companyScout/companyScout.ts` (skeleton — slice 1); `companyRegistry.ts` (LoggingCompanyRegistry — slice 1)
-- OrgScorer module: `backend/src/services/companyScout/orgScorer.ts` (planned — slice 2/3)
+- GitHub API client: `backend/src/services/companyScout/githubClient.ts` (shipped — slice 2 / PR #247)
+- OrgScorer module: `backend/src/services/companyScout/orgScorer.ts` (shipped — slice 2 / PR #247)
 - HTTPS shim: separate deliverable in `data-pipeline/` repo (not in JobFlow)
 - Cassandra schema: `data-pipeline/schema/004_companies.cql` + `005_alter_companies_initialized.cql`
 - Canonical pipeline design: `docs/CassandraPlan.md` §4.4 (`companies` table)

--- a/knowledge/wiki/company-scout.md
+++ b/knowledge/wiki/company-scout.md
@@ -11,6 +11,7 @@ sources:
 related: [[application]] [[company]] [[first-sighting]] [[org]] [[active-github-presence]] [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[email-agent]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0009-org-scorer-weighted-scoring]] [[adr-0010-https-shim-write-path]]
 updated: 2026-05-24
 status: stable
+shipped: "#181 (slice 1)"
 ---
 
 # Company Scout
@@ -65,8 +66,8 @@ The analytics pipeline can't profile a Company until its `(Company, Org)` rows e
 ## Source pointers
 
 - Trigger site: `backend/src/services/cardService.ts` (in `createCard`)
-- Scout orchestrator: `backend/src/services/companyScout/` (planned)
-- OrgScorer module: `backend/src/services/companyScout/orgScorer.ts` (planned)
+- Scout orchestrator: `backend/src/services/companyScout/companyScout.ts` (skeleton — slice 1); `companyRegistry.ts` (LoggingCompanyRegistry — slice 1)
+- OrgScorer module: `backend/src/services/companyScout/orgScorer.ts` (planned — slice 2/3)
 - HTTPS shim: separate deliverable in `data-pipeline/` repo (not in JobFlow)
 - Cassandra schema: `data-pipeline/schema/004_companies.cql` + `005_alter_companies_initialized.cql`
 - Canonical pipeline design: `docs/CassandraPlan.md` §4.4 (`companies` table)


### PR DESCRIPTION
## Summary

- Add `githubClient.ts`: thin GitHub API wrapper with `getOrg`, `listOrgRepos`, `searchOrgs`; 3 s timeout (mirrors Clearbit pattern); returns null on rate-limit (403 + `X-RateLimit-Remaining: 0`) and short-circuits to null without any HTTP call when `GITHUB_TOKEN` is absent
- Add `orgScorer.ts`: `scoreOrgCandidate(company, candidate, urls?)` pure function + `ORG_ACCEPT_THRESHOLD = 80` + all weight constants in one file per ADR 0009; ATS-slug-disagrees is the only negative signal (−50)
- Export `ATSEntry`, `ATS_PLATFORMS`, `extractATSSlug` from `cardService.ts` so `orgScorer.ts` reuses the ATS platform table without duplication

Both modules are dormant — nothing in JobFlow's runtime calls them yet (wired in slice #183).

## Acceptance criteria

- [x] GitHub API client exposes `getOrg`, `listOrgRepos`, `searchOrgs`; sends the token, applies the short timeout, and returns null on a rate-limited response
- [x] When `GITHUB_TOKEN` is absent, the API client returns null on every call without making an HTTP request
- [x] `OrgScorer` exposes `scoreOrgCandidate(company, candidate, urls?)`, `ORG_ACCEPT_THRESHOLD = 80`, and the weight constants — all in one file
- [x] Each scoring signal in the starting rubric is implemented and contributes the listed weight
- [x] ATS-slug-present-but-disagrees produces a negative contribution (the only signal that can subtract from the score)
- [x] Manual calibration: Wix→wix (85), Tenable→tenable (120), Salesforce→salesforce (120) all ≥80; Riverside→Riverside-Software (40), Faye→faye (50), Rise→rise (50) all <80; no weight tuning needed
- [x] Nothing in JobFlow's runtime code calls either module yet — they are dormant until slice #183

## Stacking / dependencies

> **Blocked by #244 / depends on #181**
>
> This is a stacked PR. The branch `feature/company-scout-slice-2-api-client-orgscorer` is based on `feature/company-scout-slice-1-first-sighting-trigger-scout-skeleton` (PR #244), **not** on `main`. The diff shown here includes cumulative changes from slice 1 as well. Do not merge until PR #244 lands on main.

## Related

Closes #182
Parent PRD: #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)