### PR TITLE
company-scout: log skip when not First Sighting (debuggability)

### DIFF
--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -3,6 +3,7 @@ import db from '../config/database';
 import { AppError } from '../middleware/errorHandler';
 import { shiftUp, shiftDown, withTransaction } from '../util/positions';
 import { runCompanyCheck } from './companyScout/companyScout';
+import logger from '../config/logger';
 
 export interface CardFilters {
   stage?: string;
@@ -327,6 +328,11 @@ export const cardService = {
         applicationUrl: data.application_url,
         careersUrl: data.careers_url,
       }).catch(() => { /* intentionally suppressed — Scout errors must not fail card creation */ });
+    } else {
+      logger.debug('company_scout.skipped_not_first_sighting', {
+        service: 'company-scout',
+        company: normalizedCompany,
+      });
     }
 
     // Return card with stage name

--- a/knowledge/learnings.md
+++ b/knowledge/learnings.md
@@ -13,6 +13,8 @@ Each entry: **what happened → what we'd change**. Skip generic platitudes.
 
 ---
 
+- **2026-05-24 — PR #254 (issue #252 — Scout skip debug log).** The absence of any Scout log on the `!isFirstSighting` path was ambiguous — during the 2026-05-24 E2E test, Salesforce produced no Scout logs because it was already known; the operator had to query `cards` directly to confirm. Adding a `debug`-level log at the branch resolves the ambiguity without production noise. → When a code path that silently returns/skips is also a "system is healthy" path, add a `debug` log at the branch point so operators can tell "skipped intentionally" from "never reached".
+
 - **2026-05-24 — slice 4 ship (PR #249).** Edits made in the main working dir (on the wrong slice-3 branch) were copied to the worktree via `cp` before staging — the worktree isolation pattern means all Edit/Write calls must target the worktree path directly, not the main jobflow dir. → When shipping in a worktree context, always compute the absolute worktree path and pass it to Edit/Write from the start; don't rely on the main checkout.
 
 ## 2026-05-24 (PR #248 — Company Scout slice 3)

--- a/knowledge/wiki/company-scout.md
+++ b/knowledge/wiki/company-scout.md
@@ -12,7 +12,7 @@ related: [[application]] [[company]] [[first-sighting]] [[org]] [[active-github-
 updated: 2026-05-24
 status: stable
 shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248), #184 (slice 4 — PR #249)"
-shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248), #246 (shim — PR #250)"
+shipped: "#181 (slice 1), #182 (slice 2 — PR #247), #183 (slice 3 — PR #248), #246 (shim — PR #250), #252 (debug log — PR #254)"
 ---
 
 # Company Scout
@@ -48,6 +48,7 @@ The analytics pipeline can't profile a Company until its `(Company, Org)` rows e
 - The shim is the sole writer of `initialized = false` — that invariant lives in one place (see [[adr-0010-https-shim-write-path]] and [[adr-0003-backfill-hourly-relay-race]]).
 - Card creation latency is unaffected — `runCompanyCheck` is fired detached and never awaited.
 - No retry; no scheduled re-evaluation; the Scout never runs twice for the same Company while a card with that name exists.
+- **Skip path is now observable (PR #254).** When `!isFirstSighting`, `cardService.createCard` emits `company_scout.skipped_not_first_sighting` at `debug` level with `service: "company-scout"` and `company: <normalized name>`. Silent at default `LOG_LEVEL=info`; raise to `debug` to distinguish "Scout skipped" from "Scout ran and found nothing".
 
 ## Surprises / gotchas
 


### PR DESCRIPTION
## Summary
- Adds a single `debug`-level log line (`company_scout.skipped_not_first_sighting`) inside `cardService.createCard` on the `!isFirstSighting` path
- Resolves the ambiguity between "Scout skipped (company already known)" and "Scout ran and found nothing" — previously both produced identical log silence
- No-op at default `LOG_LEVEL=info`; only visible when raised to `debug` for operator troubleshooting

## Acceptance criteria
- [x] When a card is created for a Company name already present (normalized) on any existing card, exactly one `debug`-level log line `company_scout.skipped_not_first_sighting` is emitted with the company name as a structured field
- [x] No log line is emitted on the First-Sighting path (existing `company_scout.first_sighting` log covers that case)
- [x] No change to the dedup behavior itself — only an observability addition
- [x] No production log volume impact in default config (`LOG_LEVEL=info`); the line only appears when `LOG_LEVEL` is raised to `debug` for troubleshooting

## Related
Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)