### PR TITLE
Company Scout slice 4: HttpShimCompanyRegistry (production write path)

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -40,6 +40,10 @@ const schema = z.object({
     ctx.addIssue({ code: 'custom', path: ['COMPANY_REGISTRY_TOKEN'], message: 'COMPANY_REGISTRY_TOKEN is required when COMPANY_REGISTRY_URL is set' });
   }
 
+  if (v.COMPANY_REGISTRY_URL && !v.COMPANY_REGISTRY_URL.startsWith('https://')) {
+    ctx.addIssue({ code: 'custom', path: ['COMPANY_REGISTRY_URL'], message: 'COMPANY_REGISTRY_URL must use https:// in production (bearer token must not be sent in plaintext)' });
+  }
+
   for (const [k, defaultVal] of [
     ['CORS_ORIGIN', 'http://localhost:5173'],
     ['BACKEND_URL', 'http://localhost:3001'],

--- a/backend/src/services/companyScout/companyRegistry.ts
+++ b/backend/src/services/companyScout/companyRegistry.ts
@@ -1,4 +1,5 @@
 import logger from '../../config/logger';
+import { env } from '../../config/env';
 
 export interface ActiveOrg {
   org_name: string;
@@ -12,7 +13,7 @@ export interface CompanyRegistry {
 /**
  * Dev fallback used when COMPANY_REGISTRY_URL is not configured. Logs a
  * structured line describing what would have been POSTed to the HTTPS shim.
- * HttpShimCompanyRegistry (slice #184) is the production implementation.
+ * HttpShimCompanyRegistry is the production implementation.
  */
 export class LoggingCompanyRegistry implements CompanyRegistry {
   register(company: string, activeOrgs: ActiveOrg[]): Promise<void> {
@@ -24,4 +25,105 @@ export class LoggingCompanyRegistry implements CompanyRegistry {
     });
     return Promise.resolve();
   }
+}
+
+interface ShimResult {
+  org_name: string;
+  status: 'registered' | 'already_exists';
+}
+
+interface ShimResponse {
+  company: string;
+  results: ShimResult[];
+}
+
+/**
+ * Production implementation — POSTs one batch per Company to the HTTPS shim
+ * running alongside Cassandra on the analytics-pipeline host. See ADR 0010.
+ *
+ * Fire-and-forget: network errors, 4xx, and 5xx are caught and logged at
+ * warn; they never propagate so card creation latency is unaffected.
+ */
+export class HttpShimCompanyRegistry implements CompanyRegistry {
+  private readonly url: string;
+  private readonly token: string;
+
+  constructor(url: string, token: string) {
+    this.url = url;
+    this.token = token;
+  }
+
+  async register(company: string, activeOrgs: ActiveOrg[]): Promise<void> {
+    const controller = new AbortController();
+    // Mirror the 3 s Clearbit timeout used elsewhere in the backend.
+    const timer = setTimeout(() => controller.abort(), 3000);
+
+    try {
+      const res = await fetch(`${this.url}/companies`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          company,
+          active_orgs: activeOrgs,
+        }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+
+      if (!res.ok) {
+        logger.warn('company_registry.http_error', {
+          service: 'company-scout',
+          company,
+          status: res.status,
+        });
+        return;
+      }
+
+      const data = (await res.json()) as ShimResponse;
+
+      for (const result of data.results) {
+        if (result.status === 'registered') {
+          const org = activeOrgs.find((o) => o.org_name === result.org_name);
+          logger.info('company_registry.registered', {
+            service: 'company-scout',
+            company,
+            org: result.org_name,
+            last_repo_push: org?.last_repo_push ?? null,
+          });
+        } else if (result.status === 'already_exists') {
+          logger.info('company_registry.already_exists', {
+            service: 'company-scout',
+            company,
+            org: result.org_name,
+          });
+        }
+      }
+    } catch (err: unknown) {
+      clearTimeout(timer);
+      logger.warn('company_registry.network_error', {
+        service: 'company-scout',
+        company,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Resolve which CompanyRegistry implementation to use at startup:
+ * - COMPANY_REGISTRY_URL set → HttpShimCompanyRegistry (production)
+ * - COMPANY_REGISTRY_URL unset → LoggingCompanyRegistry (dev fallback)
+ */
+export function resolveRegistry(): CompanyRegistry {
+  if (env.COMPANY_REGISTRY_URL) {
+    return new HttpShimCompanyRegistry(
+      env.COMPANY_REGISTRY_URL,
+      env.COMPANY_REGISTRY_TOKEN ?? '',
+    );
+  }
+  return new LoggingCompanyRegistry();
 }

--- a/backend/src/services/companyScout/companyScout.ts
+++ b/backend/src/services/companyScout/companyScout.ts
@@ -1,14 +1,13 @@
 import logger from '../../config/logger';
-import { LoggingCompanyRegistry, type CompanyRegistry } from './companyRegistry';
+import { resolveRegistry, type CompanyRegistry } from './companyRegistry';
 import { resolveOrgs } from './orgResolver';
 import { listOrgRepos } from './githubClient';
 import { latestActivePush } from './activePresenceClassifier';
 
 // The registry singleton is resolved once at module load time.
-// HttpShimCompanyRegistry (slice #184) will be swapped in here when
-// COMPANY_REGISTRY_URL is configured; for now LoggingCompanyRegistry is the
-// only implementation.
-const registry: CompanyRegistry = new LoggingCompanyRegistry();
+// HttpShimCompanyRegistry is used when COMPANY_REGISTRY_URL is set (production);
+// LoggingCompanyRegistry is the dev fallback (COMPANY_REGISTRY_URL unset).
+const registry: CompanyRegistry = resolveRegistry();
 
 /**
  * Runs the Company Scout for a Company on its First Sighting.
@@ -19,8 +18,9 @@ const registry: CompanyRegistry = new LoggingCompanyRegistry();
  *   3. Keep only Orgs with Active GitHub Presence.
  *   4. Build the activeOrgs payload and hand off to CompanyRegistry.register.
  *
- * In this slice the registry is LoggingCompanyRegistry — real `registered` /
- * `already_exists` statuses arrive in slice #184 with the HTTPS shim client.
+ * In production (COMPANY_REGISTRY_URL set) the registry is HttpShimCompanyRegistry
+ * which returns real `registered` / `already_exists` statuses from the shim.
+ * In dev (URL unset) LoggingCompanyRegistry is the fallback.
  *
  * ---
  * ACCEPTED EDGE CASE — gmailSync transaction-boundary race:
@@ -118,7 +118,8 @@ export async function runCompanyCheck(
     }
 
     // ------------------------------------------------------------------
-    // Step 3 — Hand off to registry (LoggingCompanyRegistry in this slice)
+    // Step 3 — Hand off to registry (HttpShimCompanyRegistry in production;
+    //           LoggingCompanyRegistry when COMPANY_REGISTRY_URL is unset)
     // ------------------------------------------------------------------
 
     await registry.register(companyName, activeOrgs);

--- a/backend/src/services/companyScout/companyScout.ts
+++ b/backend/src/services/companyScout/companyScout.ts
@@ -12,7 +12,7 @@ const registry: CompanyRegistry = resolveRegistry();
 /**
  * Runs the Company Scout for a Company on its First Sighting.
  *
- * Full end-to-end flow (slice #183):
+ * Full end-to-end flow (slices #181–#184):
  *   1. Org Resolver → accepted candidate Orgs (slug probe + search + prefix sweep).
  *   2. For each accepted Org: listOrgRepos → Active-Presence Classifier.
  *   3. Keep only Orgs with Active GitHub Presence.

--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -13,6 +13,8 @@ Each entry: **what happened → what we'd change**. Skip generic platitudes.
 
 ---
 
+- **2026-05-24 — slice 4 ship (PR #249).** Edits made in the main working dir (on the wrong slice-3 branch) were copied to the worktree via `cp` before staging — the worktree isolation pattern means all Edit/Write calls must target the worktree path directly, not the main jobflow dir. → When shipping in a worktree context, always compute the absolute worktree path and pass it to Edit/Write from the start; don't rely on the main checkout.
+
 ## 2026-05-24 (PR #248 — Company Scout slice 3)
 
 - **Anchor prefix sweep requires an explicit login-prefix filter after `searchOrgs`.** `searchOrgs("wix-")` returns any org whose name or login contains "wix-", not just those whose login literally starts with `wix-`. Always filter results with `login.toLowerCase().startsWith(anchor + "-")` before scoring — otherwise unrelated orgs that happen to contain the anchor substring get the W_ANCHOR_PREFIX_SIBLING bonus. This filter is in `orgResolver.ts:prefixResults.filter`.

--- a/knowledge/wiki/company-scout.md
+++ b/knowledge/wiki/company-scout.md
@@ -11,7 +11,7 @@ sources:
 related: [[application]] [[company]] [[first-sighting]] [[org]] [[active-github-presence]] [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[email-agent]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0009-org-scorer-weighted-scoring]] [[adr-0010-https-shim-write-path]]
 updated: 2026-05-24
 status: stable
-shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248)"
+shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248), #184 (slice 4 — PR #249)"
 ---
 
 # Company Scout
@@ -66,7 +66,7 @@ The analytics pipeline can't profile a Company until its `(Company, Org)` rows e
 ## Source pointers
 
 - Trigger site: `backend/src/services/cardService.ts` (in `createCard`)
-- Scout orchestrator: `backend/src/services/companyScout/companyScout.ts` (wired end-to-end — slice 3 / PR #248); `companyRegistry.ts` (LoggingCompanyRegistry — slice 1)
+- Scout orchestrator: `backend/src/services/companyScout/companyScout.ts` (wired end-to-end — slice 3 / PR #248); `companyRegistry.ts` (LoggingCompanyRegistry dev fallback — slice 1; HttpShimCompanyRegistry production impl + resolveRegistry() factory — slice 4 / PR #249)
 - Org Resolver: `backend/src/services/companyScout/orgResolver.ts` (shipped — slice 3 / PR #248)
 - Active-Presence Classifier: `backend/src/services/companyScout/activePresenceClassifier.ts` (shipped — slice 3 / PR #248)
 - GitHub API client: `backend/src/services/companyScout/githubClient.ts` (shipped — slice 2 / PR #247)


### PR DESCRIPTION
## Summary

- Adds `HttpShimCompanyRegistry` — the production `CompanyRegistry` implementation that POSTs accepted active Orgs to the analytics-pipeline HTTPS shim (one POST per Company, per ADR 0010)
- Bearer-token auth via `COMPANY_REGISTRY_TOKEN`; 3 s timeout; per-Org `registered`/`already_exists` outcomes logged at `info`; network/4xx/5xx errors logged at `warn` and never propagated
- Composition-root selection: `resolveRegistry()` uses `HttpShimCompanyRegistry` when `COMPANY_REGISTRY_URL` is set; falls back to `LoggingCompanyRegistry` in dev

## Acceptance criteria

- [x] `HttpShimCompanyRegistry` implements the `CompanyRegistry` interface and is used in production
- [x] One POST per Company; request body matches the wire contract in PRD #180 ("CompanyRegistry seam and the HTTPS shim") and ADR 0010
- [x] Bearer token from `COMPANY_REGISTRY_TOKEN` is included in the `Authorization` header
- [x] Per-Org `registered` outcomes are logged with the Company name, Org login, and `last_repo_push` (one line per Org)
- [x] Per-Org `already_exists` outcomes are logged with the Company name and Org login (one line per Org)
- [x] Network error / 4xx / 5xx responses are caught, logged at `warn`, and never delay or fail card creation
- [x] In development with `COMPANY_REGISTRY_URL` unset, behaviour is unchanged from slice #183 (uses `LoggingCompanyRegistry`); in production, `HttpShimCompanyRegistry` is used
- [x] No new database fields, no migration, no Notification, no user-facing change

## Stacked PR — do not merge out of order

This PR is the **top of a 4-PR stack**. All four must be merged in order before this one lands:

```
#244 (slice 1 — CompanyRegistry seam)
  → #247 (slice 2 — OrgScorer + GitHub client)
    → #248 (slice 3 — Org Resolver + Active-Presence Classifier; base of this branch)
      → THIS PR (slice 4 — HttpShimCompanyRegistry)
```

**Do not merge this PR until #244, #247, and #248 are merged first.**

## Shim-blocked — do not merge until the shim is deployed

This PR also has a coordination dependency that is **not just a merge-order issue**: the HTTPS shim it calls (issue #246, `data-pipeline/` deliverable) has not yet been built or deployed. Merging and deploying this PR before the shim is running and its contract is confirmed will cause all Scout writes to fail silently (logged at `warn`, never propagated, but silently unregistered forever — see ADR 0010 / `knowledge/wiki/company-scout.md` Open Questions).

**Do not merge or deploy until:**
1. All four stacked PRs above are merged in order, AND
2. Issue #246 (HTTPS shim) is deployed to the Xubuntu box, AND
3. The wire contract (`POST /companies`, `INSERT … IF NOT EXISTS`, `initialized = false` invariant from ADR 0003) is confirmed honored by the running shim

## Related

Closes #184
Part of PRD #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)