### PR TITLE
Cassandra write shim: HTTPS endpoint on the Linux box for Company Scout writes

### DIFF
--- a/data-pipeline/shim/.env.example
+++ b/data-pipeline/shim/.env.example
@@ -1,10 +1,17 @@
 # Copy to .env and fill in real values before starting the shim.
 # This file is committed; .env is gitignored.
+#
+# After copying, lock down the real file so only the service user can read it:
+#   chmod 600 /opt/jobflow/data-pipeline/shim/.env
+#
+# Never commit the real .env. Never paste real token values into chat,
+# screenshots, or commit messages.
 
 # Port the shim binds on localhost (reverse-proxy forwards to this)
 SHIM_PORT=3100
 
 # Shared secret — must match COMPANY_REGISTRY_TOKEN in JobFlow's Render env vars.
+# Generate a fresh value with: openssl rand -hex 32
 # Rotate by updating this value and restarting the shim, then updating Render.
 SHIM_BEARER_TOKEN=change-me
 

--- a/data-pipeline/shim/.env.example
+++ b/data-pipeline/shim/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env and fill in real values before starting the shim.
+# This file is committed; .env is gitignored.
+
+# Port the shim binds on localhost (reverse-proxy forwards to this)
+SHIM_PORT=3100
+
+# Shared secret — must match COMPANY_REGISTRY_TOKEN in JobFlow's Render env vars.
+# Rotate by updating this value and restarting the shim, then updating Render.
+SHIM_BEARER_TOKEN=change-me
+
+# Cassandra connection — same values as ingester/.env
+CASSANDRA_CONTACT_POINTS=127.0.0.1
+CASSANDRA_LOCAL_DC=datacenter1
+CASSANDRA_KEYSPACE=jobflow
+
+# Optional
+LOG_LEVEL=info
+NODE_ENV=production

--- a/data-pipeline/shim/RUNBOOK.md
+++ b/data-pipeline/shim/RUNBOOK.md
@@ -20,6 +20,11 @@ Render (JobFlow)
 
 Cassandra's native port (9042) is never reachable from outside the box.
 
+**Process model:** Cassandra runs as a Docker container managed by `docker compose`
+(see `data-pipeline/SETUP.md`); the shim runs as a *native* systemd service
+(`jobflow-shim`), not in a container. Both processes are local to this box and
+communicate over `127.0.0.1` — no container/host networking concerns.
+
 ---
 
 ## Deploy steps (first-time)
@@ -45,7 +50,13 @@ npm install --omit=dev
 cp /opt/jobflow/data-pipeline/shim/.env.example /opt/jobflow/data-pipeline/shim/.env
 # Edit .env: set SHIM_BEARER_TOKEN and verify Cassandra vars
 nano /opt/jobflow/data-pipeline/shim/.env
+
+# Lock the env file — it contains SHIM_BEARER_TOKEN.
+sudo chown tomer:tomer /opt/jobflow/data-pipeline/shim/.env
+chmod 600 /opt/jobflow/data-pipeline/shim/.env
 ```
+
+Generate a strong token: `openssl rand -hex 32`.
 
 `SHIM_BEARER_TOKEN` must match `COMPANY_REGISTRY_TOKEN` in JobFlow's Render
 environment variables.
@@ -106,9 +117,12 @@ at reload time). Check: `sudo journalctl -u caddy -n 30`.
 5. Trigger a Render redeploy (env var change auto-triggers it)
 
 Both sides must be updated atomically in terms of effect — there is a brief
-window while Render is restarting where Scout writes will fail (JobFlow returns
-a log line from `LoggingCompanyRegistry`). This is acceptable for the v1
-write volume.
+window while Render is restarting where Scout writes will fail. **The Company
+Scout has no retry**: per `knowledge/wiki/company-scout.md` (Surprises /
+gotchas), any First Sighting that hits the shim during this window is silently
+un-registered until the same Company is sighted again. For v1 the write volume
+is sparse enough that this gap is acceptable; if it becomes a real problem,
+the documented future fix is a manual re-trigger admin endpoint.
 
 ---
 
@@ -124,6 +138,10 @@ sudo journalctl -u jobflow-shim -f
 # Confirm it is bound on localhost only
 ss -tlnp | grep 3100
 # expected: 127.0.0.1:3100 — NOT 0.0.0.0:3100
+
+# Unauthenticated liveness check via Caddy (no bearer required)
+curl -fsS https://YOUR_DOMAIN/health
+# expected: {"status":"ok"}
 ```
 
 ---
@@ -181,6 +199,51 @@ docker exec -it jobflow-cassandra cqlsh -e \
 # ── Step 5: Clean up the test row ────────────────────────────────────────────
 docker exec -it jobflow-cassandra cqlsh -e \
   "DELETE FROM jobflow.companies WHERE company = 'smoke-test-co' AND org_name = 'smoke-test-org';"
+```
+
+### Negative-path smoke checks
+
+The shim should reject malformed or unauthorised requests cleanly. Run these
+once after a fresh deploy to confirm the auth, validation, and method-routing
+paths all behave:
+
+```bash
+# 401 — wrong token
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "${SHIM_URL}/companies" \
+  -H "Authorization: Bearer wrong-token" \
+  -H "Content-Type: application/json" \
+  -d '{"company":"x","active_orgs":[{"org_name":"y","last_repo_push":"2026-01-01T00:00:00Z"}]}'
+# expected: 401
+
+# 400 — invalid JSON body
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "${SHIM_URL}/companies" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d 'not-json'
+# expected: 400
+
+# 400 — missing required field (last_repo_push)
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "${SHIM_URL}/companies" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"company":"x","active_orgs":[{"org_name":"y"}]}'
+# expected: 400
+
+# 415 — wrong Content-Type
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "${SHIM_URL}/companies" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: text/plain" \
+  -d 'whatever'
+# expected: 415
+
+# 405 — wrong method on /companies (Caddy rejects before reaching shim)
+curl -sS -o /dev/null -w "%{http_code}\n" -X GET "${SHIM_URL}/companies" \
+  -H "Authorization: Bearer ${TOKEN}"
+# expected: 405
+
+# 404 — unknown path
+curl -sS -o /dev/null -w "%{http_code}\n" "${SHIM_URL}/nope"
+# expected: 404
 ```
 
 ---

--- a/data-pipeline/shim/RUNBOOK.md
+++ b/data-pipeline/shim/RUNBOOK.md
@@ -1,0 +1,209 @@
+# JobFlow Cassandra Write Shim — Operator Runbook
+
+The shim is a small Node HTTP service running on the Xubuntu box at
+`tomer@192.168.10.12`. It exposes one authenticated endpoint (`POST /companies`)
+that JobFlow's `HttpShimCompanyRegistry` calls to register `(company, org)` pairs
+into the `jobflow.companies` Cassandra table using `INSERT … IF NOT EXISTS`.
+
+---
+
+## Architecture
+
+```
+Render (JobFlow)
+  └─ HttpShimCompanyRegistry
+       └─ POST https://YOUR_DOMAIN/companies
+            └─ Caddy (TLS termination, Let's Encrypt)
+                 └─ 127.0.0.1:3100 ← shim.js (systemd: jobflow-shim)
+                      └─ 127.0.0.1:9042 ← Cassandra (Docker)
+```
+
+Cassandra's native port (9042) is never reachable from outside the box.
+
+---
+
+## Deploy steps (first-time)
+
+### 1. Prerequisites
+
+- Node ≥ 20.6 on PATH
+- Cassandra running via `docker compose` (see `data-pipeline/SETUP.md`)
+- A public hostname with a DNS A record pointing to the box's WAN IP
+  (the Caddy block in `deploy/Caddyfile` must match this hostname)
+- Port 443 open on the router/firewall; port 3100 is NOT forwarded externally
+
+### 2. Install Node dependencies
+
+```bash
+cd /opt/jobflow/data-pipeline/shim
+npm install --omit=dev
+```
+
+### 3. Create the env file
+
+```bash
+cp /opt/jobflow/data-pipeline/shim/.env.example /opt/jobflow/data-pipeline/shim/.env
+# Edit .env: set SHIM_BEARER_TOKEN and verify Cassandra vars
+nano /opt/jobflow/data-pipeline/shim/.env
+```
+
+`SHIM_BEARER_TOKEN` must match `COMPANY_REGISTRY_TOKEN` in JobFlow's Render
+environment variables.
+
+### 4. Install and start the systemd unit
+
+```bash
+sudo cp /opt/jobflow/data-pipeline/shim/deploy/jobflow-shim.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now jobflow-shim
+sudo systemctl status jobflow-shim   # should show "Active: active (running)"
+```
+
+### 5. Install Caddy (if not already present)
+
+```bash
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update && sudo apt install caddy
+```
+
+### 6. Install the Caddyfile
+
+```bash
+# Replace YOUR_DOMAIN with the real hostname in the file first
+sudo cp /opt/jobflow/data-pipeline/shim/deploy/Caddyfile /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+```
+
+Caddy will provision a Let's Encrypt cert automatically on first request (or
+at reload time). Check: `sudo journalctl -u caddy -n 30`.
+
+---
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `SHIM_PORT` | no | `3100` | Port shim binds on localhost |
+| `SHIM_BEARER_TOKEN` | **yes** | — | Shared secret; must match `COMPANY_REGISTRY_TOKEN` in Render |
+| `CASSANDRA_CONTACT_POINTS` | **yes** | — | Comma-separated host list (e.g. `127.0.0.1`) |
+| `CASSANDRA_LOCAL_DC` | **yes** | — | Cassandra local datacenter name (e.g. `datacenter1`) |
+| `CASSANDRA_KEYSPACE` | no | `jobflow` | Cassandra keyspace |
+| `LOG_LEVEL` | no | `info` | Pino log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`) |
+| `NODE_ENV` | no | — | Set to `production` to disable pino-pretty |
+
+---
+
+## Rotating the shared secret
+
+1. Generate a new secret: `openssl rand -hex 32`
+2. Update `SHIM_BEARER_TOKEN` in `/opt/jobflow/data-pipeline/shim/.env`
+3. Restart the shim: `sudo systemctl restart jobflow-shim`
+4. Update `COMPANY_REGISTRY_TOKEN` in JobFlow's Render environment variables
+5. Trigger a Render redeploy (env var change auto-triggers it)
+
+Both sides must be updated atomically in terms of effect — there is a brief
+window while Render is restarting where Scout writes will fail (JobFlow returns
+a log line from `LoggingCompanyRegistry`). This is acceptable for the v1
+write volume.
+
+---
+
+## Verify it is running
+
+```bash
+# Service status
+sudo systemctl status jobflow-shim
+
+# Tail live logs
+sudo journalctl -u jobflow-shim -f
+
+# Confirm it is bound on localhost only
+ss -tlnp | grep 3100
+# expected: 127.0.0.1:3100 — NOT 0.0.0.0:3100
+```
+
+---
+
+## End-to-end smoke test
+
+Run from any machine with internet access (replace values as needed):
+
+```bash
+SHIM_URL="https://YOUR_DOMAIN"
+TOKEN="your-bearer-token"
+
+# ── Step 1: POST a synthetic Company ─────────────────────────────────────────
+curl -s -X POST "${SHIM_URL}/companies" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "company": "smoke-test-co",
+    "active_orgs": [
+      { "org_name": "smoke-test-org", "last_repo_push": "2026-05-24T00:00:00Z" }
+    ]
+  }' | jq .
+
+# Expected response:
+# { "company": "smoke-test-co", "results": [{ "org_name": "smoke-test-org", "status": "registered" }] }
+
+# ── Step 2: Confirm row in Cassandra with initialized = false ─────────────────
+# On the Xubuntu box:
+docker exec -it jobflow-cassandra cqlsh -e \
+  "SELECT company, org_name, active, initialized FROM jobflow.companies WHERE company = 'smoke-test-co';"
+
+# Expected output:
+#  company       | org_name        | active | initialized
+# ---------------+-----------------+--------+-------------
+#  smoke-test-co | smoke-test-org  |   True |       False
+
+# ── Step 3: Re-POST the same body → should return already_exists ─────────────
+curl -s -X POST "${SHIM_URL}/companies" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "company": "smoke-test-co",
+    "active_orgs": [
+      { "org_name": "smoke-test-org", "last_repo_push": "2026-05-24T00:00:00Z" }
+    ]
+  }' | jq .
+
+# Expected response:
+# { "company": "smoke-test-co", "results": [{ "org_name": "smoke-test-org", "status": "already_exists" }] }
+
+# ── Step 4: Confirm row is unchanged (initialized still false, not regressed) ─
+docker exec -it jobflow-cassandra cqlsh -e \
+  "SELECT company, org_name, active, initialized FROM jobflow.companies WHERE company = 'smoke-test-co';"
+
+# ── Step 5: Clean up the test row ────────────────────────────────────────────
+docker exec -it jobflow-cassandra cqlsh -e \
+  "DELETE FROM jobflow.companies WHERE company = 'smoke-test-co' AND org_name = 'smoke-test-org';"
+```
+
+---
+
+## Roll back
+
+If the shim needs to be disabled:
+
+```bash
+sudo systemctl stop jobflow-shim
+sudo systemctl disable jobflow-shim
+```
+
+JobFlow falls back to `LoggingCompanyRegistry` automatically when
+`COMPANY_REGISTRY_URL` is unset or unreachable — no code change required.
+Remove or clear `COMPANY_REGISTRY_URL` from Render env vars to activate the
+fallback without removing the token.
+
+---
+
+## Where logs go
+
+- Shim process logs: `sudo journalctl -u jobflow-shim`
+- Caddy access + TLS logs: `sudo journalctl -u caddy`
+- To persist logs to a file, add `StandardOutput=append:/home/tomer/jobflow-logs/shim.log`
+  to the `[Service]` block in `jobflow-shim.service` and reload systemd.

--- a/data-pipeline/shim/deploy/Caddyfile
+++ b/data-pipeline/shim/deploy/Caddyfile
@@ -1,0 +1,27 @@
+# Caddyfile for the JobFlow Cassandra write shim.
+#
+# Replace YOUR_DOMAIN with the actual public hostname (e.g. shim.example.com).
+# Caddy automatically obtains and renews a Let's Encrypt TLS certificate
+# for this domain — no certbot, no cron, no manual renewal required.
+#
+# Install Caddy on Ubuntu: https://caddyserver.com/docs/install#debian-ubuntu-raspbian
+#   sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+#   curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+#   curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+#   sudo apt update && sudo apt install caddy
+#
+# Place this file at /etc/caddy/Caddyfile and run: sudo systemctl reload caddy
+#
+# The shim binds on 127.0.0.1:3100 (SHIM_PORT). Adjust the upstream port here
+# if SHIM_PORT is changed in shim/.env.
+
+YOUR_DOMAIN {
+    # Only the Company Scout write endpoint is exposed.
+    @companies path /companies
+    route @companies {
+        reverse_proxy 127.0.0.1:3100
+    }
+
+    # Reject everything else at the proxy layer before it reaches the shim.
+    respond 404
+}

--- a/data-pipeline/shim/deploy/Caddyfile
+++ b/data-pipeline/shim/deploy/Caddyfile
@@ -2,7 +2,9 @@
 #
 # Replace YOUR_DOMAIN with the actual public hostname (e.g. shim.example.com).
 # Caddy automatically obtains and renews a Let's Encrypt TLS certificate
-# for this domain — no certbot, no cron, no manual renewal required.
+# for this domain — no certbot, no cron, no manual renewal required. Caddy
+# also redirects HTTP→HTTPS for the same host by default; the bare HTTP
+# endpoint never serves the shim.
 #
 # Install Caddy on Ubuntu: https://caddyserver.com/docs/install#debian-ubuntu-raspbian
 #   sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
@@ -16,12 +18,51 @@
 # if SHIM_PORT is changed in shim/.env.
 
 YOUR_DOMAIN {
-    # Only the Company Scout write endpoint is exposed.
-    @companies path /companies
-    route @companies {
+    # Cap inbound bodies at the proxy layer so the shim never has to read a
+    # giant payload off the wire (shim.js also enforces a 64 KB internal cap).
+    request_body {
+        max_size 64KB
+    }
+
+    # Security headers applied to every response.
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        X-Content-Type-Options "nosniff"
+        Referrer-Policy "no-referrer"
+        # Remove the default Server: Caddy banner so we don't advertise.
+        -Server
+    }
+
+    # POST /companies → shim. Only POST is forwarded; other methods get 405.
+    @register {
+        method POST
+        path /companies
+    }
+    handle @register {
         reverse_proxy 127.0.0.1:3100
     }
 
-    # Reject everything else at the proxy layer before it reaches the shim.
-    respond 404
+    # GET /health → shim. Unauthenticated liveness check used by the RUNBOOK
+    # smoke test and any future external monitor.
+    @health {
+        method GET
+        path /health
+    }
+    handle @health {
+        reverse_proxy 127.0.0.1:3100
+    }
+
+    # Path matches /companies but with the wrong method → 405 (matches HTTP
+    # semantics better than a generic 404 for the same path).
+    @companies_other_method {
+        path /companies
+    }
+    handle @companies_other_method {
+        respond 405
+    }
+
+    # Everything else gets 404 without reaching the shim.
+    handle {
+        respond 404
+    }
 }

--- a/data-pipeline/shim/deploy/jobflow-shim.service
+++ b/data-pipeline/shim/deploy/jobflow-shim.service
@@ -6,7 +6,8 @@
 #   sudo systemctl enable --now jobflow-shim
 #
 # The service reads its config from /opt/jobflow/data-pipeline/shim/.env via
-# EnvironmentFile. Create that file from shim/.env.example before enabling.
+# EnvironmentFile. Create that file from shim/.env.example before enabling and
+# `chmod 600` it (it contains SHIM_BEARER_TOKEN).
 #
 # Assumes the repo is cloned at /opt/jobflow and Node ≥ 20.6 is installed.
 # Adjust WorkingDirectory and ExecStart paths if the repo lives elsewhere.
@@ -14,8 +15,19 @@
 [Unit]
 Description=JobFlow Cassandra write shim
 Documentation=https://github.com/tomerp20/jobflow
-After=network.target docker.service
-Wants=docker.service
+# Wait for the network to be actually online (DNS, routes ready), not just for
+# the kernel network stack to exist. `network.target` is satisfied very early
+# and is the wrong target for services that need IP reachability.
+After=network-online.target
+Wants=network-online.target
+# Cassandra runs in Docker on this box. Adding `After=docker.service` only
+# orders against the Docker daemon being up, NOT against the Cassandra
+# container being ready to accept connections. The shim handles transient
+# connect failures via the cassandra-driver's built-in reconnection policy; if
+# stricter ordering is needed, add a oneshot helper unit that waits for the
+# container's healthcheck and add `After=` it here.
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -23,7 +35,7 @@ User=tomer
 Group=tomer
 WorkingDirectory=/opt/jobflow/data-pipeline/shim
 
-# Env file created from shim/.env.example — not committed.
+# Env file created from shim/.env.example — not committed. Must be chmod 600.
 EnvironmentFile=/opt/jobflow/data-pipeline/shim/.env
 
 ExecStart=/usr/bin/node shim.js
@@ -33,11 +45,41 @@ StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=jobflow-shim
 
-# Hardening: shim binds only to 127.0.0.1 and makes no outbound calls
-# beyond Cassandra on localhost; restrict network to localhost only.
-RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
-PrivateTmp=true
+# ── Hardening ────────────────────────────────────────────────────────────────
+# The shim binds only to 127.0.0.1, makes no outbound calls beyond Cassandra
+# on localhost, never writes to the filesystem, and runs as an unprivileged
+# user. Most of the namespace/syscall restrictions below are safe wins.
+
 NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+
+ProtectSystem=strict
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+ProtectHostname=true
+ProtectClock=true
+ProtectProc=invisible
+LockPersonality=true
+RestrictRealtime=true
+RestrictNamespaces=true
+RestrictSUIDSGID=true
+MemoryDenyWriteExecute=true
+RemoveIPC=true
+
+# AF_INET/AF_INET6 for HTTP + Cassandra; AF_UNIX for journald/syslog sockets.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources @mount @swap @reboot @debug @cpu-emulation @obsolete
+
+# Drop all capabilities — Node can bind 127.0.0.1:3100 (>1024) without any.
+CapabilityBoundingSet=
+AmbientCapabilities=
 
 [Install]
 WantedBy=multi-user.target

--- a/data-pipeline/shim/deploy/jobflow-shim.service
+++ b/data-pipeline/shim/deploy/jobflow-shim.service
@@ -1,0 +1,43 @@
+# systemd unit for the JobFlow Cassandra write shim.
+#
+# Install:
+#   sudo cp jobflow-shim.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now jobflow-shim
+#
+# The service reads its config from /opt/jobflow/data-pipeline/shim/.env via
+# EnvironmentFile. Create that file from shim/.env.example before enabling.
+#
+# Assumes the repo is cloned at /opt/jobflow and Node ≥ 20.6 is installed.
+# Adjust WorkingDirectory and ExecStart paths if the repo lives elsewhere.
+
+[Unit]
+Description=JobFlow Cassandra write shim
+Documentation=https://github.com/tomerp20/jobflow
+After=network.target docker.service
+Wants=docker.service
+
+[Service]
+Type=simple
+User=tomer
+Group=tomer
+WorkingDirectory=/opt/jobflow/data-pipeline/shim
+
+# Env file created from shim/.env.example — not committed.
+EnvironmentFile=/opt/jobflow/data-pipeline/shim/.env
+
+ExecStart=/usr/bin/node shim.js
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=jobflow-shim
+
+# Hardening: shim binds only to 127.0.0.1 and makes no outbound calls
+# beyond Cassandra on localhost; restrict network to localhost only.
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/data-pipeline/shim/lib/cassandra.js
+++ b/data-pipeline/shim/lib/cassandra.js
@@ -1,0 +1,36 @@
+import cassandra from 'cassandra-driver';
+
+const { Client, types } = cassandra;
+
+const INSERT_CQL =
+  `INSERT INTO jobflow.companies (company, org_name, added_at, active, initialized)
+   VALUES (?, ?, toTimestamp(now()), true, false)
+   IF NOT EXISTS`;
+
+export function buildClient({ contactPoints, localDc, keyspace }) {
+  return new Client({
+    contactPoints,
+    localDataCenter: localDc,
+    keyspace,
+    queryOptions: {
+      consistency: types.consistencies.localOne,
+      prepare: true,
+    },
+  });
+}
+
+/**
+ * Registers one (company, org_name) pair using an LWT INSERT … IF NOT EXISTS.
+ *
+ * The shim is the sole writer of `initialized = false`.  We never UPDATE an
+ * existing row — that would silently regress `initialized` from true back to
+ * false and break the ADR 0003 Backfill/Hourly relay race.
+ *
+ * @returns {'registered' | 'already_exists'}
+ */
+export async function insertIfNotExists(client, { company, orgName }) {
+  const result = await client.execute(INSERT_CQL, [company, orgName], { prepare: true });
+  // LWT result: first row has a boolean `[applied]` column
+  const applied = result.rows[0]['[applied]'];
+  return applied ? 'registered' : 'already_exists';
+}

--- a/data-pipeline/shim/lib/cassandra.js
+++ b/data-pipeline/shim/lib/cassandra.js
@@ -2,8 +2,11 @@ import cassandra from 'cassandra-driver';
 
 const { Client, types } = cassandra;
 
+// Unqualified table name so the Client's `keyspace` config (set from
+// CASSANDRA_KEYSPACE env via buildClient) determines where we write. Hardcoding
+// `jobflow.companies` would silently ignore that knob.
 const INSERT_CQL =
-  `INSERT INTO jobflow.companies (company, org_name, added_at, active, initialized)
+  `INSERT INTO companies (company, org_name, added_at, active, initialized)
    VALUES (?, ?, toTimestamp(now()), true, false)
    IF NOT EXISTS`;
 
@@ -14,6 +17,10 @@ export function buildClient({ contactPoints, localDc, keyspace }) {
     keyspace,
     queryOptions: {
       consistency: types.consistencies.localOne,
+      // LWTs run a Paxos round; pin serial consistency explicitly rather than
+      // relying on the driver default, so behaviour stays predictable if the
+      // topology grows beyond one datacenter.
+      serialConsistency: types.consistencies.localSerial,
       prepare: true,
     },
   });
@@ -26,11 +33,21 @@ export function buildClient({ contactPoints, localDc, keyspace }) {
  * existing row — that would silently regress `initialized` from true back to
  * false and break the ADR 0003 Backfill/Hourly relay race.
  *
- * @returns {'registered' | 'already_exists'}
+ * @returns {Promise<'registered' | 'already_exists'>}
  */
 export async function insertIfNotExists(client, { company, orgName }) {
   const result = await client.execute(INSERT_CQL, [company, orgName], { prepare: true });
-  // LWT result: first row has a boolean `[applied]` column
-  const applied = result.rows[0]['[applied]'];
+  // LWT result: first row carries a `[applied]` boolean column. Be defensive —
+  // a missing row or a non-boolean value silently bucketing to `already_exists`
+  // would let `initialized = true` rows quietly survive write attempts and
+  // break the relay-race idempotency guarantee.
+  const row = result?.rows?.[0];
+  if (!row) {
+    throw new Error('cassandra LWT returned no rows');
+  }
+  const applied = row['[applied]'];
+  if (typeof applied !== 'boolean') {
+    throw new Error('cassandra LWT response missing or non-boolean [applied] column');
+  }
   return applied ? 'registered' : 'already_exists';
 }

--- a/data-pipeline/shim/package.json
+++ b/data-pipeline/shim/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "jobflow-company-shim",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "HTTPS write shim: registers (company, org) pairs into jobflow.companies via INSERT … IF NOT EXISTS",
+  "main": "shim.js",
+  "engines": {
+    "node": ">=20.6.0"
+  },
+  "scripts": {
+    "start": "node --env-file=.env shim.js"
+  },
+  "dependencies": {
+    "cassandra-driver": "^4.7.2",
+    "pino": "^9.0.0"
+  },
+  "devDependencies": {
+    "pino-pretty": "^13.0.0"
+  }
+}

--- a/data-pipeline/shim/shim.js
+++ b/data-pipeline/shim/shim.js
@@ -1,4 +1,5 @@
 import http from 'node:http';
+import crypto from 'node:crypto';
 import pino from 'pino';
 import { buildClient, insertIfNotExists } from './lib/cassandra.js';
 
@@ -10,6 +11,11 @@ const CASSANDRA_LOCAL_DC   = process.env.CASSANDRA_LOCAL_DC ?? '';
 const CASSANDRA_KEYSPACE   = process.env.CASSANDRA_KEYSPACE ?? 'jobflow';
 const LOG_LEVEL            = process.env.LOG_LEVEL ?? 'info';
 const IS_PROD              = process.env.NODE_ENV === 'production';
+
+// 64 KB is generous for a per-Company batch (largest plausible Wix-style payload
+// is well under 4 KB); larger requests are rejected before parsing to bound
+// memory and rule out trivial DoS.
+const MAX_BODY_BYTES = 64 * 1024;
 
 // ── Logger ────────────────────────────────────────────────────────────────────
 const loggerOpts = { level: LOG_LEVEL };
@@ -30,6 +36,10 @@ if (!CASSANDRA_LOCAL_DC) {
   process.exit(1);
 }
 
+// Pre-encode the expected Authorization header once so request-time comparison
+// is fixed-length and constant-time (see checkAuth).
+const EXPECTED_AUTH_BUFFER = Buffer.from(`Bearer ${SHIM_BEARER_TOKEN}`);
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 function send(res, status, body) {
   const payload = JSON.stringify(body);
@@ -37,10 +47,34 @@ function send(res, status, body) {
   res.end(payload);
 }
 
+// Constant-time bearer check. A naive `!==` leaks token bytes via timing
+// (each match continues comparison further; mismatches return early). Comparing
+// fixed-length buffers with timingSafeEqual closes that side channel.
+function checkAuth(req) {
+  const header = req.headers['authorization'];
+  if (typeof header !== 'string') return false;
+  const provided = Buffer.from(header);
+  if (provided.length !== EXPECTED_AUTH_BUFFER.length) return false;
+  return crypto.timingSafeEqual(provided, EXPECTED_AUTH_BUFFER);
+}
+
 function readBody(req) {
   return new Promise((resolve, reject) => {
+    let size = 0;
     const chunks = [];
-    req.on('data', c => chunks.push(c));
+    req.on('data', c => {
+      size += c.length;
+      if (size > MAX_BODY_BYTES) {
+        // Destroy the socket so the client doesn't keep streaming a giant body
+        // we'll never accept.
+        req.destroy();
+        const err = new Error('payload too large');
+        err.statusCode = 413;
+        reject(err);
+        return;
+      }
+      chunks.push(c);
+    });
     req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
     req.on('error', reject);
   });
@@ -49,16 +83,24 @@ function readBody(req) {
 // ── Request handler ───────────────────────────────────────────────────────────
 async function handleRegister(req, res, client) {
   // Auth
-  const auth = req.headers['authorization'] ?? '';
-  if (auth !== `Bearer ${SHIM_BEARER_TOKEN}`) {
+  if (!checkAuth(req)) {
     return send(res, 401, { error: 'unauthorized' });
+  }
+
+  // Content-Type — fail early if the client sent something we can't parse
+  const contentType = (req.headers['content-type'] ?? '').toLowerCase();
+  if (!contentType.startsWith('application/json')) {
+    return send(res, 415, { error: 'content-type must be application/json' });
   }
 
   // Body
   let body;
   try {
     body = JSON.parse(await readBody(req));
-  } catch {
+  } catch (err) {
+    if (err && err.statusCode === 413) {
+      return send(res, 413, { error: 'payload too large' });
+    }
     return send(res, 400, { error: 'invalid JSON' });
   }
 
@@ -73,6 +115,11 @@ async function handleRegister(req, res, client) {
     if (typeof org.org_name !== 'string' || org.org_name.trim() === '') {
       return send(res, 400, { error: 'each active_orgs entry must have a non-empty org_name' });
     }
+    // `last_repo_push` is part of the agreed wire contract (ADR 0010) and is
+    // required so producers cannot silently drift. The current Cassandra schema
+    // for `jobflow.companies` does not yet store this column; it is preserved
+    // in structured logs (the `org write` line below). When the schema gains a
+    // `last_repo_push timestamp` column, switch insertIfNotExists to write it.
     if (typeof org.last_repo_push !== 'string') {
       return send(res, 400, { error: 'each active_orgs entry must have a last_repo_push string' });
     }
@@ -80,11 +127,11 @@ async function handleRegister(req, res, client) {
 
   // Per-org LWT writes
   const results = [];
-  for (const { org_name } of body.active_orgs) {
+  for (const { org_name, last_repo_push } of body.active_orgs) {
     try {
       const status = await insertIfNotExists(client, { company: body.company, orgName: org_name });
       results.push({ org_name, status });
-      logger.info({ company: body.company, org_name, status }, 'org write');
+      logger.info({ company: body.company, org_name, last_repo_push, status }, 'org write');
     } catch (err) {
       logger.error({ company: body.company, org_name, err }, 'cassandra write failed');
       return send(res, 500, { error: 'cassandra write failed', org_name });
@@ -95,8 +142,12 @@ async function handleRegister(req, res, client) {
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
+// Hoisted so the top-level main().catch() can clean up if startup fails after
+// the Cassandra client has been created but before steady state.
+let client = null;
+
 async function main() {
-  const client = buildClient({
+  client = buildClient({
     contactPoints: CASSANDRA_CONTACT_POINTS,
     localDc: CASSANDRA_LOCAL_DC,
     keyspace: CASSANDRA_KEYSPACE,
@@ -106,6 +157,11 @@ async function main() {
   logger.info({ contactPoints: CASSANDRA_CONTACT_POINTS, keyspace: CASSANDRA_KEYSPACE }, 'cassandra connected');
 
   const server = http.createServer(async (req, res) => {
+    // Liveness check — Caddy passes /health through; useful for `curl` from
+    // RUNBOOK and for future external monitoring without needing the bearer.
+    if (req.method === 'GET' && req.url === '/health') {
+      return send(res, 200, { status: 'ok' });
+    }
     if (req.method === 'POST' && req.url === '/companies') {
       await handleRegister(req, res, client).catch(err => {
         logger.error({ err }, 'unhandled handler error');
@@ -115,6 +171,12 @@ async function main() {
       send(res, 404, { error: 'not found' });
     }
   });
+
+  // Slowloris mitigation — bound the time a single request can monopolise a
+  // socket. Values are generous for our latency profile (Cassandra LWTs may
+  // take a few hundred ms each, batch up to 20 Orgs per Company).
+  server.requestTimeout = 30_000; // 30s overall request
+  server.headersTimeout = 10_000; // 10s to receive request headers
 
   server.listen(SHIM_PORT, '127.0.0.1', () => {
     logger.info({ port: SHIM_PORT }, 'shim listening on localhost');
@@ -132,7 +194,10 @@ async function main() {
   }
 }
 
-main().catch(err => {
+main().catch(async err => {
   logger.fatal({ err }, 'startup failed');
+  if (client) {
+    try { await client.shutdown(); } catch { /* best-effort cleanup */ }
+  }
   process.exit(1);
 });

--- a/data-pipeline/shim/shim.js
+++ b/data-pipeline/shim/shim.js
@@ -1,0 +1,138 @@
+import http from 'node:http';
+import pino from 'pino';
+import { buildClient, insertIfNotExists } from './lib/cassandra.js';
+
+// ── Env config ───────────────────────────────────────────────────────────────
+const SHIM_PORT            = parseInt(process.env.SHIM_PORT ?? '3100', 10);
+const SHIM_BEARER_TOKEN    = process.env.SHIM_BEARER_TOKEN ?? '';
+const CASSANDRA_CONTACT_POINTS = (process.env.CASSANDRA_CONTACT_POINTS ?? '').split(',').map(s => s.trim()).filter(Boolean);
+const CASSANDRA_LOCAL_DC   = process.env.CASSANDRA_LOCAL_DC ?? '';
+const CASSANDRA_KEYSPACE   = process.env.CASSANDRA_KEYSPACE ?? 'jobflow';
+const LOG_LEVEL            = process.env.LOG_LEVEL ?? 'info';
+const IS_PROD              = process.env.NODE_ENV === 'production';
+
+// ── Logger ────────────────────────────────────────────────────────────────────
+const loggerOpts = { level: LOG_LEVEL };
+if (!IS_PROD) loggerOpts.transport = { target: 'pino-pretty' };
+const logger = pino(loggerOpts);
+
+// ── Startup validation ────────────────────────────────────────────────────────
+if (!SHIM_BEARER_TOKEN) {
+  logger.fatal('SHIM_BEARER_TOKEN is required');
+  process.exit(1);
+}
+if (CASSANDRA_CONTACT_POINTS.length === 0) {
+  logger.fatal('CASSANDRA_CONTACT_POINTS is required');
+  process.exit(1);
+}
+if (!CASSANDRA_LOCAL_DC) {
+  logger.fatal('CASSANDRA_LOCAL_DC is required');
+  process.exit(1);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function send(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) });
+  res.end(payload);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', c => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+// ── Request handler ───────────────────────────────────────────────────────────
+async function handleRegister(req, res, client) {
+  // Auth
+  const auth = req.headers['authorization'] ?? '';
+  if (auth !== `Bearer ${SHIM_BEARER_TOKEN}`) {
+    return send(res, 401, { error: 'unauthorized' });
+  }
+
+  // Body
+  let body;
+  try {
+    body = JSON.parse(await readBody(req));
+  } catch {
+    return send(res, 400, { error: 'invalid JSON' });
+  }
+
+  // Validation
+  if (typeof body.company !== 'string' || body.company.trim() === '') {
+    return send(res, 400, { error: 'company must be a non-empty string' });
+  }
+  if (!Array.isArray(body.active_orgs) || body.active_orgs.length === 0) {
+    return send(res, 400, { error: 'active_orgs must be a non-empty array' });
+  }
+  for (const org of body.active_orgs) {
+    if (typeof org.org_name !== 'string' || org.org_name.trim() === '') {
+      return send(res, 400, { error: 'each active_orgs entry must have a non-empty org_name' });
+    }
+    if (typeof org.last_repo_push !== 'string') {
+      return send(res, 400, { error: 'each active_orgs entry must have a last_repo_push string' });
+    }
+  }
+
+  // Per-org LWT writes
+  const results = [];
+  for (const { org_name } of body.active_orgs) {
+    try {
+      const status = await insertIfNotExists(client, { company: body.company, orgName: org_name });
+      results.push({ org_name, status });
+      logger.info({ company: body.company, org_name, status }, 'org write');
+    } catch (err) {
+      logger.error({ company: body.company, org_name, err }, 'cassandra write failed');
+      return send(res, 500, { error: 'cassandra write failed', org_name });
+    }
+  }
+
+  return send(res, 200, { company: body.company, results });
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+async function main() {
+  const client = buildClient({
+    contactPoints: CASSANDRA_CONTACT_POINTS,
+    localDc: CASSANDRA_LOCAL_DC,
+    keyspace: CASSANDRA_KEYSPACE,
+  });
+
+  await client.connect();
+  logger.info({ contactPoints: CASSANDRA_CONTACT_POINTS, keyspace: CASSANDRA_KEYSPACE }, 'cassandra connected');
+
+  const server = http.createServer(async (req, res) => {
+    if (req.method === 'POST' && req.url === '/companies') {
+      await handleRegister(req, res, client).catch(err => {
+        logger.error({ err }, 'unhandled handler error');
+        if (!res.headersSent) send(res, 500, { error: 'internal server error' });
+      });
+    } else {
+      send(res, 404, { error: 'not found' });
+    }
+  });
+
+  server.listen(SHIM_PORT, '127.0.0.1', () => {
+    logger.info({ port: SHIM_PORT }, 'shim listening on localhost');
+  });
+
+  // Graceful shutdown: allow in-flight requests to drain before closing Cassandra.
+  for (const sig of ['SIGTERM', 'SIGINT']) {
+    process.on(sig, () => {
+      logger.info({ signal: sig }, 'shutting down');
+      server.close(async () => {
+        await client.shutdown();
+        process.exit(0);
+      });
+    });
+  }
+}
+
+main().catch(err => {
+  logger.fatal({ err }, 'startup failed');
+  process.exit(1);
+});

--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -28,6 +28,11 @@ Each entry: **what happened → what we'd change**. Skip generic platitudes.
 
 - **Global dedup in `createCard` must use the base `db` instance, not the caller's `trx`.** The First Sighting check queries `cards.company_name` globally across all users; using `runner` (which may be a `trx`) would scope the read to uncommitted rows inside the current transaction, making concurrent creates race past the dedup. → Always use `db` (not `runner`/`trx`) for reads that need committed global state even when the surrounding write uses a transaction.
 
+## 2026-05-24 (PR #250 — Cassandra write shim)
+
+- **Caddy beats nginx for a single-endpoint HTTPS shim with no existing infra dependency.** Caddy provisions and renews Let's Encrypt certs automatically; the Caddyfile for "one route, reverse-proxy to localhost" is ~15 lines vs ~40 for a minimal nginx block. When the choice is unconstrained, Caddy is lower ongoing ops burden. → Use Caddy as the default reverse-proxy for new services on the Linux box; document nginx only if a service joins existing nginx infra.
+- **LWT `[applied]` column access in cassandra-driver:** the driver returns the LWT applied column as `rows[0]['[applied]']` (bracket notation, not `.applied`). Must access with bracket syntax or the value is undefined.
+
 ## 2026-05-24 (PR #242 — fetcher p-limit bump)
 
 - **File size varies ~3× across different months of GH Archive.** Jan 2025 files averaged ~77 MB/hour vs ~25 MB for May 2026 — GitHub event volume grew significantly. When benchmarking fetcher throughput, files/sec is a misleading metric across different date ranges; MB/s is the correct comparison. The p-limit(3→6) bump yielded ~2.2× MB/s improvement (71 vs 33 MB/s) on the Xubuntu box, clearing the >1.3× approval threshold.

--- a/knowledge/wiki/company-scout.md
+++ b/knowledge/wiki/company-scout.md
@@ -11,7 +11,7 @@ sources:
 related: [[application]] [[company]] [[first-sighting]] [[org]] [[active-github-presence]] [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[email-agent]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0009-org-scorer-weighted-scoring]] [[adr-0010-https-shim-write-path]]
 updated: 2026-05-24
 status: stable
-shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248)"
+shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248), #246 (shim — PR #250)"
 ---
 
 # Company Scout
@@ -71,7 +71,7 @@ The analytics pipeline can't profile a Company until its `(Company, Org)` rows e
 - Active-Presence Classifier: `backend/src/services/companyScout/activePresenceClassifier.ts` (shipped — slice 3 / PR #248)
 - GitHub API client: `backend/src/services/companyScout/githubClient.ts` (shipped — slice 2 / PR #247)
 - OrgScorer module: `backend/src/services/companyScout/orgScorer.ts` (shipped — slice 2 / PR #247)
-- HTTPS shim: separate deliverable in `data-pipeline/` repo (not in JobFlow)
+- HTTPS shim: `data-pipeline/shim/shim.js` — Node ESM service; deploy config in `data-pipeline/shim/deploy/` (shipped — PR #250)
 - Cassandra schema: `data-pipeline/schema/004_companies.cql` + `005_alter_companies_initialized.cql`
 - Canonical pipeline design: `docs/CassandraPlan.md` §4.4 (`companies` table)
 - Related ADRs: [[adr-0003-backfill-hourly-relay-race]], [[adr-0009-org-scorer-weighted-scoring]], [[adr-0010-https-shim-write-path]]


### PR DESCRIPTION
## Summary
- Adds `data-pipeline/shim/` — a small Node ESM service that exposes `POST /companies` so JobFlow's `HttpShimCompanyRegistry` can register `(company, org)` pairs into `jobflow.companies` without speaking CQL
- Bearer-token auth, request validation, per-org `INSERT … IF NOT EXISTS` (Cassandra LWT) — shim is the sole writer of `initialized = false`, enforcing the ADR 0003 relay-race invariant
- Full deploy plumbing: systemd unit, Caddy reverse-proxy config (Let's Encrypt), `.env.example`, and a RUNBOOK.md covering deploy, secret rotation, smoke-test, rollback, and log locations

## Acceptance criteria
- [x] HTTPS-only — Caddy in front with automatic Let's Encrypt cert; Cassandra port 9042 stays on localhost
- [x] `Authorization: Bearer <shared-secret>` required; absent/incorrect → `401`
- [x] Body validation: `company` (non-empty string), `active_orgs` (array of `{ org_name, last_repo_push }`); malformed → `400`
- [x] Per-org `INSERT … IF NOT EXISTS` — never unconditional INSERT, never UPDATE
- [x] `200 OK` for any well-formed authenticated request with per-org `registered` / `already_exists` results
- [x] 5xx only for Cassandra connectivity/write errors; auth + validation are 4xx
- [x] Running as a `systemd` service with auto-restart on failure
- [x] Bound to localhost behind the reverse proxy; not directly internet-exposed
- [x] Operational doc (RUNBOOK.md): deploy steps, env vars, secret rotation, how to verify, rollback, log locations
- [x] End-to-end smoke-test script in RUNBOOK.md: POST synthetic Company → confirm `initialized = false` row; re-POST → confirm `already_exists` and no row change

## Deploy note

Actual deployment to the Xubuntu box (`tomer@192.168.10.12`) is a **manual follow-up** — SSH access from CI is not available. Follow `data-pipeline/shim/RUNBOOK.md`.

## Related
Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)