### PR TITLE
ci(gmail-sync): print response body on curl failure

### DIFF
--- a/.github/workflows/gmail-sync.yml
+++ b/.github/workflows/gmail-sync.yml
@@ -10,12 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Gmail Sync
+        # Capture the response body even on HTTP error. The previous version used
+        # `bash -e` + `RESPONSE=$(curl --fail-with-body ...)`: on a non-2xx, the
+        # assignment failed and the shell exited before `echo "$RESPONSE"` ran,
+        # so failures showed only "exit code 22" with no body. We now disable
+        # errexit around the curl, always print the response, and exit explicitly
+        # on non-2xx so the step still fails loudly.
         run: |
+          set +e
           RESPONSE=$(curl --fail-with-body \
             -s -w "\nHTTP_STATUS:%{http_code}" \
             -X POST "${{ secrets.RENDER_SYNC_URL }}/api/gmail/sync" \
             -H "Authorization: Bearer ${{ secrets.CRON_API_KEY }}" \
             -H "Content-Type: application/json")
+          CURL_EXIT=$?
           echo "$RESPONSE"
           HTTP_CODE=$(echo "$RESPONSE" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
-          echo "HTTP status: $HTTP_CODE"
+          echo "HTTP status: $HTTP_CODE (curl exit: $CURL_EXIT)"
+          if [ "$CURL_EXIT" -ne 0 ]; then
+            exit "$CURL_EXIT"
+          fi


### PR DESCRIPTION
## Summary
- Disable `errexit` around the cron curl so the response body is always echoed, even on HTTP failure
- Echo the HTTP status + curl exit code, then exit non-zero explicitly when curl failed (preserves loud failure)

## Why
The previous workflow used `bash -e` together with `RESPONSE=$(curl --fail-with-body ...)`. On any non-2xx the assignment failed and the shell exited before `echo "$RESPONSE"` ran — GH Actions logs showed only "Process completed with exit code 22" with no clue what the server returned. This just masked ~24h of failed cron runs caused by a stale `CRON_API_KEY` (rotated on Render after the 2026-05-24 env-var wipe, never updated in GH secrets). With the secret resynced, those runs are green again — but the next time something goes wrong we should see the body.

## Test plan
- [x] Triggered a manual run on `main` (run 26444983592) — succeeded in 5s with the stale-key fix in place
- [ ] After merge, observe the next scheduled run still passes
- [ ] If a future run fails, confirm the response body now appears in the step log