### PR TITLE
fix: self-heal stale Chromium SingletonLock on shim startup

### DIFF
--- a/data-pipeline/shim/lib/whatsapp.js
+++ b/data-pipeline/shim/lib/whatsapp.js
@@ -12,11 +12,36 @@
 // messages, so a bulk Email Agent sync that creates N Applications doesn't fire
 // N near-simultaneous WhatsApp messages (a spam-shaped pattern).
 
+import fs from 'node:fs';
+import path from 'node:path';
 import wweb from 'whatsapp-web.js';
 import qrcode from 'qrcode-terminal';
 import { toChatId } from './message.js';
 
 const { Client, LocalAuth } = wweb;
+
+// LocalAuth's default profile lives at <cwd>/.wwebjs_auth/session.
+const SESSION_DIR = path.join(process.cwd(), '.wwebjs_auth', 'session');
+
+// Chromium writes a SingletonLock (a symlink stamped with the container
+// hostname) into the profile while running. The host-mounted profile outlives
+// the container, so on every recreate the hostname differs and the stale lock
+// aborts launch with "profile appears to be in use ... on another computer".
+// Removing the Singleton* lock files before launch is always safe here — the
+// authenticated session lives elsewhere in the profile and is left intact, and
+// only one Chromium ever uses this single-tenant volume.
+function clearStaleChromiumLocks(logger) {
+  try {
+    for (const name of fs.readdirSync(SESSION_DIR)) {
+      if (name.startsWith('Singleton')) {
+        fs.rmSync(path.join(SESSION_DIR, name), { force: true });
+        logger.info({ lock: name }, 'whatsapp.cleared_stale_lock');
+      }
+    }
+  } catch {
+    // First run (no profile yet) or nothing to clean — safe to ignore.
+  }
+}
 
 const MIN_SEND_INTERVAL_MS = 3000;
 
@@ -99,6 +124,9 @@ export function createWhatsApp({ recipient, logger, executablePath }) {
       drain();
     },
     init() {
+      // Self-heal the always-stale Chromium lock left by the previous container
+      // so restarts/redeploys don't need a manual cleanup.
+      clearStaleChromiumLocks(logger);
       return client.initialize();
     },
   };


### PR DESCRIPTION
## Summary
- Lands the Chromium restart fix that was missed from PR #261 (it merged before this commit was added to that branch).
- whatsapp-web.js's LocalAuth profile is host-mounted, so Chromium's `SingletonLock` (a symlink stamped with the container hostname) outlives the container. On every recreate the hostname differs, so the stale lock aborts the launch ("profile appears to be in use ... on another computer") and `/notify` is stuck at 503 until the lock is cleared by hand.

## Changes
- `data-pipeline/shim/lib/whatsapp.js` — `clearStaleChromiumLocks()` removes the `Singleton*` lock files on `init()`, before `client.initialize()`. The authenticated session is untouched (it lives elsewhere in the profile); the volume is single-tenant so no live Chromium is ever using the lock at boot.

## Context
- The fix is already running on the box (deployed directly), verified: `whatsapp.cleared_stale_lock` → `whatsapp.ready` on a clean recreate with no manual step. This PR just gets it onto `main` so a rebuild-from-`main` keeps the fix.

## Test plan
- [x] Box recreate self-heals the lock and reaches `whatsapp.ready` with no manual lock removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)