### PR TITLE
WhatsApp Notifier — outbound WhatsApp Message on every Application creation (#259)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,14 @@ _Avoid_: Alert, Toast, Message
 A user-created action item with a description, priority (low / medium / high / urgent), and status (active / completed). A Task may optionally be linked to an Application; without a link it is standalone. Linked Tasks appear on the Application's detail panel; all Tasks are accessible from the dedicated Tasks page.
 _Avoid_: Todo (internal/DB term), Checklist item
 
+**WhatsApp Notifier**:
+An automated process that sends an outbound **WhatsApp Message** from the user's personal WhatsApp account to a single configured recipient whenever an Application is created — across both the manual create path and the Email Agent's auto-create path. A sibling of the Email Agent and Company Scout (automated processes acting on Applications), but triggered by Application creation rather than by email or Company novelty. It runs as a route on the Cassandra write shim on the Linux box and is reached from JobFlow over the existing ngrok tunnel. It produces **no Notification** and writes no `notifications` row — the WhatsApp Message is ephemeral and never persisted in JobFlow.
+_Avoid_: Notification (reserved for the persistent in-app entity), Alert, WhatsApp bot
+
+**WhatsApp Message**:
+The single ephemeral outbound message the WhatsApp Notifier sends on Application creation. Not stored anywhere in JobFlow; not a Notification.
+_Avoid_: Notification, Alert, Toast
+
 ## Relationships
 
 - A **User** owns a set of **Stages**
@@ -98,6 +106,7 @@ _Avoid_: Todo (internal/DB term), Checklist item
 - The **First Sighting** of a **Company** on a new **Application** triggers the **Company Scout**
 - The **Company Scout** resolves a **Company** to zero or more candidate **Orgs**, scores each candidate, and admits those above the acceptance threshold
 - The **Company Scout** classifies each admitted **Org** as having an **Active GitHub Presence** or not, and writes only the active ones to the JobFlow Analytics system's `companies` table — one row per (Company, Org) pair
+- The **WhatsApp Notifier** sends one outbound **WhatsApp Message** to a single configured recipient whenever an **Application** is created (both the manual and Email Agent auto-create paths); it produces no **Notification** and persists nothing in JobFlow
 
 ## Example dialogue
 

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -25,6 +25,11 @@ const schema = z.object({
   GITHUB_TOKEN:            z.string().optional(),
   COMPANY_REGISTRY_URL:    z.string().url().optional(),
   COMPANY_REGISTRY_TOKEN:  z.string().optional(),
+
+  // WhatsApp Notifier (ADR 0011). Optional — feature is a no-op when unset.
+  // Base URL of the shim (same host as COMPANY_REGISTRY_URL); the notifier
+  // appends /notify and reuses COMPANY_REGISTRY_TOKEN as the bearer token.
+  WHATSAPP_NOTIFY_URL:     z.string().url().optional(),
 }).superRefine((v, ctx) => {
   if (v.NODE_ENV !== 'production') return;
 
@@ -42,6 +47,15 @@ const schema = z.object({
 
   if (v.COMPANY_REGISTRY_URL && !v.COMPANY_REGISTRY_URL.startsWith('https://')) {
     ctx.addIssue({ code: 'custom', path: ['COMPANY_REGISTRY_URL'], message: 'COMPANY_REGISTRY_URL must use https:// in production (bearer token must not be sent in plaintext)' });
+  }
+
+  // WhatsApp Notifier reuses COMPANY_REGISTRY_TOKEN as its bearer token, so it
+  // must be present when the notify URL is set; and it must be https in prod.
+  if (v.WHATSAPP_NOTIFY_URL && !v.COMPANY_REGISTRY_TOKEN) {
+    ctx.addIssue({ code: 'custom', path: ['COMPANY_REGISTRY_TOKEN'], message: 'COMPANY_REGISTRY_TOKEN is required when WHATSAPP_NOTIFY_URL is set (reused as the shim bearer token)' });
+  }
+  if (v.WHATSAPP_NOTIFY_URL && !v.WHATSAPP_NOTIFY_URL.startsWith('https://')) {
+    ctx.addIssue({ code: 'custom', path: ['WHATSAPP_NOTIFY_URL'], message: 'WHATSAPP_NOTIFY_URL must use https:// in production (bearer token must not be sent in plaintext)' });
   }
 
   for (const [k, defaultVal] of [

--- a/backend/src/services/cardService.ts
+++ b/backend/src/services/cardService.ts
@@ -3,6 +3,7 @@ import db from '../config/database';
 import { AppError } from '../middleware/errorHandler';
 import { shiftUp, shiftDown, withTransaction } from '../util/positions';
 import { runCompanyCheck } from './companyScout/companyScout';
+import { notifyApplicationCreated } from './whatsappNotifier/whatsappNotifier';
 
 export interface CardFilters {
   stage?: string;
@@ -328,6 +329,17 @@ export const cardService = {
         careersUrl: data.careers_url,
       }).catch(() => { /* intentionally suppressed — Scout errors must not fail card creation */ });
     }
+
+    // WhatsApp Notifier (ADR 0011) — fire detached on EVERY Application
+    // creation (manual + Email Agent paths), never awaited so card-creation
+    // latency is unaffected. NOTE: createCard may run inside gmailSync's
+    // per-email transaction, so on a rare rollback this can notify for an
+    // Application that was never saved (accepted edge — see ADR 0011).
+    notifyApplicationCreated({
+      company: data.company_name,
+      role: data.role_title,
+      url: data.application_url,
+    });
 
     // Return card with stage name
     const stage = await runner('stages').where({ id: card.stage_id }).first();

--- a/backend/src/services/whatsappNotifier/whatsappNotifier.ts
+++ b/backend/src/services/whatsappNotifier/whatsappNotifier.ts
@@ -1,0 +1,130 @@
+import logger from '../../config/logger';
+import { env } from '../../config/env';
+
+/**
+ * WhatsApp Notifier (ADR 0011). Sends an outbound WhatsApp Message on every
+ * Application creation by POSTing { company, role, url } to the shim's /notify
+ * route. The recipient and wording live shim-side — JobFlow only supplies the
+ * three data fields.
+ *
+ * Mirrors the CompanyRegistry pattern: an interface with a production HTTP
+ * implementation and a logging dev fallback, fire-and-forget so card-creation
+ * latency is never affected.
+ */
+export interface ApplicationDetails {
+  company: string;
+  role: string;
+  url?: string | null;
+}
+
+export interface WhatsAppNotifier {
+  notify(details: ApplicationDetails): Promise<void>;
+}
+
+/**
+ * Dev fallback used when WHATSAPP_NOTIFY_URL is not configured. Logs a
+ * structured line describing what would have been sent — so local dev and
+ * tests never message anyone.
+ */
+export class LoggingWhatsAppNotifier implements WhatsAppNotifier {
+  notify(details: ApplicationDetails): Promise<void> {
+    logger.info('whatsapp_notifier.would_notify', {
+      service: 'whatsapp-notifier',
+      company: details.company,
+      role: details.role,
+      url: details.url ?? null,
+    });
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Production implementation — POSTs to the shim's /notify route running
+ * alongside Cassandra on the analytics-pipeline host. See ADR 0011.
+ *
+ * Fire-and-forget: network errors, 4xx, and 5xx are caught and logged at warn;
+ * they never propagate so card creation latency is unaffected.
+ */
+export class HttpShimWhatsAppNotifier implements WhatsAppNotifier {
+  private readonly url: string;
+  private readonly token: string;
+
+  constructor(url: string, token: string) {
+    this.url = url;
+    this.token = token;
+  }
+
+  async notify(details: ApplicationDetails): Promise<void> {
+    const controller = new AbortController();
+    // Mirror the 3 s timeout used by the Company Scout registry.
+    const timer = setTimeout(() => controller.abort(), 3000);
+
+    try {
+      const res = await fetch(`${this.url}/notify`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          company: details.company,
+          role: details.role,
+          url: details.url ?? undefined,
+        }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timer);
+
+      if (!res.ok) {
+        logger.warn('whatsapp_notifier.http_error', {
+          service: 'whatsapp-notifier',
+          company: details.company,
+          status: res.status,
+        });
+        return;
+      }
+
+      logger.info('whatsapp_notifier.queued', {
+        service: 'whatsapp-notifier',
+        company: details.company,
+        role: details.role,
+      });
+    } catch (err: unknown) {
+      clearTimeout(timer);
+      logger.warn('whatsapp_notifier.network_error', {
+        service: 'whatsapp-notifier',
+        company: details.company,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+let cached: WhatsAppNotifier | null = null;
+
+/**
+ * Resolve which WhatsAppNotifier implementation to use:
+ * - WHATSAPP_NOTIFY_URL set → HttpShimWhatsAppNotifier (production), reusing
+ *   COMPANY_REGISTRY_TOKEN as the shared shim bearer token
+ * - WHATSAPP_NOTIFY_URL unset → LoggingWhatsAppNotifier (dev fallback / no-op)
+ */
+export function resolveWhatsAppNotifier(): WhatsAppNotifier {
+  if (cached) return cached;
+  cached = env.WHATSAPP_NOTIFY_URL
+    ? new HttpShimWhatsAppNotifier(env.WHATSAPP_NOTIFY_URL, env.COMPANY_REGISTRY_TOKEN ?? '')
+    : new LoggingWhatsAppNotifier();
+  return cached;
+}
+
+/**
+ * Fire-and-forget entry point for the createCard call site. Never throws —
+ * notifier errors must never fail card creation.
+ */
+export function notifyApplicationCreated(details: ApplicationDetails): void {
+  resolveWhatsAppNotifier()
+    .notify(details)
+    .catch(() => {
+      /* intentionally suppressed — notifier errors must not fail card creation */
+    });
+}

--- a/backend/src/services/whatsappNotifier/whatsappNotifier.ts
+++ b/backend/src/services/whatsappNotifier/whatsappNotifier.ts
@@ -101,20 +101,18 @@ export class HttpShimWhatsAppNotifier implements WhatsAppNotifier {
   }
 }
 
-let cached: WhatsAppNotifier | null = null;
-
 /**
- * Resolve which WhatsAppNotifier implementation to use:
+ * Resolve which WhatsAppNotifier implementation to use (constructed fresh, to
+ * match resolveRegistry() and avoid module-level state that leaks across tests):
  * - WHATSAPP_NOTIFY_URL set → HttpShimWhatsAppNotifier (production), reusing
  *   COMPANY_REGISTRY_TOKEN as the shared shim bearer token
  * - WHATSAPP_NOTIFY_URL unset → LoggingWhatsAppNotifier (dev fallback / no-op)
  */
 export function resolveWhatsAppNotifier(): WhatsAppNotifier {
-  if (cached) return cached;
-  cached = env.WHATSAPP_NOTIFY_URL
-    ? new HttpShimWhatsAppNotifier(env.WHATSAPP_NOTIFY_URL, env.COMPANY_REGISTRY_TOKEN ?? '')
-    : new LoggingWhatsAppNotifier();
-  return cached;
+  if (env.WHATSAPP_NOTIFY_URL) {
+    return new HttpShimWhatsAppNotifier(env.WHATSAPP_NOTIFY_URL, env.COMPANY_REGISTRY_TOKEN ?? '');
+  }
+  return new LoggingWhatsAppNotifier();
 }
 
 /**

--- a/data-pipeline/docker-compose.yml
+++ b/data-pipeline/docker-compose.yml
@@ -72,6 +72,14 @@ services:
       # Only contains SHIM_BEARER_TOKEN (the one secret). Created from
       # shim/.env.example on first deploy; not committed.
       - ./shim/.env
+    # whatsapp-web.js LocalAuth session (ADR 0011) — bind-mounted so the QR is
+    # scanned once and survives restarts/rebuilds. Create on the host first:
+    #   mkdir -p /home/tomer/whatsapp-session && sudo chown 1000:1000 /home/tomer/whatsapp-session
+    volumes:
+      - /home/tomer/whatsapp-session:/app/.wwebjs_auth
+    # Chromium needs far more shared memory than Docker's 64 MB default; pair
+    # with the --disable-dev-shm-usage flag set in lib/whatsapp.js.
+    shm_size: "512mb"
     depends_on:
       cassandra:
         condition: service_healthy

--- a/data-pipeline/shim/Dockerfile
+++ b/data-pipeline/shim/Dockerfile
@@ -19,6 +19,9 @@ ENV PUPPETEER_SKIP_DOWNLOAD=true \
 
 # Chromium + the runtime libraries it needs headless. --no-install-recommends
 # keeps the image lean; fonts-liberation avoids blank glyphs in rendered pages.
+# The explicit lib list is belt-and-suspenders — most are already hard Depends
+# of the `chromium` package — but pinning them documents the headless surface
+# and guards against a future apt resolver trimming a transitive dependency.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       chromium \
       ca-certificates \
@@ -47,8 +50,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install production deps first so layer caches across source-only edits.
-COPY package.json ./
-RUN npm install --omit=dev --no-audit --no-fund
+# npm ci against the committed lockfile makes rebuilds reproducible (pins the
+# whatsapp-web.js + puppeteer tree so a rebuild can't silently drift).
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --no-audit --no-fund
 
 # Source.
 COPY shim.js ./

--- a/data-pipeline/shim/Dockerfile
+++ b/data-pipeline/shim/Dockerfile
@@ -1,12 +1,50 @@
-# JobFlow Cassandra write shim — container image.
+# JobFlow write shim — container image.
 #
-# Run via docker-compose from data-pipeline/. The shim binds on
-# SHIM_BIND_ADDRESS:SHIM_PORT (defaults set in compose to 0.0.0.0:3333) and
-# talks to Cassandra on the docker network via the 'cassandra' service name.
+# Runs two routes (see ADR 0010 + ADR 0011):
+#   POST /companies  — Cassandra write shim (Company Scout)
+#   POST /notify     — WhatsApp Notifier (sends via whatsapp-web.js + Chromium)
+#
+# Base is Debian slim (not Alpine): whatsapp-web.js drives Chromium via
+# puppeteer, and puppeteer's bundled Chromium does not run on Alpine's musl.
+# We install the distro Chromium and point puppeteer at it instead of letting
+# puppeteer download its own.
 
-FROM node:20-alpine
+FROM node:20-slim
 
 WORKDIR /app
+
+# Use the system Chromium; skip puppeteer's own download at install time.
+ENV PUPPETEER_SKIP_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Chromium + the runtime libraries it needs headless. --no-install-recommends
+# keeps the image lean; fonts-liberation avoids blank glyphs in rendered pages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      chromium \
+      ca-certificates \
+      fonts-liberation \
+      libasound2 \
+      libatk-bridge2.0-0 \
+      libatk1.0-0 \
+      libcairo2 \
+      libcups2 \
+      libdbus-1-3 \
+      libexpat1 \
+      libgbm1 \
+      libglib2.0-0 \
+      libgtk-3-0 \
+      libnspr4 \
+      libnss3 \
+      libpango-1.0-0 \
+      libx11-6 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxext6 \
+      libxfixes3 \
+      libxkbcommon0 \
+      libxrandr2 \
+      libxshmfence1 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install production deps first so layer caches across source-only edits.
 COPY package.json ./
@@ -16,8 +54,11 @@ RUN npm install --omit=dev --no-audit --no-fund
 COPY shim.js ./
 COPY lib ./lib
 
-# Non-root user. node:alpine ships a 'node' user (uid 1000) — use it.
-RUN chown -R node:node /app
+# whatsapp-web.js LocalAuth persists the session here; the directory is
+# bind-mounted to the host (see docker-compose.yml) so the QR is scanned once.
+# Create it and hand /app to the non-root 'node' user (uid 1000) that ships
+# with the image. Chromium runs with --no-sandbox so non-root is fine.
+RUN mkdir -p /app/.wwebjs_auth && chown -R node:node /app
 USER node
 
 # Documentation only — actual port comes from SHIM_PORT env var.

--- a/data-pipeline/shim/RUNBOOK.md
+++ b/data-pipeline/shim/RUNBOOK.md
@@ -266,6 +266,15 @@ After `whatsapp.ready`, you only re-scan if the session is invalidated (logout,
 phone offline > ~14 days, or a ban). Detection is manual — `docker logs jf-shim`
 shows `whatsapp.disconnected` / `whatsapp.auth_failure`.
 
+> **If you get a fresh QR on every restart**, the host session directory is not
+> writable by the container's uid 1000. The `LocalAuth` session can't persist, so
+> it re-authenticates each boot — easy to misread as a code bug. Fix the owner and
+> verify:
+> ```bash
+> sudo chown -R 1000:1000 /home/tomer/whatsapp-session
+> ls -ld /home/tomer/whatsapp-session   # owner column must read 1000 (or 'node')
+> ```
+
 ### JobFlow (Render) config
 
 Add one env var: `WHATSAPP_NOTIFY_URL` = the same static ngrok base URL already
@@ -274,6 +283,12 @@ The bearer token is reused from `COMPANY_REGISTRY_TOKEN`. Leaving
 `WHATSAPP_NOTIFY_URL` unset makes the feature a no-op (`LoggingWhatsAppNotifier`).
 
 ### Smoke test
+
+Because this PR changes the shim's base image (Alpine → Debian) and the shared
+container, ADR 0006 / ADR 0011 require the **same transcript** to also prove the
+`/companies` Cassandra path did not regress. Run the `/companies` happy-path +
+Cassandra-row check from the "End-to-end smoke test" section above **first**,
+then the `/notify` checks below.
 
 ```bash
 SHIM_URL="https://YOUR_NGROK_HOST"

--- a/data-pipeline/shim/RUNBOOK.md
+++ b/data-pipeline/shim/RUNBOOK.md
@@ -234,6 +234,80 @@ fallback without removing the token.
 
 ---
 
+## WhatsApp Notifier (`POST /notify`) — ADR 0011
+
+The shim also hosts the WhatsApp Notifier: JobFlow POSTs `{ company, role, url }`
+on every Application creation and the shim sends a WhatsApp Message from the
+sender phone's personal account to a single hardcoded recipient (in
+`lib/message.js`). It runs on the same container, port, ngrok tunnel, and bearer
+token as `/companies`; a dead WhatsApp session returns `503` on `/notify` and
+never affects `/companies`.
+
+### First-time setup (one-time QR scan)
+
+```bash
+# 1. Create the host-side session directory (bind-mounted; makes the QR scan
+#    survive restarts/rebuilds). uid 1000 = the container's 'node' user.
+mkdir -p /home/tomer/whatsapp-session
+sudo chown 1000:1000 /home/tomer/whatsapp-session
+
+# 2. Build + start the shim (now Debian-based, with Chromium baked in).
+cd /home/tomer/jobflow/data-pipeline
+docker compose up -d --build shim
+
+# 3. Watch the logs for the ASCII QR code, then scan it from the sender phone:
+#    WhatsApp → Settings → Linked Devices → Link a Device.
+docker logs jf-shim -f
+# Expect: 'whatsapp.qr_required' followed by a QR, then 'whatsapp.authenticated'
+# and 'whatsapp.ready'. The session is now saved to /home/tomer/whatsapp-session.
+```
+
+After `whatsapp.ready`, you only re-scan if the session is invalidated (logout,
+phone offline > ~14 days, or a ban). Detection is manual — `docker logs jf-shim`
+shows `whatsapp.disconnected` / `whatsapp.auth_failure`.
+
+### JobFlow (Render) config
+
+Add one env var: `WHATSAPP_NOTIFY_URL` = the same static ngrok base URL already
+used for `COMPANY_REGISTRY_URL` (no `/notify` suffix — the client appends it).
+The bearer token is reused from `COMPANY_REGISTRY_TOKEN`. Leaving
+`WHATSAPP_NOTIFY_URL` unset makes the feature a no-op (`LoggingWhatsAppNotifier`).
+
+### Smoke test
+
+```bash
+SHIM_URL="https://YOUR_NGROK_HOST"
+TOKEN="your-bearer-token"
+NGROK_HDR=(-H 'ngrok-skip-browser-warning: 1')
+
+# Happy path (with URL) — recipient should receive the message.
+curl -s -X POST "${SHIM_URL}/notify" "${NGROK_HDR[@]}" \
+  -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+  -d '{"company":"Wix","role":"Senior Backend Engineer","url":"https://wix.com/careers/123"}'
+# expected: {"status":"queued"}
+
+# Happy path (no URL) — message sent without the link line.
+curl -s -X POST "${SHIM_URL}/notify" "${NGROK_HDR[@]}" \
+  -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+  -d '{"company":"Acme","role":"Platform Engineer"}'
+# expected: {"status":"queued"}
+
+# Negative paths
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "${SHIM_URL}/notify" "${NGROK_HDR[@]}" \
+  -H "Authorization: Bearer wrong" -H "Content-Type: application/json" -d '{}'        # 401
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "${SHIM_URL}/notify" "${NGROK_HDR[@]}" \
+  -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" -d 'nope'   # 400
+curl -sS -o /dev/null -w "%{http_code}\n" -X POST "${SHIM_URL}/notify" "${NGROK_HDR[@]}" \
+  -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: text/plain" -d 'x'            # 415
+# When the WhatsApp client is not ready: expect 503 {"status":"whatsapp_unavailable"}
+```
+
+> ⚠️ whatsapp-web.js is unofficial (against WhatsApp ToS); ban risk on the sender
+> number is accepted. The `/notify` send queue paces messages (min 3 s apart) so a
+> bulk Email Agent sync doesn't fire a spam-shaped burst.
+
+---
+
 ## Where logs go
 
 - Shim logs: `docker logs jf-shim -f`

--- a/data-pipeline/shim/lib/message.js
+++ b/data-pipeline/shim/lib/message.js
@@ -1,0 +1,29 @@
+// Pure helpers for the WhatsApp Notifier route (see ADR 0011).
+//
+// Kept dependency-free and side-effect-free so the formatting and recipient
+// rules are trivial to reason about in isolation.
+
+// Single hardcoded recipient (Netali). The recipient lives shim-side so the
+// number/wording can change with a box-side edit + restart — JobFlow never
+// knows who is messaged (it sends only { company, role, url }).
+export const RECIPIENT = '+972525912293';
+
+// whatsapp-web.js addresses chats by `<countrycode><number>@c.us` with no
+// '+', spaces, or dashes. Normalise any human-formatted number to that form.
+export function toChatId(rawNumber) {
+  const digits = String(rawNumber).replace(/\D/g, '');
+  return `${digits}@c.us`;
+}
+
+// Render the outbound WhatsApp Message. The link line is dropped when the
+// Application has no job-posting URL; company + role alone is still sent.
+export function formatMessage({ company, role, url }) {
+  const lines = [
+    'Hey Netali, I found new position, Here are the Details:',
+    `${company} — ${role}`,
+  ];
+  if (typeof url === 'string' && url.trim() !== '') {
+    lines.push(url.trim());
+  }
+  return lines.join('\n');
+}

--- a/data-pipeline/shim/lib/message.js
+++ b/data-pipeline/shim/lib/message.js
@@ -15,15 +15,39 @@ export function toChatId(rawNumber) {
   return `${digits}@c.us`;
 }
 
+// Collapse any whitespace run — including newlines, carriage returns and tabs —
+// to a single space, then trim. company/role are user-controlled card fields,
+// so an embedded newline could otherwise forge extra lines (e.g. a spoofed link
+// line) in the outbound message. `\s` covers \n \r \t \f \v, which is exactly
+// the line-forging surface.
+function sanitizeField(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+
+// Only emit the link line for a syntactically valid http(s) URL; drop anything
+// else (malformed, or whitespace/control-char-laden) rather than risk a forged
+// line.
+function sanitizeUrl(url) {
+  if (typeof url !== 'string' || url.trim() === '') return null;
+  try {
+    const parsed = new URL(url.trim());
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
 // Render the outbound WhatsApp Message. The link line is dropped when the
-// Application has no job-posting URL; company + role alone is still sent.
+// Application has no (valid) job-posting URL; company + role alone is still sent.
 export function formatMessage({ company, role, url }) {
   const lines = [
     'Hey Netali, I found new position, Here are the Details:',
-    `${company} — ${role}`,
+    `${sanitizeField(company)} — ${sanitizeField(role)}`,
   ];
-  if (typeof url === 'string' && url.trim() !== '') {
-    lines.push(url.trim());
+  const cleanUrl = sanitizeUrl(url);
+  if (cleanUrl) {
+    lines.push(cleanUrl);
   }
   return lines.join('\n');
 }

--- a/data-pipeline/shim/lib/whatsapp.js
+++ b/data-pipeline/shim/lib/whatsapp.js
@@ -1,0 +1,97 @@
+// WhatsApp client wrapper for the Notifier route (see ADR 0011).
+//
+// Hides the whatsapp-web.js lifecycle (QR auth, ready/disconnected state,
+// sending) behind a small surface: isReady() / enqueue(text) / init().
+//
+// Isolation: this module never throws into the shim's HTTP path. A dead or
+// unauthenticated Chromium just means isReady() === false, so /notify returns
+// 503 while /companies keeps serving. Initialisation failures are logged, not
+// propagated.
+//
+// Throttle: sends are serialised through a queue with a minimum gap between
+// messages, so a bulk Email Agent sync that creates N Applications doesn't fire
+// N near-simultaneous WhatsApp messages (a spam-shaped pattern).
+
+import wweb from 'whatsapp-web.js';
+import qrcode from 'qrcode-terminal';
+import { toChatId } from './message.js';
+
+const { Client, LocalAuth } = wweb;
+
+const MIN_SEND_INTERVAL_MS = 3000;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export function createWhatsApp({ recipient, logger, executablePath }) {
+  const chatId = toChatId(recipient);
+
+  let ready = false;
+  const queue = [];
+  let draining = false;
+
+  const client = new Client({
+    authStrategy: new LocalAuth(), // persists to .wwebjs_auth (host-mounted)
+    puppeteer: {
+      headless: true,
+      executablePath, // system Chromium (Debian slim); undefined → puppeteer default
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+      ],
+    },
+  });
+
+  client.on('qr', (qr) => {
+    // First-run auth: render the QR as ASCII so it can be scanned from an SSH
+    // session / `docker logs jf-shim`. Scanned once; the session is then
+    // persisted to the host-mounted .wwebjs_auth directory.
+    logger.warn('whatsapp.qr_required — scan this QR with WhatsApp on the sender phone');
+    qrcode.generate(qr, { small: true });
+  });
+
+  client.on('authenticated', () => logger.info('whatsapp.authenticated'));
+
+  client.on('ready', () => {
+    ready = true;
+    logger.info({ chatId }, 'whatsapp.ready');
+  });
+
+  client.on('auth_failure', (msg) => {
+    ready = false;
+    logger.error({ msg }, 'whatsapp.auth_failure — re-scan required');
+  });
+
+  client.on('disconnected', (reason) => {
+    ready = false;
+    logger.error({ reason }, 'whatsapp.disconnected — sends will 503 until reconnected');
+  });
+
+  async function drain() {
+    if (draining) return;
+    draining = true;
+    while (queue.length > 0) {
+      const text = queue.shift();
+      try {
+        await client.sendMessage(chatId, text);
+        logger.info('whatsapp.sent');
+      } catch (err) {
+        logger.error({ err: err instanceof Error ? err.message : String(err) }, 'whatsapp.send_failed');
+      }
+      if (queue.length > 0) await sleep(MIN_SEND_INTERVAL_MS);
+    }
+    draining = false;
+  }
+
+  return {
+    isReady: () => ready,
+    enqueue(text) {
+      queue.push(text);
+      // Fire-and-forget; drain serialises and paces the sends itself.
+      drain();
+    },
+    init() {
+      return client.initialize();
+    },
+  };
+}

--- a/data-pipeline/shim/lib/whatsapp.js
+++ b/data-pipeline/shim/lib/whatsapp.js
@@ -71,6 +71,14 @@ export function createWhatsApp({ recipient, logger, executablePath }) {
     if (draining) return;
     draining = true;
     while (queue.length > 0) {
+      // If the session dropped mid-drain, stop and log the loss explicitly
+      // rather than throw on every send. This is the ADR 0011 "silent death"
+      // edge — made loud here so it shows up in `docker logs jf-shim`.
+      if (!ready) {
+        logger.warn({ dropped: queue.length }, 'whatsapp.not_ready_mid_drain — dropping queued messages');
+        queue.length = 0;
+        break;
+      }
       const text = queue.shift();
       try {
         await client.sendMessage(chatId, text);

--- a/data-pipeline/shim/package-lock.json
+++ b/data-pipeline/shim/package-lock.json
@@ -1,0 +1,2598 @@
+{
+  "name": "jobflow-company-shim",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jobflow-company-shim",
+      "version": "1.1.0",
+      "dependencies": {
+        "cassandra-driver": "^4.7.2",
+        "pino": "^9.0.0",
+        "qrcode-terminal": "^0.12.0",
+        "whatsapp-web.js": "^1.34.0"
+      },
+      "devDependencies": {
+        "pino-pretty": "^13.0.0"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
+      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.4.tgz",
+      "integrity": "sha512-zbQJi2YQUe3SrX19TItQ8DoPj9E1i5rrdE9iHV4PhUif1GodNRSe85lavVGbmU7P4M8579EQi4akGFuhCATWaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cassandra-driver": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-4.9.0.tgz",
+      "integrity": "sha512-svYpdkLIGjD0WmuuwkkeYbfBdPX1zksK2cDyT1mWjX53OVTzuWBOVy54K6PPij8GgYpIG+K82OryrBv/xNeuWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^20.14.8",
+        "adm-zip": "~0.5.10",
+        "long": "~5.2.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1581282",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
+      "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fluent-ffmpeg": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fluent-ffmpeg/-/fluent-ffmpeg-2.1.3.tgz",
+      "integrity": "sha512-Be3narBNt2s6bsaqP6Jzq91heDgOEaDCJAXcE3qcma/EJBSy5FB4cvO31XBInuAuKBx8Kptf8dkhjK0IOru39Q==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^0.2.9",
+        "which": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fluent-ffmpeg/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/long": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.5.tgz",
+      "integrity": "sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-webpmux": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-webpmux/-/node-webpmux-3.2.1.tgz",
+      "integrity": "sha512-MKgpq9nFgo44pIVNx/umD3nkqb2E8oqQTfmstVsfNdx9uV4cX7a4LqA+d8AZd3v5tgJXwENKUFsXNP3bRLP8nQ==",
+      "license": "LGPL-3.0-or-later"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/pino": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.38.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.38.0.tgz",
+      "integrity": "sha512-abnJOBVoL9PQTLKSbYGm9mjNFyIPaTVj77J/6cS370dIQtcZMpx8wyZoAuBzR71Aoon6yvI71NEVFUsl3JU82g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1581282",
+        "puppeteer-core": "24.38.0",
+        "typed-query-selector": "^2.12.1"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.38.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.38.0.tgz",
+      "integrity": "sha512-zB3S/tksIhgi2gZRndUe07AudBz5SXOB7hqG0kEa9/YXWrGwlVlYm3tZtwKgfRftBzbmLQl5iwHkQQl04n/mWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.13.0",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1581282",
+        "typed-query-selector": "^2.12.1",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/qrcode-terminal": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+      "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatsapp-web.js": {
+      "version": "1.34.7",
+      "resolved": "https://registry.npmjs.org/whatsapp-web.js/-/whatsapp-web.js-1.34.7.tgz",
+      "integrity": "sha512-CscRtB32OnozLj+cuG9Q5f7IhnNV2EU4RGRJYeYF7wwhN6acQ0efabnFpetSEh5Y8OL4YqBj7nSQbUrTZYLDGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fluent-ffmpeg": "2.1.3",
+        "mime": "3.0.0",
+        "node-fetch": "2.7.0",
+        "node-webpmux": "3.2.1",
+        "puppeteer": "24.38.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "archiver": "7.0.1",
+        "fs-extra": "11.3.4",
+        "unzipper": "0.12.3"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yauzl/node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/data-pipeline/shim/package.json
+++ b/data-pipeline/shim/package.json
@@ -1,8 +1,8 @@
 {
   "name": "jobflow-company-shim",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
-  "description": "HTTPS write shim: registers (company, org) pairs into jobflow.companies via INSERT … IF NOT EXISTS",
+  "description": "Write shim: registers (company, org) pairs into jobflow.companies; also sends WhatsApp Messages on Application creation (POST /notify)",
   "main": "shim.js",
   "engines": {
     "node": ">=20.6.0"
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "cassandra-driver": "^4.7.2",
-    "pino": "^9.0.0"
+    "pino": "^9.0.0",
+    "qrcode-terminal": "^0.12.0",
+    "whatsapp-web.js": "^1.34.0"
   },
   "devDependencies": {
     "pino-pretty": "^13.0.0"

--- a/data-pipeline/shim/shim.js
+++ b/data-pipeline/shim/shim.js
@@ -2,6 +2,8 @@ import http from 'node:http';
 import crypto from 'node:crypto';
 import pino from 'pino';
 import { buildClient, insertIfNotExists } from './lib/cassandra.js';
+import { createWhatsApp } from './lib/whatsapp.js';
+import { formatMessage, RECIPIENT } from './lib/message.js';
 
 // ── Env config ───────────────────────────────────────────────────────────────
 const SHIM_PORT            = parseInt(process.env.SHIM_PORT ?? '3333', 10);
@@ -142,10 +144,64 @@ async function handleRegister(req, res, client) {
   return send(res, 200, { company: body.company, results });
 }
 
+// WhatsApp Notifier route (ADR 0011). JobFlow POSTs { company, role, url? };
+// the recipient + wording live shim-side (see lib/message.js). Isolated from
+// the Cassandra path: when the WhatsApp client is not ready, this returns 503
+// and /companies is unaffected.
+async function handleNotify(req, res, whatsapp) {
+  // Auth — same bearer token as /companies.
+  if (!checkAuth(req)) {
+    return send(res, 401, { error: 'unauthorized' });
+  }
+
+  const contentType = (req.headers['content-type'] ?? '').toLowerCase();
+  if (!contentType.startsWith('application/json')) {
+    return send(res, 415, { error: 'content-type must be application/json' });
+  }
+
+  let body;
+  try {
+    body = JSON.parse(await readBody(req));
+  } catch (err) {
+    if (err && err.statusCode === 413) {
+      return send(res, 413, { error: 'payload too large' });
+    }
+    return send(res, 400, { error: 'invalid JSON' });
+  }
+
+  // Validation
+  if (typeof body.company !== 'string' || body.company.trim() === '') {
+    return send(res, 400, { error: 'company must be a non-empty string' });
+  }
+  if (typeof body.role !== 'string' || body.role.trim() === '') {
+    return send(res, 400, { error: 'role must be a non-empty string' });
+  }
+  if (body.url !== undefined && body.url !== null && typeof body.url !== 'string') {
+    return send(res, 400, { error: 'url must be a string when provided' });
+  }
+
+  // Degrade cleanly if WhatsApp is down/unauthenticated — never 500, never
+  // touch the Cassandra path.
+  if (!whatsapp || !whatsapp.isReady()) {
+    logger.warn({ company: body.company }, 'whatsapp.unavailable — dropping notify');
+    return send(res, 503, { status: 'whatsapp_unavailable' });
+  }
+
+  const text = formatMessage({ company: body.company, role: body.role, url: body.url });
+  whatsapp.enqueue(text);
+  logger.info({ company: body.company, role: body.role }, 'notify queued');
+  return send(res, 200, { status: 'queued' });
+}
+
 // ── Main ──────────────────────────────────────────────────────────────────────
 // Hoisted so the top-level main().catch() can clean up if startup fails after
 // the Cassandra client has been created but before steady state.
 let client = null;
+
+// The WhatsApp Notifier client (ADR 0011). Stays null until initialised in
+// main(); the /notify handler treats null/not-ready as 503. Module-scoped so
+// the request handler closure can see it.
+let whatsapp = null;
 
 async function main() {
   client = buildClient({
@@ -168,6 +224,11 @@ async function main() {
         logger.error({ err }, 'unhandled handler error');
         if (!res.headersSent) send(res, 500, { error: 'internal server error' });
       });
+    } else if (req.method === 'POST' && req.url === '/notify') {
+      await handleNotify(req, res, whatsapp).catch(err => {
+        logger.error({ err }, 'unhandled handler error');
+        if (!res.headersSent) send(res, 500, { error: 'internal server error' });
+      });
     } else {
       send(res, 404, { error: 'not found' });
     }
@@ -182,6 +243,24 @@ async function main() {
   server.listen(SHIM_PORT, SHIM_BIND_ADDRESS, () => {
     logger.info({ port: SHIM_PORT, bind: SHIM_BIND_ADDRESS }, 'shim listening');
   });
+
+  // WhatsApp Notifier (ADR 0011) — initialised AFTER the HTTP server is
+  // listening and in its own isolated scope, so a dead/unauthenticated
+  // Chromium degrades /notify (503) without ever affecting /companies. Init
+  // is fire-and-forget: errors are logged, never thrown. On first run this
+  // emits a QR (rendered as ASCII in the logs) to scan once.
+  try {
+    whatsapp = createWhatsApp({
+      recipient: RECIPIENT,
+      logger,
+      executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+    });
+    whatsapp.init().catch(err => {
+      logger.error({ err: err instanceof Error ? err.message : String(err) }, 'whatsapp.init_failed');
+    });
+  } catch (err) {
+    logger.error({ err: err instanceof Error ? err.message : String(err) }, 'whatsapp.setup_failed');
+  }
 
   // Graceful shutdown: allow in-flight requests to drain before closing Cassandra.
   for (const sig of ['SIGTERM', 'SIGINT']) {

--- a/docs/adr/0011-whatsapp-notifier-on-shim.md
+++ b/docs/adr/0011-whatsapp-notifier-on-shim.md
@@ -1,0 +1,66 @@
+# ADR 0011 — The WhatsApp Notifier lives as a route on the Cassandra write shim, not as its own component
+
+**Status:** Accepted
+**Date:** 2026-06-04
+
+## Context
+
+We want an outbound WhatsApp message sent to a single personal recipient (Netali, hardcoded) whenever an **Application** is created — see `/CONTEXT.md` → **WhatsApp Notifier**, `knowledge/wiki/whatsapp-notifier.md`. The sender is the user's personal WhatsApp account, driven by `whatsapp-web.js` (free, unofficial, drives a headless Chromium via puppeteer; personal-number ban risk explicitly accepted).
+
+The network topology is identical to the Company Scout's (ADR 0010): **JobFlow runs on Render (public cloud)** and must reach a service on the **Xubuntu box at `tomer@192.168.10.12` (home LAN)**. That bridge already exists — a single `ngrok` systemd agent forwards `localhost:3333` → one static `*.ngrok-free.dev` hostname, in front of the Cassandra write shim.
+
+Constraints surfaced during the grill (2026-06-04):
+
+- **ngrok free = exactly 1 static domain** (3 concurrent endpoints / 20k req-mo / 1 GB-mo). A second endpoint would get a *rotating* `*.ngrok-free.app` URL, breaking JobFlow's `WHATSAPP_NOTIFY_URL` on every box restart.
+- The user's explicit directive: **no new components in the system** — reuse the existing shim, the existing ngrok tunnel.
+- The send path must never block Application creation, and must never take down the Company Scout's Cassandra write path.
+
+## Decision
+
+The WhatsApp Notifier is a **new `POST /notify` route on the existing Cassandra write shim** (`data-pipeline/shim/`). No new container, no reverse proxy, no second ngrok endpoint. Because ngrok already forwards the whole static domain to `localhost:3333`, `/notify` is reachable for free the moment the route exists — both `/companies` and `/notify` live under the one static domain.
+
+**Wire contract** (mirrors `/companies` conventions):
+
+```
+POST /notify
+Authorization: Bearer <SHIM_BEARER_TOKEN>   # same token guards both routes
+Content-Type: application/json
+
+{ "company": "Wix", "role": "Senior Backend Engineer", "url": "https://wix.com/careers/12345" }
+
+→ 200 { "status": "queued" }
+→ 401 bad/missing token · 400 bad body · 415 wrong content-type
+→ 503 { "status": "whatsapp_unavailable" }   # Chromium dead/unauthenticated
+```
+
+- **JobFlow stays generic** — it posts only `{ company, role, url }`. The **recipient number (`+972 54-448-3175`) and the message template ("Hey Netali, I found new position…") are hardcoded in the shim.** Changing recipient/wording is a box-side edit + container restart; no Render redeploy.
+- **`url` is optional** — when the Application has no `application_url`, the shim drops the link line and still sends company + role.
+- **Throttle:** `/notify` enqueues into a serialized queue with a min send-interval, so a bulk Gmail sync that creates N Applications doesn't fire N near-simultaneous messages (a WhatsApp spam-flag pattern).
+- **Isolation:** the `whatsapp-web.js` client is initialized in its own guarded scope *after* the HTTP server is listening; if Chromium is dead/unauthenticated, `/notify` returns 503 and **`/companies` keeps serving**. A Chromium crash degrades `/notify` only.
+- **Base image:** the shim moves from `node:20-alpine` to **`node:20-slim` (Debian)** — the supported puppeteer/Chromium path. `cassandra-driver` + `pino` run identically on Debian. Image grows to ~400 MB (inherent to bundling Chromium).
+- **Auth:** first run renders the WhatsApp Web QR as ASCII via `qrcode-terminal` (visible over SSH / in `docker logs`); the `LocalAuth` session directory is **bind-mounted to the host** so the QR is scanned exactly once and survives restarts/rebuilds.
+- **Observability (v1):** logs only. The shim logs every send outcome and logs loudly on `disconnected`/`auth_failure`. Detection of a dead session is manual (`docker logs jf-shim`) — consistent with the Company Scout's no-alerting posture.
+
+JobFlow's side mirrors `CompanyRegistry` exactly: a `WhatsAppNotifier` interface with `HttpShimWhatsAppNotifier` (production, POSTs to `WHATSAPP_NOTIFY_URL` with a 3s `AbortController` timeout, swallows all errors) and `LoggingWhatsAppNotifier` (dev fallback when `WHATSAPP_NOTIFY_URL` is unset → feature is a no-op locally and in tests). Fired **detached** from inside `cardService.createCard`, next to `runCompanyCheck` — one shared call site covering both the manual and Email Agent create paths.
+
+## Consequences
+
+- **No new infrastructure.** Zero new containers, no proxy, no second tunnel, well within ngrok-free limits (a few sends/day vs 20k req/mo).
+- **The shim is no longer "tiny," and two unrelated features share one container.** A future reader will be surprised to find `whatsapp-web.js` + Chromium inside a service named "Cassandra write shim" — this ADR is that explanation. The isolation guard keeps the *failure* domains separate (a Chromium crash can't sink `/companies`), but the *deploy* domain is now shared: redeploying the shim restarts the Cassandra write path too.
+- **The base-image change touches a working production container.** ADR 0006 (smoke-test transcripts required for data-pipeline PRs) applies: the PR must show `/companies` still green *and* a `/notify` send transcript.
+- **The transaction-boundary edge is accepted.** `createCard` runs inside gmailSync's per-email transaction; the detached `/notify` can fire before commit, so a (rare) rollback means Netali receives a message for an Application that was never saved. Carries a code comment; same accepted edge as the Scout (ADR 0010 / `company-scout.md`), but with a human-visible blast radius rather than an invisible Cassandra row.
+- **Silent-failure gap.** A dead WhatsApp session drops every message with no active alert in v1; the documented future fix is a self-alert ping (message the user's own number on `disconnected`/`auth_failure`).
+
+## Alternatives considered
+
+- **Separate `jf-whatsapp` container + a path-routing reverse proxy** under the one static domain (`/companies`→shim, `/notify`→whatsapp). Clean separation of concerns and failure domains; but re-introduces a proxy component and a second container. **Rejected** — the user explicitly wanted no new components, and the isolation guard recovers most of the failure-domain benefit.
+- **Second ngrok endpoint for the WhatsApp service.** Allowed by the 3-endpoint free limit, but only one *static* domain exists on free; the second endpoint's URL rotates on every restart, silently breaking `WHATSAPP_NOTIFY_URL`. **Rejected** as brittle.
+- **Switch the box to Cloudflare Tunnel** (free, unlimited stable named hostnames → trivial second hostname). A real, free, stable option; **rejected** for v1 because ngrok reuse was locked and changing the tunnel provider is out of scope.
+- **Stay on `node:20-alpine` with Alpine's chromium apk.** Keeps the lean base, but Alpine's Chromium is the quirkier, less-trodden puppeteer path (version lag, crashes). **Rejected** in favour of the boring Debian-slim path.
+
+## See also
+
+- `knowledge/wiki/whatsapp-notifier.md` — full system context
+- ADR 0010 — Company Scout's HTTPS-shim write path (the pattern this mirrors and the shim it extends)
+- ADR 0006 — smoke-test transcripts required for data-pipeline changes
+- `/CONTEXT.md` → **WhatsApp Notifier**, **WhatsApp Message**

--- a/knowledge/raw/2026-06-04-grill-whatsapp-notifier.md
+++ b/knowledge/raw/2026-06-04-grill-whatsapp-notifier.md
@@ -1,0 +1,82 @@
+# Grill transcript — WhatsApp Notifier (2026-06-04)
+
+Topic: send an outbound WhatsApp message from the user's personal account to one
+recipient (Netali) whenever an Application is created, via `whatsapp-web.js` on
+the Linux box, reached from JobFlow (Render) over the existing ngrok tunnel.
+
+Pre-loaded: CONTEXT.md, wiki/company-scout.md, ADR 0010 (HTTPS shim), shim source.
+
+## Locked decisions
+
+1. **Auth / session** — SSH in once, scan the WhatsApp Web QR rendered as ASCII via
+   `qrcode-terminal` (visible in `docker logs`). Dockerized. **`LocalAuth` session
+   directory bind-mounted to the host** so the QR is scanned exactly once and
+   survives restarts/rebuilds. Headless Chromium needs `--no-sandbox`.
+
+2. **No new components — `/notify` is a route on the existing Cassandra write shim.**
+   Not a separate container, not a proxy, not a second ngrok endpoint. ngrok free =
+   1 static domain (3 endpoints / 20k req-mo / 1 GB-mo, verified); a 2nd endpoint
+   would get a rotating URL → rejected. `/notify` reachable for free under the one
+   static domain.
+
+3. **Coupling accepted, failures isolated.** Pulling whatsapp-web.js + Chromium into
+   the shim makes it a heavier, two-feature container. The WhatsApp client is
+   isolated: if Chromium is dead/unauthenticated, `/notify` → 503 and `/companies`
+   keeps serving. → ADR 0011.
+
+4. **Naming.** System = **WhatsApp Notifier** (sibling of Email Agent / Company
+   Scout). What it sends = **WhatsApp Message**, explicitly NOT a Notification (the
+   glossary reserves Notification for the persistent in-app entity). CONTEXT.md
+   updated inline.
+
+5. **Burst handling = (b) throttle.** `/notify` serializes sends with a min interval
+   so a bulk Gmail sync (N Applications back-to-back) doesn't fire a spam-shaped
+   flurry. Keeps one-message-per-Application semantics.
+
+6. **Wire contract + auth.** `POST /notify`, reuse the existing `SHIM_BEARER_TOKEN`
+   (same middleware guards both routes). Body = `{ company, role, url }` only.
+   `url` = the Application's `application_url` (job posting); optional.
+
+7. **Message text** (template lives in the shim):
+   ```
+   Hey Netali, I found new position, Here are the Details:
+   <Company> — <Role>
+   <url>
+   ```
+   No URL → drop the link line, still send.
+
+8. **Recipient.** Number `+972 54-448-3175` **hardcoded in the shim** (normalized to
+   `972544483175@c.us`). Recipient + template live shim-side; JobFlow stays generic
+   (sends only the 3 fields). Changing recipient/wording = box-side edit + restart,
+   no Render redeploy.
+
+9. **Observability = (a) logs-only** for v1. Shim logs every send outcome + loud log
+   on `disconnected`/`auth_failure`. Manual detection (`docker logs jf-shim`).
+   Self-alert ping deferred to v2.
+
+10. **JobFlow wiring.** Mirror `CompanyRegistry`: `WhatsAppNotifier` interface +
+    `HttpShimWhatsAppNotifier` (prod, POST to `WHATSAPP_NOTIFY_URL`, 3s
+    `AbortController` timeout, swallow errors) + `LoggingWhatsAppNotifier` (dev
+    fallback when URL unset → no-op locally/in tests). Fired **detached** from
+    `createCard` next to `runCompanyCheck` — one shared call site (manual + Email
+    Agent). **Transaction-boundary edge = (a) accept** with a comment (rare rollback
+    → spurious message to Netali); same edge as the Scout.
+
+11. **Base image = (b) `node:20-slim` (Debian).** Alpine's musl breaks puppeteer's
+    bundled Chromium; Debian-slim is the supported path. Image → ~400 MB. Touches the
+    container carrying the Cassandra write path → ADR 0006 smoke-test transcripts
+    required (`/companies` green + `/notify` send transcript).
+
+## Artifacts produced
+
+- `docs/adr/0011-whatsapp-notifier-on-shim.md`
+- `knowledge/wiki/whatsapp-notifier.md`
+- `CONTEXT.md` — added WhatsApp Notifier + WhatsApp Message glossary entries + relationship
+- `knowledge/wiki/index.md` — added system + ADR links
+
+## Out of scope / deferred (v2)
+
+- Self-alert ping on session death.
+- Coalescing bursts into one summary message (chose per-Application + throttle instead).
+- Cloudflare Tunnel migration (ngrok reuse locked).
+- Throttle interval exact value — set during implementation.

--- a/knowledge/raw/2026-06-04-prd-whatsapp-notifier.md
+++ b/knowledge/raw/2026-06-04-prd-whatsapp-notifier.md
@@ -1,0 +1,101 @@
+## Problem Statement
+
+As the JobFlow user, every time a new [[application|Application]] enters my pipeline — whether I add it manually or the [[email-agent|Email Agent]] auto-creates it from an [[application-receipt|Application Receipt]] — I only find out by looking at JobFlow. I want a specific person (Netali) to be told in real time, over WhatsApp, the moment a new Application is created, without me opening the app or taking any action.
+
+## Solution
+
+A new automated process — the **[[whatsapp-notifier|WhatsApp Notifier]]** — sends a single ephemeral outbound **WhatsApp Message** from my personal WhatsApp account to one hardcoded recipient (Netali, `+972 54-448-3175`) whenever an [[application|Application]] is created. It is a sibling of the [[email-agent|Email Agent]] and [[company-scout|Company Scout]], triggered by Application creation rather than by email or [[first-sighting|Company novelty]].
+
+It reuses existing infrastructure end to end: a new `POST /notify` route is added to the existing Cassandra write shim on the [[infra-linux-deployment|Linux box]], reached from JobFlow (Render) over the **existing ngrok static domain** — no new container, no proxy, no second tunnel. JobFlow fires the call **detached** so Application creation latency is never affected, and the WhatsApp Message is never persisted in JobFlow (it is explicitly **not** a [[notification|Notification]]).
+
+The message reads:
+
+```
+Hey Netali, I found new position, Here are the Details:
+<Company> — <Role>
+<job-posting URL>
+```
+
+The full design is authoritative in [[adr-0011-whatsapp-notifier-on-shim]], [[whatsapp-notifier]], `CONTEXT.md`, and the grill transcript at `knowledge/raw/2026-06-04-grill-whatsapp-notifier.md`.
+
+## User Stories
+
+1. As the JobFlow user, I want a WhatsApp Message sent automatically whenever an Application is created, so that I am notified in real time without opening JobFlow.
+2. As the JobFlow user, I want the message sent on **both** the manual create path and the Email Agent auto-create path, so that no new Application is ever missed regardless of how it entered.
+3. As the JobFlow user, I want the message delivered to one specific person (Netali), so that the right person is kept informed of every new opportunity.
+4. As the JobFlow user, I want the message to contain the company name, the role title, and the job-posting URL, so that Netali has the essential details at a glance.
+5. As the JobFlow user, I want the message to still be sent when an Application has no job-posting URL (just dropping the link line), so that I am notified even for Applications lacking a link.
+6. As the JobFlow user, I want the greeting and recipient phone number to live on the shim (box-side), so that I can change the recipient or wording with a box-side edit and restart — no JobFlow code change or Render redeploy.
+7. As the JobFlow user, I want JobFlow to send only `{ company, role, url }` and never know who the recipient is, so that the personal contact stays out of the application code.
+8. As the JobFlow user, I want Application creation to never be blocked or slowed by the WhatsApp send, so that the board stays responsive even if WhatsApp is slow or down.
+9. As the JobFlow user, I want the message sent from my own personal WhatsApp account (via whatsapp-web.js), so that it costs nothing and arrives as a normal personal message.
+10. As the JobFlow user, I want to authenticate the WhatsApp session once by scanning a QR code over SSH, so that setup is a single one-time step.
+11. As the JobFlow user, I want the authenticated session to survive container restarts, rebuilds, and reboots, so that I do not have to re-scan the QR repeatedly.
+12. As the JobFlow user, I want a burst of Applications created in one Email Agent sync to be sent as a throttled, paced sequence rather than a simultaneous flurry, so that my account does not look like a spam bot and risk a ban.
+13. As the JobFlow user, I want every Application in a burst to still get its own message (paced, not dropped or merged), so that one-message-per-Application is preserved.
+14. As the JobFlow user, I want a failure of the WhatsApp send path to never affect the Company Scout's Cassandra write path on the same shim, so that adding this feature does not destabilise an existing one.
+15. As the JobFlow user, I want the WhatsApp send outcomes and session lifecycle events logged, so that I can diagnose a dead session by checking the shim logs.
+16. As the JobFlow user, I want the feature to be a no-op in local development and tests (when the notify URL is unset), so that nobody is messaged outside production.
+17. As the JobFlow user, I want the notify endpoint protected by the same bearer token as the existing shim, so that only JobFlow can trigger messages.
+18. As the JobFlow user, I want a clear operator runbook for the one-time QR scan, the session volume, and the recipient/template config, so that I can set it up and recover it reliably.
+19. As the JobFlow user, I want the PR to demonstrate the existing `/companies` path still works and a real `/notify` send succeeds, so that I can trust the shared-container change did not regress the Company Scout.
+20. As Netali, I want each message clearly phrased as a new-position heads-up with the company, role, and link, so that I immediately understand what it is and can act on it.
+
+## Implementation Decisions
+
+**Topology & infrastructure (locked in [[adr-0011-whatsapp-notifier-on-shim]])**
+- The WhatsApp Notifier is a **new `POST /notify` route on the existing Cassandra write shim** — no new component. Reachable for free under the one ngrok static domain (ngrok free = 1 static domain; a second endpoint would get a rotating URL and was rejected).
+- The shim's base image moves from `node:20-alpine` to **`node:20-slim` (Debian)** to host whatsapp-web.js / puppeteer / Chromium reliably (Alpine's musl breaks the bundled Chromium). Image grows to ~400 MB.
+- The WhatsApp client is initialized **after** the HTTP server is listening and isolated, so a dead/unauthenticated Chromium causes `/notify` to return `503` while `/companies` keeps serving. Failure domains stay separate; the deploy domain is shared (redeploying the shim restarts the Cassandra write path).
+- Authentication: the QR is rendered as ASCII via `qrcode-terminal` (visible over SSH and in `docker logs`); the whatsapp-web.js `LocalAuth` session directory is **bind-mounted to the host** so the QR is scanned exactly once and survives restarts/rebuilds.
+
+**Wire contract (`POST /notify` on the shim)**
+- Auth: `Authorization: Bearer <SHIM_BEARER_TOKEN>` — the **same token** already guarding `/companies` (same middleware).
+- Content-Type `application/json`; body `{ "company": string, "role": string, "url"?: string }`.
+- Responses mirror `/companies` conventions: `200 { status: "queued" }`, `401` bad/missing token, `400` bad body, `415` wrong content-type, `503 { status: "whatsapp_unavailable" }` when the client is not ready.
+
+**Shim-side modules**
+- **Message formatter** — pure `(company, role, url) → text`: the `"Hey Netali, I found new position, Here are the Details:"` template, `<Company> — <Role>` line, and the optional URL line dropped when `url` is absent. Recipient name + number hardcoded shim-side.
+- **Recipient normalizer** — pure `+972 54-448-3175 → 972544483175@c.us` (strip `+`, spaces, dashes; append `@c.us`).
+- **Throttled send queue** — a serialized queue with a minimum send-interval so a bulk Email Agent sync does not fire near-simultaneous messages. Every Application still gets its own paced message.
+- **WhatsApp client wrapper** — hides the whatsapp-web.js lifecycle (init, QR logging, `ready`/`disconnected`/`auth_failure` state, `sendMessage`) behind a small `isReady()` / `send(text)` surface. Logs every send outcome and logs loudly on disconnect/auth_failure (v1 observability is logs-only).
+- **`/notify` route handler** — auth + content-type + body validation, then enqueue; returns `503` when the client is not ready.
+
+**JobFlow-side modules (mirror the [[company-scout|Company Scout]]'s `CompanyRegistry`)**
+- A `WhatsAppNotifier` interface with two implementations and a factory:
+  - `HttpShimWhatsAppNotifier` (production) — `POST {WHATSAPP_NOTIFY_URL}` with the bearer token, a 3s `AbortController` timeout, and swallows all errors (network, 4xx, 5xx) at warn level.
+  - `LoggingWhatsAppNotifier` (dev fallback) — selected when `WHATSAPP_NOTIFY_URL` is unset; logs what *would* have been sent. The feature is a **no-op until configured** (local dev + tests never message anyone).
+- Wired into `cardService.createCard`, fired **detached** (never awaited) next to `runCompanyCheck` — one shared call site covering both the manual and Email Agent create paths. Payload sourced from the created card: `company_name`, `role_title`, `application_url`.
+
+**Accepted edge cases**
+- **Transaction-boundary edge:** `createCard` runs inside the Email Agent's per-email transaction; the detached `/notify` can fire before commit, so a rare rollback sends Netali a message for an Application that was never saved. Accepted with a code comment — same edge as the Company Scout, with a human-visible blast radius.
+- **Silent session death:** a dead WhatsApp session drops every message with no active alert in v1; detection is manual via `docker logs jf-shim`.
+
+**Configuration**
+- JobFlow (Render): new `WHATSAPP_NOTIFY_URL` (the static ngrok domain + `/notify`); reuses the existing shim bearer token value.
+- Shim (box): recipient number and template hardcoded in shim code; `LocalAuth` session directory bind-mounted via `docker-compose.yml`; `qrcode-terminal` for first-run QR.
+
+## Testing Decisions
+
+- **No automated tests** are written for this feature (explicit user decision). The shim has no existing test harness and none is introduced; the JobFlow side adds no Jest specs.
+- **Verification is via the ADR-0006 smoke-test transcript**, which is mandatory for this data-pipeline PR. The transcript must show:
+  1. The existing `POST /companies` path still returns its expected results (no regression from the base-image change and shared container).
+  2. A real `POST /notify` call producing a delivered WhatsApp Message to the recipient (happy path, with URL and without URL).
+  3. The negative paths return correctly (`401` wrong token, `400` bad body, `415` wrong content-type, `503` when the WhatsApp client is not ready).
+- **Local safety net:** the `LoggingWhatsAppNotifier` dev fallback guarantees that running JobFlow without `WHATSAPP_NOTIFY_URL` set messages no one — so manual local exercise of the create paths is safe.
+
+## Out of Scope
+
+- **Automated test suites** for any module (per the testing decision above).
+- **Self-alert on session death** (messaging the user's own number on `disconnected`/`auth_failure`) — deferred to v2; v1 is logs-only.
+- **Coalescing bursts** into a single summary message — rejected in favour of per-Application messages with a throttle.
+- **Cloudflare Tunnel migration** — ngrok reuse is locked; changing tunnel providers is out of scope.
+- **Configurable recipient / multiple recipients / per-source filtering** — a single hardcoded recipient on all Application creation is the v1 scope.
+- **Retry / delivery guarantees** — fire-and-forget; a failed send is logged and dropped, consistent with the Company Scout.
+- **Any frontend / in-app surface** — the WhatsApp Message is purely outbound and external; it produces no [[notification|Notification]] and no UI change.
+
+## Further Notes
+
+- **Personal-number ban risk is explicitly accepted.** whatsapp-web.js is unofficial and against WhatsApp ToS; the throttle exists to reduce burst-shaped spam signals. Risk is low for an aged, daily-used number sending occasional messages to one recipient.
+- **Recommended pre-build spike (CLAUDE.md "verify external deps"):** before the full build, spend ~10 minutes proving whatsapp-web.js authenticates on the specific box (scan QR, send one test message) — this is the one runtime-unproven dependency.
+- **Exact throttle interval** (min gap between sends) is to be set during implementation and tuned if bursts still trip WhatsApp heuristics.

--- a/knowledge/wiki/index.md
+++ b/knowledge/wiki/index.md
@@ -35,6 +35,7 @@ Mirror `CONTEXT.md` terms. Each page adds *system context* the glossary cannot c
 
 - [[email-agent]] — reads inbox, routes/creates Applications, produces Notifications
 - [[company-scout]] — runs on First Sighting; resolves Orgs; classifies GH presence
+- [[whatsapp-notifier]] — sends an outbound WhatsApp Message on every Application creation (route on the shim)
 - [[cassandra-analytics-pipeline]] — Cassandra ingestion (Backfill + Hourly Ingest)
 - [[ingestion-pipeline]] — Fetcher → Ingester → Cassandra; subsystem of the above
 - [[backfill]] — nightly catchup process for uninitialised (Company, Org) rows
@@ -66,6 +67,7 @@ Mirror `CONTEXT.md` terms. Each page adds *system context* the glossary cannot c
 - [[adr-0005-processed-files-hourly-only]] → `/docs/adr/0005-processed-files-hourly-only.md`
 - [[adr-0007-processed-files-single-partition]] → `/docs/adr/0007-processed-files-single-partition.md`
 - [[adr-0008-ingester-worker-side-decompression]] → `/docs/adr/0008-ingester-worker-side-decompression.md`
+- [[adr-0011-whatsapp-notifier-on-shim]] → `/docs/adr/0011-whatsapp-notifier-on-shim.md`
 
 ## References (external systems & infrastructure)
 

--- a/knowledge/wiki/whatsapp-notifier.md
+++ b/knowledge/wiki/whatsapp-notifier.md
@@ -1,0 +1,80 @@
+---
+title: WhatsApp Notifier
+slug: whatsapp-notifier
+type: system
+tags: [automation, whatsapp, notifications, shim]
+sources:
+  - CONTEXT.md#whatsapp-notifier
+  - docs/adr/0011-whatsapp-notifier-on-shim.md
+  - docs/adr/0010-https-shim-write-path.md
+related: [[application]] [[company-scout]] [[email-agent]] [[notification]] [[cassandra-analytics-pipeline]] [[infra-linux-deployment]] [[adr-0010-https-shim-write-path]]
+updated: 2026-06-04
+status: planned
+---
+
+# WhatsApp Notifier
+
+> Canonical definition: see `/CONTEXT.md` → **WhatsApp Notifier**.
+
+An automated process that sends one outbound [[notification|WhatsApp Message]] — explicitly **not** a [[notification|Notification]] — from the user's personal WhatsApp account to a single hardcoded recipient (Netali, `+972 54-448-3175`) whenever an [[application|Application]] is created. A sibling of the [[email-agent|Email Agent]] and [[company-scout|Company Scout]], triggered by Application creation rather than by email or Company novelty.
+
+## Why it exists
+
+The user wants a real-time heads-up to a specific person every time a new Application enters the pipeline, without opening JobFlow. Free, no third-party API: `whatsapp-web.js` drives the user's own WhatsApp Web session (personal-number ban risk explicitly accepted).
+
+## How it relates
+
+- Triggered from `cardService.createCard` — fired **detached** next to `runCompanyCheck`, one shared call site covering both the manual create path and the [[email-agent|Email Agent]]'s auto-create path.
+- Reuses the [[company-scout|Company Scout]]'s network bridge: JobFlow (Render) → existing **ngrok** static domain → the **Cassandra write shim** on the [[infra-linux-deployment|Linux box]].
+- Does **not** run as its own component — it is a `POST /notify` route added to the existing shim (see [[adr-0010-https-shim-write-path]] for the shim; ADR 0011 for this extension).
+- Produces **no [[notification|Notification]]**, no `notifications` row, no JobFlow-side persistence. The WhatsApp Message is ephemeral.
+
+## Wire contract
+
+`POST /notify` on the shim, `Authorization: Bearer <SHIM_BEARER_TOKEN>` (the same token that guards `/companies`):
+
+```
+{ "company": "Wix", "role": "Senior Backend Engineer", "url": "https://wix.com/careers/12345" }
+→ 200 { "status": "queued" }   ·   401 / 400 / 415   ·   503 whatsapp_unavailable
+```
+
+JobFlow sends only `{ company, role, url }`. The recipient number and the template
+("Hey Netali, I found new position, Here are the Details:") are hardcoded **in the shim**.
+
+Rendered message:
+
+```
+Hey Netali, I found new position, Here are the Details:
+Wix — Senior Backend Engineer
+https://wix.com/careers/12345
+```
+
+When `url` is absent the link line is dropped; the message still sends.
+
+## Key invariants
+
+- Fires on **every** Application creation (manual + Email Agent). No filtering by source.
+- JobFlow never knows the recipient or the wording — only the three data fields.
+- `/notify` failures (Chromium dead/unauthenticated → 503) **never affect `/companies`** — the WhatsApp client is isolated and initialized after the HTTP server is listening.
+- Card-creation latency is unaffected — the call is detached and never awaited (mirrors the Scout).
+- Bursts are throttled: `/notify` serializes sends with a min interval so a bulk Gmail sync doesn't fire a spam-shaped flurry.
+
+## Surprises / gotchas
+
+- **Chromium inside a "Cassandra write shim."** The shim's base image moves `node:20-alpine` → `node:20-slim` to host puppeteer/Chromium reliably; image grows to ~400 MB. Two unrelated features now share one container's *deploy* domain (redeploying the shim restarts the Cassandra write path), though their *failure* domains are kept separate by the isolation guard. See ADR 0011.
+- **Scan the QR exactly once.** First run renders the WhatsApp Web QR as ASCII (`qrcode-terminal`, visible over SSH / in `docker logs`). The `LocalAuth` session dir is **bind-mounted to the host**, so it survives restarts/rebuilds — re-scan only if WhatsApp invalidates the session (logout, phone offline >14 days, or ban).
+- **Transaction-boundary edge.** `createCard` runs inside gmailSync's per-email transaction; the detached `/notify` can fire before commit, so a rare rollback sends Netali a message for an Application that was never saved. Accepted with a code comment — same edge as the Scout, but human-visible.
+- **Silent death.** A dead session drops every message with no active alert in v1 — detection is manual (`docker logs jf-shim`). Consistent with the Scout's no-alerting posture.
+
+## Open questions
+
+- **Self-alert on session death** (message the user's own number on `disconnected`/`auth_failure`) — deferred to v2; v1 is logs-only.
+- **Throttle tuning** — exact min send-interval to be set during implementation; revisit if bursts still trip WhatsApp heuristics.
+
+## Source pointers (planned)
+
+- Trigger site: `backend/src/services/cardService.ts` (in `createCard`, next to `runCompanyCheck`)
+- JobFlow client: `WhatsAppNotifier` interface + `HttpShimWhatsAppNotifier` / `LoggingWhatsAppNotifier` (mirrors `companyScout/companyRegistry.ts`)
+- Shim route: `data-pipeline/shim/shim.js` (`POST /notify`) + the `whatsapp-web.js` client module
+- Deploy/runbook: `data-pipeline/shim/RUNBOOK.md` (QR scan, session volume, env)
+- Related ADRs: [[adr-0010-https-shim-write-path]], ADR 0011, ADR 0006 (smoke-test transcripts)


### PR DESCRIPTION
## Summary
- Sends a WhatsApp Message from the user's personal account to one hardcoded recipient whenever an **Application** is created (manual + Email Agent paths).
- Implemented as a new `POST /notify` route on the existing Cassandra write shim — **no new component** — reached from JobFlow over the existing ngrok tunnel.
- Implements PRD #259. Design locked in ADR 0011.

## Changes
**Shim (`data-pipeline/shim/`)**
- `lib/message.js` — pure message formatter (`"Hey Netali…"`) + recipient normalizer (`+972525912293 → 972525912293@c.us`); recipient hardcoded shim-side.
- `lib/whatsapp.js` — whatsapp-web.js client wrapper: `LocalAuth` session, QR via `qrcode-terminal`, ready/disconnected state, **throttled serialized send queue** (min 3s gap) so bulk syncs aren't spam-shaped.
- `shim.js` — `POST /notify` (reuses bearer auth; `400/401/415`; `503` when WhatsApp not ready); client initialized **after** `listen()` and isolated so a dead Chromium never affects `/companies`.
- `Dockerfile` — `node:20-alpine → node:20-slim` + system Chromium (puppeteer's bundled Chromium can't run on musl).
- `docker-compose.yml` — bind-mount the `LocalAuth` session dir + `shm_size` for Chromium.
- `RUNBOOK.md` — one-time QR scan, Render config, `/notify` smoke test.

**JobFlow (`backend/`)**
- `whatsappNotifier/whatsappNotifier.ts` — `WhatsAppNotifier` interface + `HttpShimWhatsAppNotifier` + `LoggingWhatsAppNotifier` dev fallback (no-op when `WHATSAPP_NOTIFY_URL` unset), mirroring `CompanyRegistry`.
- `cardService.createCard` — `notifyApplicationCreated` fired **detached** next to `runCompanyCheck` (transaction-boundary edge accepted, ADR 0011).
- `config/env.ts` — `WHATSAPP_NOTIFY_URL` (optional; https + reused token required in prod).

## Test plan
No automated tests (per request). Verification is the **ADR-0006 smoke transcript** — to be captured on the box after deploy:
- [ ] `/companies` still green (no regression from the base-image change)
- [ ] `/notify` happy path **with** URL → recipient receives `Hey Netali…` + link
- [ ] `/notify` happy path **without** URL → message sent, link line dropped
- [ ] Negative paths: `401` wrong token, `400` bad body, `415` wrong content-type, `503` when client not ready
- [ ] First-run QR scanned once; session survives a container restart

## Deploy (operator)
1. Box: `mkdir -p /home/tomer/whatsapp-session && sudo chown 1000:1000 …`, `docker compose up -d --build shim`, watch `docker logs jf-shim -f`, scan the QR once.
2. Render: set `WHATSAPP_NOTIFY_URL` to the same ngrok base as `COMPANY_REGISTRY_URL`.

> ⚠️ whatsapp-web.js is unofficial (against WhatsApp ToS); sender-number ban risk accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)