### PR TITLE
docs: capture 3 cross-cutting lessons from Company Scout E2E session

### DIFF
--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -13,6 +13,14 @@ Each entry: **what happened → what we'd change**. Skip generic platitudes.
 
 ---
 
+## 2026-05-24 (Company Scout E2E + three cross-cutting lessons)
+
+- **Render's `PUT /v1/services/{serviceId}/env-vars` is a full-replace, not an upsert.** Sent a 3-element array thinking it would merge with existing env vars; wiped 15 production env vars including `DATABASE_URL` which the Render API does not expose snapshots of. The deployed app refused to start until each value was rebuilt — some from local `.env`, some asked from the user, some regenerated (forced a JWT-secret rotation that invalidated the user's active session). → For 1–3 env-var changes, use `PUT /v1/services/{serviceId}/env-vars/{key}` per-key (creates if missing). Only use the bulk endpoint when you have the complete list of existing values to send back. Captured in `reference_render.md` for next-session recall.
+- **First-Sighting silent skip cost a confused round-trip during the E2E test.** Operator added a Salesforce card to test the pipeline; nothing appeared in the logs. Reason: Salesforce was already in `cards` from 2026-05-13, so `createCard`'s dedup correctly skipped invoking `runCompanyCheck` — but the skip path emits no log line, so "Scout did nothing" was indistinguishable from "Scout never ran." → Tracked as issue #252 (one-line `debug` log on the skip path). Gotcha also added to `knowledge/wiki/company-scout.md` Surprises section so future debuggers find it on the same page they read about how the Scout works.
+- **Stacked-PR chain (`ship-181 → ship-182 → ship-183 → ship-184`) works cleanly in one autonomous run when each agent branches off the prior WIP branch.** All four slices shipped + reviewed + fix-committed via `/ship` without human merge gates between them. The trick: `gh pr create --base main` in every agent so each PR's eventual merge target is `main` — the diff against `main` includes prior unmerged slices' changes (expected for a stacked PR), and merge order is `#244 → #247 → #248 → #249` per stack depth. Branch-rebase pain was essentially zero because each slice was small. → Refines the existing `feedback_sequential_tasks.md` memory; the chain pattern is now validated for autonomous-window multi-slice shipping, not just for "agents-with-human-in-the-loop."
+
+---
+
 - **2026-05-24 — slice 4 ship (PR #249).** Edits made in the main working dir (on the wrong slice-3 branch) were copied to the worktree via `cp` before staging — the worktree isolation pattern means all Edit/Write calls must target the worktree path directly, not the main jobflow dir. → When shipping in a worktree context, always compute the absolute worktree path and pass it to Edit/Write from the start; don't rely on the main checkout.
 
 ## 2026-05-24 (PR #248 — Company Scout slice 3)

--- a/knowledge/wiki/company-scout.md
+++ b/knowledge/wiki/company-scout.md
@@ -11,8 +11,7 @@ sources:
 related: [[application]] [[company]] [[first-sighting]] [[org]] [[active-github-presence]] [[cassandra-analytics-pipeline]] [[backfill]] [[hourly-ingest]] [[email-agent]] [[adr-0003-backfill-hourly-relay-race]] [[adr-0009-org-scorer-weighted-scoring]] [[adr-0010-https-shim-write-path]]
 updated: 2026-05-24
 status: stable
-shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248), #184 (slice 4 — PR #249)"
-shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248), #246 (shim — PR #250)"
+shipped: "#181 (slice 1, PR #244), #182 (slice 2, PR #247), #183 (slice 3, PR #248), #184 (slice 4, PR #249), #246 (shim, PR #250) — verified end-to-end against a live Datadog card 2026-05-24"
 ---
 
 # Company Scout
@@ -57,6 +56,7 @@ The analytics pipeline can't profile a Company until its `(Company, Org)` rows e
   - Company adds a new Org months later → Scout doesn't re-evaluate; the new Org is never registered.
   - All cards for a Company are deleted then a new one is added → Scout fires again; previously-registered Orgs return `already_exists` from the shim (safe).
 - **`active` column in `companies` is effectively always `true` in v1.** Only active Orgs are written, so the column never carries a `false` value through this path. The schema retains it for future flexibility; no v1 change.
+- **First-Sighting silent skip is invisible — debuggability dark zone.** When a card is created for a Company name *already* present in `cards`, the dedup in `createCard` returns early and `runCompanyCheck` is never invoked. There is currently **no log line** emitted on this skip path, so an absence of Scout logs is ambiguous between "Scout ran but found nothing" and "Scout was never invoked at all." Cost a confused round-trip during the 2026-05-24 E2E test (operator added a Salesforce card that already existed from 2026-05-13 and saw zero Scout output). Tracked for fix as a one-line debug-level log in issue #252.
 - **OrgScorer calibration result (slice 2).** No weight tuning was needed. Under the ADR 0009 starting weights: Wix→wix (85), Tenable→tenable (120), Salesforce→salesforce (120) all pass ≥80; Riverside→Riverside-Software (40), Faye→faye (50), Rise→rise (50) all reject <80. The key mechanism: exact slug (+50) alone doesn't clear the threshold — the credibility signals (repos +10, followers +10) and display-name match together push anchors over 80, while small/unknown orgs with only an exact slug hit stay at 50.
 
 ## Open questions


### PR DESCRIPTION
## Summary
- Three observations worth carrying forward from the 2026-05-24 Company Scout E2E session, written across the right destinations per `knowledge/CLAUDE.md`.

## Changes
- **`knowledge/wiki/company-scout.md`** — fix duplicate `shipped:` frontmatter lines (the second was silently overriding the first) by consolidating into one combined line; add a "Surprises / gotchas" bullet for the First-Sighting silent-skip debuggability dark zone, cross-referenced to follow-up issue #252.
- **`knowledge/learnings.md`** — new dated section at the top with three bullets:
  1. Render `PUT /env-vars` is full-replace (recovery cost; safer path is per-key PUT) — 15 prod env vars wiped this session.
  2. First-Sighting silent skip cost a confused round-trip during the E2E test; tracked as #252.
  3. Stacked-PR chain (`ship-181 → ship-182 → ship-183 → ship-184`) works cleanly in one autonomous run with `gh pr create --base main`.

## Out of scope (handled separately)
- Project memory updates (`reference_render.md`, `feedback_sequential_tasks.md`) live outside this repo at `~/.claude/projects/-Users-itc-Desktop-jobflow/memory/` and were edited directly — not in this PR's diff.
- Follow-up issue #252 (one-line debug log for the silent-skip case) — already opened.

No code changes.

## Test plan
- [ ] Wiki renders correctly on GitHub
- [ ] No duplicate-key warnings in the consolidated frontmatter
- [ ] Learnings entry reads coherently with the prior section structure

Related: PRD #180, ADRs 0009 + 0010, issue #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)